### PR TITLE
feat(convex): site settings schema, flags, and seed (INF-69)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as inquiries from "../inquiries.js";
 import type * as seed from "../seed.js";
 import type * as siteSettings from "../siteSettings.js";
+import type * as siteSettingsConstants from "../siteSettingsConstants.js";
 
 import type {
   ApiFromModules,
@@ -20,10 +21,11 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "admin/siteSettings": typeof admin_siteSettings;
   inquiries: typeof inquiries;
   seed: typeof seed;
   siteSettings: typeof siteSettings;
-  "admin/siteSettings": typeof admin_siteSettings;
+  siteSettingsConstants: typeof siteSettingsConstants;
 }>;
 
 /**

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,7 +8,10 @@
  * @module
  */
 
+import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as inquiries from "../inquiries.js";
+import type * as seed from "../seed.js";
+import type * as siteSettings from "../siteSettings.js";
 
 import type {
   ApiFromModules,
@@ -18,6 +21,9 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   inquiries: typeof inquiries;
+  seed: typeof seed;
+  siteSettings: typeof siteSettings;
+  "admin/siteSettings": typeof admin_siteSettings;
 }>;
 
 /**

--- a/convex/admin/siteSettings.ts
+++ b/convex/admin/siteSettings.ts
@@ -1,0 +1,18 @@
+import { internalQuery } from "../_generated/server";
+import { SITE_SETTINGS_KEY } from "../siteSettingsConstants";
+
+/**
+ * Full site settings document for admins / debugging (includes optional draft).
+ * Run from the Convex dashboard (Functions) or `bunx convex run internal/admin/siteSettings:debugSnapshot`.
+ */
+export const debugSnapshot = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+
+    return row;
+  },
+});

