### PR TITLE
INF-71: Auth gate for /admin and Convex admin mutations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,18 @@
 # Convex (https://dashboard.convex.dev) — deploy functions and copy deployment URL
 NEXT_PUBLIC_CONVEX_URL=
 
+# Clerk (https://dashboard.clerk.com) — App Router; keys from Clerk → API Keys
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+
+# Clerk user ids allowed to access /admin and admin Convex functions (comma-separated).
+# Find ids in Clerk Dashboard → Users → select user → User ID.
+CLERK_ADMIN_USER_IDS=
+
+# Convex deployment env (set in Convex dashboard, not only in Vercel):
+# CLERK_FRONTEND_API_URL — from Clerk → Integrations → Convex (Frontend API URL)
+# CLERK_ADMIN_USER_IDS — same comma-separated list as above
+
 # Resend (https://resend.com) — verified domain required for `from`
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "lula-lake-sound",
       "dependencies": {
+        "@clerk/nextjs": "^7.1.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "clsx": "^2.1.1",
@@ -36,6 +37,14 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@clerk/backend": ["@clerk/backend@3.2.9", "", { "dependencies": { "@clerk/shared": "^4.7.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-59h6F9wo4RrulOUh9u3Dm35VHA6k86OwU8qL4giaAMKpWcsKS+zAI7GFgVAvEMDWXam8DyTKy4/npOFT2dWlAg=="],
+
+    "@clerk/nextjs": ["@clerk/nextjs@7.1.0", "", { "dependencies": { "@clerk/backend": "^3.2.9", "@clerk/react": "^6.3.0", "@clerk/shared": "^4.7.0", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-DrvCTKmc9vECjopYW6IDXP70ltVrvpNUwRzP0nlQOCrwMBhYaC/7t1HijvzzPaPcMQ7p3A7xeYwL1ffqize1zQ=="],
+
+    "@clerk/react": ["@clerk/react@6.3.0", "", { "dependencies": { "@clerk/shared": "^4.7.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-etqEqdP5WlVn1Bb1NF2Drgvn3UzBSXmrkKtluObTQeqOoCsTO0uFv40oDi7QBs9WQWY1tvavI5aIHzY+uHKcdw=="],
+
+    "@clerk/shared": ["@clerk/shared@4.7.0", "", { "dependencies": { "@tanstack/query-core": "5.90.16", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-pm2dpxHS2teY87jmpatprG2uBAuuXuHHWvuezL3a5pRoUiIWXgWlLvwRZRgKXwDeIkIT9UCAIQBkcjueSEzqHA=="],
 
     "@emnapi/core": ["@emnapi/core@1.4.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.2", "tslib": "^2.4.0" } }, "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g=="],
 
@@ -245,6 +254,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.10", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.10", "@tailwindcss/oxide": "4.1.10", "postcss": "^8.4.41", "tailwindcss": "4.1.10" } }, "sha512-B+7r7ABZbkXJwpvt2VMnS6ujcDoR2OOcFaqrLIo1xbcdxje4Vf+VgJdBzNNbrAjBj/rLZ66/tlQ1knIGNLKOBQ=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.16", "", {}, "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -417,6 +428,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
@@ -521,6 +534,8 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
     "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
@@ -614,6 +629,8 @@
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.4.2", "", { "bin": "lib/jiti-cli.mjs" }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -777,6 +794,8 @@
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
@@ -804,6 +823,8 @@
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as admin_cms from "../admin/cms.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as inquiries from "../inquiries.js";
 import type * as seed from "../seed.js";
@@ -21,6 +22,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "admin/cms": typeof admin_cms;
   "admin/siteSettings": typeof admin_siteSettings;
   inquiries: typeof inquiries;
   seed: typeof seed;

--- a/convex/admin/cms.ts
+++ b/convex/admin/cms.ts
@@ -1,0 +1,93 @@
+import { mutation, query } from "../_generated/server";
+import { v } from "convex/values";
+import { requireAdminIdentity } from "../lib/auth";
+import { SITE_SETTINGS_KEY } from "../siteSettingsConstants";
+
+const siteFlagsValidator = v.object({
+  priceTabEnabled: v.boolean(),
+});
+
+const siteMetadataValidator = v.object({
+  title: v.optional(v.string()),
+  description: v.optional(v.string()),
+});
+
+const draftSliceValidator = v.object({
+  flags: siteFlagsValidator,
+  metadata: v.optional(siteMetadataValidator),
+});
+
+/**
+ * Full site settings row for the admin UI (includes optional draft).
+ */
+export const getForAdmin = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireAdminIdentity(ctx);
+    return await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+  },
+});
+
+/**
+ * Replace or create the draft slice (admin only).
+ */
+export const setDraft = mutation({
+  args: { draft: draftSliceValidator },
+  handler: async (ctx, args) => {
+    const identity = await requireAdminIdentity(ctx);
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        draft: args.draft,
+        updatedAt: now,
+        updatedBy: identity.subject,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("siteSettings", {
+      key: SITE_SETTINGS_KEY,
+      updatedAt: now,
+      updatedBy: identity.subject,
+      published: args.draft,
+      draft: args.draft,
+    });
+  },
+});
+
+/**
+ * Copy current `draft` onto `published` and clear `draft` (admin only).
+ */
+export const publishDraft = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await requireAdminIdentity(ctx);
+    const row = await ctx.db
+      .query("siteSettings")
+      .withIndex("by_key", (q) => q.eq("key", SITE_SETTINGS_KEY))
+      .unique();
+
+    if (!row) {
+      throw new Error("Site settings not found");
+    }
+    if (!row.draft) {
+      throw new Error("No draft to publish");
+    }
+
+    await ctx.db.patch(row._id, {
+      published: row.draft,
+      draft: undefined,
+      updatedAt: Date.now(),
+      updatedBy: identity.subject,
+    });
+    return row._id;
+  },
+});

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,0 +1,14 @@
+import type { AuthConfig } from "convex/server";
+
+/**
+ * Clerk JWT validation for Convex. Set `CLERK_FRONTEND_API_URL` on the Convex
+ * deployment (Clerk Dashboard → Integrations → Convex, or your Frontend API URL).
+ */
+export default {
+  providers: [
+    {
+      domain: process.env.CLERK_FRONTEND_API_URL!,
+      applicationID: "convex",
+    },
+  ],
+} satisfies AuthConfig;

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,0 +1,32 @@
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+function parseAdminUserIds(): string[] {
+  const raw = process.env.CLERK_ADMIN_USER_IDS ?? "";
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Clerk user ids (`UserIdentity.subject`) allowed to run admin mutations / queries.
+ * Configure on the Convex deployment as `CLERK_ADMIN_USER_IDS` (comma-separated).
+ */
+export function isAdminClerkUserId(userId: string): boolean {
+  return parseAdminUserIds().includes(userId);
+}
+
+export async function requireAdminIdentity(ctx: QueryCtx | MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity === null) {
+    throw new Error("Not authenticated");
+  }
+  const allowed = parseAdminUserIds();
+  if (allowed.length === 0) {
+    throw new Error("Server misconfiguration: CLERK_ADMIN_USER_IDS is empty");
+  }
+  if (!isAdminClerkUserId(identity.subject)) {
+    throw new Error("Forbidden");
+  }
+  return identity;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "convex:deploy": "convex deploy"
   },
   "dependencies": {
+    "@clerk/nextjs": "^7.1.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { AdminHome } from "@/components/admin/admin-home";
+
+export default function AdminPage() {
+  return <AdminHome />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from "@vercel/speed-insights/next"
+import { AppProviders } from "@/components/app-providers";
 
 export const metadata: Metadata = {
   title: "Lula Lake Sound | Recording Studio | Chattanooga, TN",
@@ -20,7 +21,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        {children}
+        <AppProviders>
+          {children}
+        </AppProviders>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/admin/admin-home.tsx
+++ b/src/components/admin/admin-home.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { api } from "@convex/_generated/api";
+import { Show, useAuth } from "@clerk/nextjs";
+import Link from "next/link";
+
+export function AdminHome() {
+  const { isLoaded } = useAuth();
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <h1 className="text-2xl font-semibold tracking-tight text-neutral-900">
+        Studio admin
+      </h1>
+      <p className="mt-2 text-sm text-neutral-600">
+        Only the studio owner (or allowlisted accounts) can use this area.
+      </p>
+      <div className="mt-8">
+        {!isLoaded ? <p className="text-sm text-neutral-600">Loading…</p> : null}
+        <Show
+          when="signed-in"
+          fallback={
+            <Show when="signed-out">
+              <p className="text-sm text-neutral-600">
+                Sign in with your studio account to continue.{" "}
+                <Link className="text-blue-700 underline" href="/">
+                  Back to site
+                </Link>
+              </p>
+            </Show>
+          }
+        >
+          <AdminSignedInPanel />
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+function AdminSignedInPanel() {
+  const { isLoading: convexAuthLoading, isAuthenticated: convexAuthenticated } =
+    useConvexAuth();
+
+  const settings = useQuery(
+    api.admin.cms.getForAdmin,
+    convexAuthenticated ? {} : "skip"
+  );
+  const setDraft = useMutation(api.admin.cms.setDraft);
+  const publishDraft = useMutation(api.admin.cms.publishDraft);
+
+  if (convexAuthLoading) {
+    return <p className="text-sm text-neutral-600">Connecting to Convex…</p>;
+  }
+
+  if (!convexAuthenticated) {
+    return (
+      <p className="text-sm text-neutral-600">
+        Your session is not linked to Convex yet. Try refreshing the page.
+      </p>
+    );
+  }
+
+  if (settings === undefined) {
+    return <p className="text-sm text-neutral-600">Loading settings…</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-medium text-neutral-900">Site settings</h2>
+        {settings === null ? (
+          <p className="mt-2 text-sm text-neutral-600">
+            No settings row yet. Seed defaults from the Convex dashboard, then refresh.
+          </p>
+        ) : (
+          <pre className="mt-3 max-h-64 overflow-auto rounded bg-neutral-50 p-3 text-xs text-neutral-800">
+            {JSON.stringify(settings, null, 2)}
+          </pre>
+        )}
+      </section>
+      {settings !== null ? (
+        <section className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            className="rounded-md bg-neutral-900 px-3 py-2 text-sm font-medium text-white hover:bg-neutral-800"
+            onClick={() =>
+              void setDraft({
+                draft: {
+                  flags: { priceTabEnabled: !settings.published.flags.priceTabEnabled },
+                  metadata: settings.published.metadata ?? undefined,
+                },
+              })
+            }
+          >
+            Toggle price tab (save draft)
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm font-medium text-neutral-900 hover:bg-neutral-50"
+            onClick={() => void publishDraft()}
+          >
+            Publish draft
+          </button>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/app-providers.tsx
+++ b/src/components/app-providers.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ClerkProvider, useAuth } from "@clerk/nextjs";
+import { ConvexProviderWithClerk } from "convex/react-clerk";
+import { ConvexReactClient } from "convex/react";
+import type { ReactNode } from "react";
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+if (!convexUrl) {
+  throw new Error("Missing NEXT_PUBLIC_CONVEX_URL");
+}
+
+const convex = new ConvexReactClient(convexUrl);
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  return (
+    <ClerkProvider>
+      <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+        {children}
+      </ConvexProviderWithClerk>
+    </ClerkProvider>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
+
+function parseAdminUserIds(): string[] {
+  const raw = process.env.CLERK_ADMIN_USER_IDS ?? "";
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isAdminRoute(req)) {
+    return;
+  }
+
+  const { userId } = await auth.protect();
+
+  const allowed = parseAdminUserIds();
+  if (allowed.length === 0) {
+    console.error("CLERK_ADMIN_USER_IDS is not set; refusing /admin access.");
+    return new NextResponse("Admin access is not configured.", { status: 503 });
+  }
+
+  if (!userId || !allowed.includes(userId)) {
+    return new NextResponse("You do not have access to this area.", { status: 403 });
+  }
+});
+
+export const config = {
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Clerk + Convex auth for the CMS admin surface per INF-71.

## Changes

- **Next.js:** `src/middleware.ts` uses `clerkMiddleware` and `createRouteMatcher` for `/admin(.*)`. After `auth.protect()`, requests must match `CLERK_ADMIN_USER_IDS` (comma-separated Clerk user IDs) or they receive **403**. If the allowlist env is empty, `/admin` returns **503** with a server log (Convex mutations use the same rule and throw if misconfigured).
- **Layout:** `ClerkProvider` wraps `ConvexProviderWithClerk` (with `useAuth` from Clerk) inside `body` via `AppProviders`.
- **Convex:** `convex/auth.config.ts` wires Clerk JWT validation (`CLERK_FRONTEND_API_URL` on the Convex deployment). `convex/lib/auth.ts` centralizes `requireAdminIdentity()` for admin functions. New `convex/admin/cms.ts` exposes `getForAdmin`, `setDraft`, and `publishDraft` — all require `ctx.auth.getUserIdentity()` plus the allowlist.
- **UI:** Minimal `/admin` page uses Clerk `Show` (not `SignedIn`/`SignedOut`) and `useConvexAuth` before calling Convex.
- **Docs:** `.env.example` documents Next.js and Convex env vars.

## Deployer checklist

1. Set **Next.js / Vercel:** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `CLERK_ADMIN_USER_IDS` (and existing Convex/Resend vars).
2. Set **Convex dashboard:** `CLERK_FRONTEND_API_URL`, `CLERK_ADMIN_USER_IDS` (same IDs as Next).
3. Run **`bunx convex dev`** (or deploy) once so auth config syncs; regenerate `convex/_generated/api.*` if the build pipeline does not (this PR updates `api.d.ts` manually because CI cannot authenticate to Convex codegen).

## Verification

- `bun run lint` — pass
- `bun run build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-71](https://linear.app/only-football-fans/issue/INF-71/lls-auth-gate-for-admin-studio-owner)

<div><a href="https://cursor.com/agents/bc-ede04225-4005-4003-bcc7-b221a5c90b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ede04225-4005-4003-bcc7-b221a5c90b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

