### PR TITLE
docs: CMS preview delivery mechanism ADR (INF-68)

### DIFF
--- a/docs/cms-preview.md
+++ b/docs/cms-preview.md
@@ -1,0 +1,214 @@
+# ADR: CMS Preview Delivery Mechanism
+
+**Status:** Proposed
+**Date:** 2026-04-14
+**Ticket:** INF-68
+
+## Context
+
+Lula Lake Sound is a Next.js 15 (App Router) + Convex + Clerk site that currently
+serves all page content as hard-coded React components. As the CMS layer is built
+out, studio owners will need to preview draft content before publishing. This ADR
+selects the preview delivery mechanism and defines the routing and data-access
+contracts implementers will follow.
+
+### Current state of the repo
+
+| Concern | Status |
+|---------|--------|
+| Next.js routes | Single page (`/`) + one API route (`POST /api/contact`). All static. |
+| Convex tables | `inquiries` only — no content/pages/posts tables yet. |
+| Auth | **Not yet integrated.** No Clerk dependencies, no middleware, no `auth.config.ts`. |
+| Hosting | Vercel (inferred from `@vercel/analytics` + `@vercel/speed-insights`). |
+
+## Decision
+
+**Owner-session preview** — draft content is visible only when the request
+carries a valid Clerk session belonging to the studio owner.
+
+### Why this option
+
+| Criterion | Owner session | Signed URL | Separate deployment |
+|-----------|:---:|:---:|:---:|
+| Simplicity for a single-owner studio | ✅ | ⚠️ token minting adds surface | ❌ infra overhead |
+| No accidental public leakage | ✅ session-scoped | ⚠️ URL can be forwarded/logged | ✅ network-isolated |
+| CDN compatibility | Compatible via `no-store` on preview routes | Compatible | N/A |
+| Clerk already planned for the stack | ✅ reuses existing auth | Needs extra signing key management | N/A |
+| Collaborative sharing | ⚠️ limited to logged-in owners | ✅ link-shareable | ❌ |
+
+For a single-owner studio site, session-based preview is the simplest approach
+with the smallest attack surface. Signed URLs can be added later as an
+incremental enhancement if external collaborators need link-based preview access
+(see Non-goals).
+
+### How it works
+
+1. Studio owner signs in via Clerk.
+2. Owner navigates to a preview URL (e.g. `/preview/pages/[slug]`).
+3. Next.js middleware (or the route's server component) verifies the Clerk
+   session and extracts the `userId`.
+4. The route calls a Convex `preview` query that checks ownership server-side
+   via `ctx.auth.getUserIdentity()` and returns the draft document.
+5. If the session is missing or the user is not the owner, the route returns
+   404 (not 403 — to avoid confirming that a draft exists).
+
+## Threat Model
+
+| Threat | Mitigation |
+|--------|------------|
+| **Draft leakage via URL guessing** | Preview routes require a valid Clerk session; unauthenticated requests get 404. |
+| **Draft leakage via CDN cache** | All preview routes use `export const dynamic = "force-dynamic"` (equivalent to `Cache-Control: no-store`). Vercel will not cache these at the edge. |
+| **Session hijacking** | Delegated to Clerk's session management (HttpOnly cookies, short-lived JWTs, rotation). No custom token handling. |
+| **Privilege escalation (non-owner sees drafts)** | Convex `preview` query checks `tokenIdentifier` against an owner allowlist stored in the DB or env. Returns `null` for non-owners. |
+| **Referrer leakage** | Preview URLs contain no secret tokens, so referrer headers are benign. Add `<meta name="referrer" content="no-referrer">` on preview pages as defense-in-depth. |
+| **Stale preview after publish** | Published content is served by a separate `published` query that reads only `status === "published"` rows. Preview always reads latest draft. No cross-contamination. |
+
+## Non-goals
+
+These are explicitly **out of scope** for this decision and the initial
+implementation:
+
+- **Signed / shareable preview URLs** — Deferred until there is a concrete need
+  for external collaborators who cannot sign in with Clerk. Can be added as a
+  thin layer on top (mint a short-lived HMAC token, verify in middleware).
+- **Separate preview deployment / staging split** — Not required when preview is
+  gated by auth on the same deployment.
+- **Real-time collaborative editing preview** — The preview route shows the
+  latest saved draft, not a live-editing cursor view.
+- **Preview for unauthenticated visitors** — All preview is owner-only.
+- **A/B testing or feature-flag based preview** — Orthogonal concern.
+- **ISR / on-demand revalidation for preview** — Preview is always dynamic.
+  On-demand revalidation applies only to published routes and is a separate
+  ticket.
+
+## Next.js Route Plan
+
+All routes live under `src/app/` (App Router, `src/` directory).
+
+| Route | Rendering | Cache | Auth | Purpose |
+|-------|-----------|-------|------|---------|
+| `/` | Static (current) | Default (static) | None | Public marketing home |
+| `/pages/[slug]` | Static + ISR | `revalidate` / on-demand | None | Published CMS page (public) |
+| `/preview/pages/[slug]` | Dynamic | `force-dynamic` (`no-store`) | Clerk session required | Draft CMS page (owner only) |
+| `POST /api/contact` | Dynamic (route handler) | N/A | None | Contact form submission |
+| `/studio/[...path]` *(future)* | Dynamic | `force-dynamic` | Clerk session required | CMS editing UI |
+
+### Key implementation notes
+
+- **Middleware:** Add `src/middleware.ts` using `clerkMiddleware()`. Protect
+  `/preview/*` and `/studio/*` routes. Public routes (`/`, `/pages/*`,
+  `/api/contact`) remain unprotected.
+- **Static published pages** should use `generateStaticParams` and on-demand
+  revalidation via a Convex webhook or mutation-triggered `revalidatePath`.
+- **Preview pages** must never be statically generated. Use
+  `export const dynamic = "force-dynamic"` in the route segment.
+
+## Convex Data-Access Contract
+
+Two query entry points per content table, enforcing a clear published/preview
+boundary.
+
+### Schema additions (illustrative)
+
+```typescript
+// convex/schema.ts — additions for CMS content
+pages: defineTable({
+  slug: v.string(),
+  title: v.string(),
+  body: v.string(),
+  status: v.union(v.literal("draft"), v.literal("published")),
+  ownerTokenIdentifier: v.string(),
+  publishedAt: v.optional(v.number()),
+  updatedAt: v.number(),
+})
+  .index("by_slug_and_status", ["slug", "status"])
+  .index("by_owner", ["ownerTokenIdentifier"]),
+```
+
+### Query entry points
+
+```typescript
+// convex/pages.ts
+
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Public query — returns only published content.
+ * No authentication required. Safe to call from static/ISR pages.
+ */
+export const published = query({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("pages")
+      .withIndex("by_slug_and_status", (q) =>
+        q.eq("slug", args.slug).eq("status", "published"),
+      )
+      .unique();
+  },
+});
+
+/**
+ * Authorized query — returns the latest draft for preview.
+ * Requires a valid Clerk session. Verifies ownership server-side.
+ * Returns null (not an error) for unauthorized callers to avoid
+ * leaking draft existence.
+ */
+export const preview = query({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    const page = await ctx.db
+      .query("pages")
+      .withIndex("by_slug_and_status", (q) =>
+        q.eq("slug", args.slug).eq("status", "draft"),
+      )
+      .unique();
+
+    if (!page) return null;
+    if (page.ownerTokenIdentifier !== identity.tokenIdentifier) return null;
+
+    return page;
+  },
+});
+```
+
+### Rules for implementers
+
+1. **Never accept a `userId` argument** for authorization — always derive
+   identity from `ctx.auth.getUserIdentity()`.
+2. **Use `tokenIdentifier`** (not `subject`) for ownership checks, per Convex
+   guidelines.
+3. The `published` query is the **only** query called from public routes. It
+   must never return draft content.
+4. The `preview` query is the **only** query called from `/preview/*` routes.
+   It must verify ownership before returning data.
+5. Both queries return `null` for missing content — the calling route converts
+   this to a Next.js `notFound()`.
+6. **No internal/private queries needed** at this layer. Both are public Convex
+   queries; access control is enforced inside the handler.
+
+## Migration Path to Signed URLs (if needed later)
+
+If external collaborators need link-based preview without a Clerk account:
+
+1. Add a `previewTokens` table to Convex (`slug`, `token`, `expiresAt`,
+   `createdBy`).
+2. Create a mutation to mint a short-lived token (e.g. 24h HMAC or random
+   UUID).
+3. Add a third query `previewByToken` that validates the token and expiry
+   instead of checking `ctx.auth`.
+4. Expose it at `/preview/pages/[slug]?token=<value>` — middleware allows
+   the request through if the query string contains a `token` param.
+5. Document referrer/logging risks: the token appears in the URL and may
+   be captured by analytics, browser history, or shared screenshots.
+
+## References
+
+- [Convex Auth docs](https://docs.convex.dev/auth)
+- [Clerk + Next.js middleware](https://clerk.com/docs/references/nextjs/clerk-middleware)
+- [Next.js App Router caching](https://nextjs.org/docs/app/building-your-application/caching)
+- Repo: `lula-lake-sound` — Next.js 15 + Convex + Clerk


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an Architecture Decision Record at `docs/cms-preview.md` that selects and documents the **preview delivery mechanism** for the Lula Lake Sound CMS layer.

**Resolves:** INF-68

## Decision

**Owner-session preview** — draft content is gated behind a valid Clerk session belonging to the studio owner. This is the simplest option for a single-owner studio with the smallest attack surface.

## What's in the doc

| Section | Contents |
|---------|----------|
| **Decision & rationale** | Comparison of owner-session vs signed-URL vs separate-deployment; why session wins |
| **Threat model** | Draft leakage, CDN caching, session hijacking, privilege escalation, referrer leakage |
| **Non-goals** | Signed URLs, staging split, real-time collab editing, unauthenticated preview, A/B testing |
| **Next.js route plan** | Exact routes with dynamic vs static classification and caching strategy |
| **Convex data-access contract** | Two query entry points — `published` (anonymous) and `preview` (authorized) — with illustrative schema and code |
| **Migration path** | How to add signed URLs later if external collaborators need them |

## No implementation changes

Per ticket scope, this PR contains **only the written spec** — no code changes beyond the new markdown file.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-68](https://linear.app/only-football-fans/issue/INF-68/lls-decide-preview-mechanism-session-vs-signed-url-vs-other)

<div><a href="https://cursor.com/agents/bc-6f48617b-017e-4d91-9d29-e257cdf0cdb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f48617b-017e-4d91-9d29-e257cdf0cdb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