--- a/convex/admin/siteSettings.ts
+++ b/convex/admin/siteSettings.ts
@@ -3,7 +3,7 @@ import { SITE_SETTINGS_KEY } from "../siteSettingsConstants";
 
 /**
  * Full site settings document for admins / debugging (includes optional draft).
- * Run from the Convex dashboard (Functions) or `bunx convex run internal/admin/siteSettings:debugSnapshot`.
+ * Run from the Convex dashboard (Functions) or `bunx convex run internal.admin.siteSettings.debugSnapshot`.
  */
 export const debugSnapshot = internalQuery({
   args: {},

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,26 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
+const siteFlagsValidator = v.object({
+  priceTabEnabled: v.boolean(),
+});
+
+const siteMetadataValidator = v.object({
+  /** Shared site copy / SEO-style fields; extend as CMS grows. */
+  title: v.optional(v.string()),
+  description: v.optional(v.string()),
+});
+
+const publishedSliceValidator = v.object({
+  flags: siteFlagsValidator,
+  metadata: v.optional(siteMetadataValidator),
+});
+
+const draftSliceValidator = v.object({
+  flags: siteFlagsValidator,
+  metadata: v.optional(siteMetadataValidator),
+});
+
 export default defineSchema({
   inquiries: defineTable({
     artistName: v.string(),
@@ -10,4 +30,16 @@ export default defineSchema({
     message: v.string(),
     createdAt: v.number(),
   }),
+  /**
+   * Site-wide CMS settings and feature flags (singleton row per `key`).
+   * `published` is what public clients read; `draft` is optional until the full draft/publish flow exists.
+   */
+  siteSettings: defineTable({
+    key: v.string(),
+    updatedAt: v.number(),
+    /** Clerk user id (`subject`) when the last write was authenticated. */
+    updatedBy: v.optional(v.string()),
+    published: publishedSliceValidator,
+    draft: v.optional(draftSliceValidator),
+  }).index("by_key", ["key"]),
 });

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,0 +1,40 @@
+import { internalMutation } from "./_generated/server";
+import { SITE_SETTINGS_KEY } from "./siteSettingsConstants";
+
+const defaultFlags = { priceTabEnabled: true };
+
+/**
+ * Idempotent seed for local dev: creates the singleton site settings row if missing.
+ *
+ * Run once after deploying schema:
+ * `bunx convex run seed:seedSiteSettingsDefaults` (or from dashboard → Functions → internal).
+ */
+export const seedSiteSettingsDefaults = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const existing = await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+
+    const now = Date.now();
+
+    if (existing) {
+      return { status: "already_seeded" as const, id: existing._id };
+    }
+
+    const id = await ctx.db.insert("siteSettings", {
+      key: SITE_SETTINGS_KEY,
+      updatedAt: now,
+      published: {
+        flags: defaultFlags,
+        metadata: {
+          title: "Lula Lake Sound",
+          description: "Studio and lake-house sessions.",
+        },
+      },
+    });
+
+    return { status: "inserted" as const, id };
+  },
+});

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -7,7 +7,7 @@ const defaultFlags = { priceTabEnabled: true };
  * Idempotent seed for local dev: creates the singleton site settings row if missing.
  *
  * Run once after deploying schema:
- * `bunx convex run seed:seedSiteSettingsDefaults` (or from dashboard → Functions → internal).
+ * `bunx convex run internal.seed.seedSiteSettingsDefaults` (or from dashboard → Functions → internal).
  */
 export const seedSiteSettingsDefaults = internalMutation({
   args: {},

--- a/convex/siteSettings.ts
+++ b/convex/siteSettings.ts
@@ -1,0 +1,26 @@
+import { query } from "./_generated/server";
+import { SITE_SETTINGS_KEY } from "./siteSettingsConstants";
+
+/**
+ * Published site settings only (flags + shared metadata). Safe for anonymous clients.
+ * Returns `null` until the singleton row is seeded.
+ */
+export const getPublished = query({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      flags: row.published.flags,
+      metadata: row.published.metadata ?? null,
+      updatedAt: row.updatedAt,
+    };
+  },
+});

--- a/convex/siteSettingsConstants.ts
+++ b/convex/siteSettingsConstants.ts
@@ -1,0 +1,2 @@
+/** Singleton document key for site-wide CMS settings. */
+export const SITE_SETTINGS_KEY = "site" as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [INF-69](https://linear.app): Convex `siteSettings` singleton (keyed row), `published` / optional `draft` slices, `priceTabEnabled` flag, optional shared `metadata`, and `updatedAt` / optional `updatedBy` (Clerk user id string).

## Changes

- **Schema** (`siteSettings` table, `by_key` index on `key`).
- **Public** `siteSettings.getPublished` — returns only the published slice (or `null` if not seeded).
- **Internal** `admin/siteSettings.debugSnapshot` — full row for dashboard / `bunx convex run internal.admin.siteSettings.debugSnapshot`.
- **Internal** `seed.seedSiteSettingsDefaults` — idempotent default row for local dev (`bunx convex run internal.seed.seedSiteSettingsDefaults`).
- **`convex/_generated/api.d.ts`** — wired new modules (codegen requires `CONVEX_DEPLOYMENT` in CI; types updated manually).

## How to verify

1. `bunx convex dev` (or deploy) with a configured project.
2. Run internal seed once: `bunx convex run internal.seed.seedSiteSettingsDefaults`.
3. Call `api.siteSettings.getPublished` from the app or dashboard; use `internal.admin.siteSettings.debugSnapshot` for full document including draft.

## Follow-ups

- Draft/publish UI and admin mutations can patch `draft` / promote to `published` when that ticket lands.
- Prefer regenerating `_generated/api.d.ts` via `bunx convex codegen` after linking a deployment if your workflow allows it.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-69](https://linear.app/only-football-fans/issue/INF-69/lls-convex-schema-and-cms-settings-model-flags-shared-metadata)

<div><a href="https://cursor.com/agents/bc-7931b302-bfc7-4a60-9cd3-e622addfaa4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7931b302-bfc7-4a60-9cd3-e622addfaa4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

