### PR TITLE
feat(cms): discard draft with confirmation (INF-76)

### DIFF
--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -161,8 +161,12 @@ export const publishSection = mutation({
 });
 
 /**
- * Drops unpublished edits and aligns the working copy with what is live.
- * Stub behavior: clears optional draft fields; no-op if there was no draft.
+ * Drops unpublished edits: removes `draftSnapshot` and clears `hasDraftChanges`.
+ * Preview/admin reads then fall back to `publishedSnapshot` (see `getSection`).
+ * When nothing has ever been published (`publishedAt === null`), published content
+ * stays as stored (typically defaults from seed / first row insert); the draft is
+ * cleared so the editor shows that same baseline. No separate storage refs today;
+ * if snapshots gain `_storage` ids, add explicit cleanup here (see INF-76).
  */
 export const discardDraft = mutation({
   args: {
@@ -181,13 +185,11 @@ export const discardDraft = mutation({
 
     const now = Date.now();
 
-    await ctx.db.replace("cmsSections", row._id, {
-      section: row.section,
-      publishedSnapshot: row.publishedSnapshot,
-      publishedAt: row.publishedAt,
+    await ctx.db.patch(row._id, {
+      draftSnapshot: undefined,
+      hasDraftChanges: false,
       updatedAt: now,
       updatedBy,
-      hasDraftChanges: false,
     });
 
     return { ok: true as const, section: args.section, discarded: true };

--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -16,7 +16,11 @@
 |----------|------|
 | `api.cms.saveDraft` | Writes `draftSnapshot`, updates `hasDraftChanges` vs `publishedSnapshot`. |
 | `api.cms.publishSection` | Copies `draftSnapshot` → `publishedSnapshot`, sets `publishedAt`, clears `hasDraftChanges` in **one** mutation. |
-| `api.cms.discardDraft` | Clears `draftSnapshot` and `hasDraftChanges` via `replace` (optional fields removed). No-op if there was nothing to discard. |
+| `api.cms.discardDraft` | Clears `draftSnapshot` and `hasDraftChanges` with `patch` (optional field removed). No-op if there was nothing to discard. `publishedSnapshot` and `publishedAt` are unchanged. |
+
+## Discard when nothing is published yet
+
+If `publishedAt` is `null`, discarding still only clears the draft; **live site content** remains whatever is already in `publishedSnapshot` (defaults until first publish). The editor preview again matches that stored baseline.
 
 ## First-time publish
 

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -259,11 +259,7 @@ function SettingsForm() {
 
       <AlertDialog
         open={discardDialogOpen}
-        onOpenChange={(open, eventDetails) => {
-          if (!open && busy === "Discarding…") {
-            eventDetails.cancel();
-            return;
-          }
+        onOpenChange={(open) => {
           setDiscardDialogOpen(open);
         }}
       >

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -259,7 +259,11 @@ function SettingsForm() {
 
       <AlertDialog
         open={discardDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open, eventDetails) => {
+          if (!open && busy === "Discarding…") {
+            eventDetails.cancel();
+            return;
+          }
           setDiscardDialogOpen(open);
         }}
       >

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -10,7 +10,17 @@ import {
 import { api } from "../../../../convex/_generated/api";
 import { useCallback, useState } from "react";
 import { Effect, pipe } from "effect";
+import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 
@@ -50,6 +60,7 @@ function SettingsForm() {
 
   const [localDraft, setLocalDraft] = useState<SettingsContent | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
 
   const source: SettingsContent | undefined =
     localDraft ??
@@ -66,16 +77,39 @@ function SettingsForm() {
   );
 
   const runAction = useCallback(
-    async (label: string, program: Effect.Effect<unknown, CmsAppError>) => {
+    async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
       setBusy(label);
       const outcome = await runAdminEffect(program);
       if (outcome !== undefined) {
         setLocalDraft(null);
       }
       setBusy(null);
+      return outcome;
     },
     [],
   );
+
+  const hasDraftOnServer = section?.hasDraftChanges ?? false;
+
+  const confirmDiscard = useCallback(async () => {
+    if (hasDraftOnServer) {
+      setBusy("Discarding…");
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() => discard({ section: "settings" })),
+      );
+      setBusy(null);
+      if (outcome === undefined) {
+        return;
+      }
+    }
+    setLocalDraft(null);
+    setDiscardDialogOpen(false);
+    toast.success(
+      hasDraftOnServer
+        ? "Draft discarded. The editor now matches the published site."
+        : "Unsaved changes discarded.",
+    );
+  }, [discard, hasDraftOnServer]);
 
   if (section === undefined) {
     return <p className="body-text text-muted-foreground">Loading settings…</p>;
@@ -88,7 +122,6 @@ function SettingsForm() {
   }
 
   const hasLocalEdits = localDraft !== null;
-  const hasDraftOnServer = section.hasDraftChanges;
 
   return (
     <div className="space-y-8">
@@ -215,18 +248,47 @@ function SettingsForm() {
         </button>
 
         <button
+          type="button"
           disabled={(!hasDraftOnServer && !hasLocalEdits) || busy !== null}
-          onClick={() =>
-            runAction(
-              "Discarding…",
-              convexMutationEffect(() => discard({ section: "settings" })),
-            )
-          }
+          onClick={() => setDiscardDialogOpen(true)}
           className="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
         >
-          {busy === "Discarding…" ? "Discarding…" : "Discard Draft"}
+          Discard draft
         </button>
       </div>
+
+      <AlertDialog open={discardDialogOpen} onOpenChange={setDiscardDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard draft changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {hasDraftOnServer
+                ? "This removes unpublished edits from the server and resets the editor to the last published settings. The live site is not changed."
+                : "This clears unsaved edits in your browser and shows the last published settings again."}
+              {!section.publishedAt && hasDraftOnServer ? (
+                <>
+                  {" "}
+                  Nothing has been published yet, so you will see the same default
+                  baseline stored for the site until you publish.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy === "Discarding…"}>
+              Cancel
+            </AlertDialogCancel>
+            <button
+              type="button"
+              disabled={busy === "Discarding…"}
+              onClick={() => void confirmDiscard()}
+              className="inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-transparent bg-destructive/10 px-2.5 text-sm font-medium text-destructive outline-none transition hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-3 focus-visible:ring-destructive/20 disabled:pointer-events-none disabled:opacity-50 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40"
+            >
+              {busy === "Discarding…" ? "Discarding…" : "Discard"}
+            </button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -257,7 +257,16 @@ function SettingsForm() {
         </button>
       </div>
 
-      <AlertDialog open={discardDialogOpen} onOpenChange={setDiscardDialogOpen}>
+      <AlertDialog
+        open={discardDialogOpen}
+        onOpenChange={(open, eventDetails) => {
+          if (!open && busy === "Discarding…") {
+            eventDetails.cancel();
+            return;
+          }
+          setDiscardDialogOpen(open);
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Discard draft changes?</AlertDialogTitle>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as AlertDialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  className,
+  ...props
+}: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger
+      data-slot="alert-dialog-trigger"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-popover p-6 text-popover-foreground shadow-lg duration-200 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-1.5 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-lg font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: AlertDialogPrimitive.Close.Props) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={className}
+      render={<Button type="button" variant="outline" />}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: AlertDialogPrimitive.Close.Props) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      className={className}
+      render={<Button type="button" variant="destructive" />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Dialog as AlertDialogPrimitive } from "@base-ui/react/dialog"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **INF-76**: discard draft / revert editor to published baseline with confirmation and success feedback.

## Changes

- **`discardDraft` mutation** (`convex/cms.ts`): Uses `db.patch` so only `draftSnapshot` (cleared), `hasDraftChanges`, `updatedAt`, and `updatedBy` change. **`publishedSnapshot`, `publishedAt`, and `publishedBy` are never rewritten** (aligned with main’s schema and owner-gated CMS).
- **Docs** (`docs/cms-publish.md`): Merged with main’s publish/admin table; discard row documents `patch` + unchanged published fields; subsection for **`publishedAt === null`**.
- **Admin UI** (`settings-editor.tsx`): Alert dialog before discard; Sonner success toast; blocks dialog dismiss (including Escape) while **Discarding…** is in flight.
- **`alert-dialog.tsx`**: Base UI **`@base-ui/react/alert-dialog`** (correct `role="alertdialog"`).

## Storage refs

Snapshots today have no `_storage` fields. Inline comment in the mutation for follow-up if media refs land on drafts.

## Testing

- `bun run lint`
- `bun run build`

---

Merged latest `main` into this branch to resolve PR conflicts.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-76](https://linear.app/only-football-fans/issue/INF-76/lls-discard-draft-revert-to-published)

<div><a href="https://cursor.com/agents/bc-1e031d86-5508-4810-bff3-860a96566946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e031d86-5508-4810-bff3-860a96566946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

