### PR TITLE
feat(cms): publish pipeline with validation, audit, owner gate (INF-75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ CLERK_FRONTEND_API_URL=
 # Admin CMS — set to "true" to enable the /admin route
 ADMIN_ENABLED=
 
+# Convex-only: comma-separated Clerk `tokenIdentifier` values allowed to publish CMS (see convex/lib/auth.ts).
+# Leave unset in dev to allow any signed-in user to publish.
+CMS_OWNER_TOKEN_IDENTIFIERS=
+
 # Resend (https://resend.com) — verified domain required for `from`
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as cms from "../cms.js";
 import type * as cmsShared from "../cmsShared.js";
@@ -24,6 +25,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
   cms: typeof cms;
   cmsShared: typeof cmsShared;

--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -1,0 +1,86 @@
+/**
+ * Admin publish API (INF-75).
+ *
+ * Prefer **`api.admin.publish.publish`** for explicit admin flows and **`api.cms.publishSection`**
+ * for the shared CMS module (both enforce owner gate when `CMS_OWNER_TOKEN_IDENTIFIERS` is set).
+ *
+ * Env: `CMS_OWNER_TOKEN_IDENTIFIERS` — comma-separated Convex `tokenIdentifier` values (Clerk).
+ * When unset, any signed-in user may publish (dev convenience).
+ */
+import { mutation } from "../_generated/server";
+import { v } from "convex/values";
+import { cmsSectionValidator } from "../schema.shared";
+import type { Doc } from "../_generated/dataModel";
+import { requireCmsOwner } from "../lib/auth";
+import { cmsPublishValidationFailed } from "../errors";
+import {
+  collectAllPublishIssues,
+  ensureSectionRow,
+  publishSettingsSectionCore,
+  rowsWithPublishableDraft,
+} from "../cmsPublishHelpers";
+
+export const publish = mutation({
+  args: { section: cmsSectionValidator },
+  handler: async (ctx, args) => {
+    const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
+    void identity;
+    const { id, row } = await ensureSectionRow(ctx, args.section, updatedBy);
+    return await publishSettingsSectionCore(ctx, {
+      section: args.section,
+      id,
+      row,
+      publishedByUserId: userId,
+      updatedByTokenId: updatedBy,
+    });
+  },
+});
+
+export const publishSite = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
+    void identity;
+
+    const rows = await ctx.db.query("cmsSections").take(50);
+    const targets = rowsWithPublishableDraft(rows);
+
+    if (targets.length === 0) {
+      return {
+        ok: true as const,
+        kind: "nothing_to_publish" as const,
+        publishedSections: [] as Doc<"cmsSections">["section"][],
+      };
+    }
+
+    const issues = collectAllPublishIssues(targets);
+    if (issues.length > 0) {
+      cmsPublishValidationFailed(
+        "site",
+        "One or more sections failed publish validation.",
+        issues,
+      );
+    }
+
+    const results: Awaited<ReturnType<typeof publishSettingsSectionCore>>[] =
+      [];
+
+    for (const row of targets) {
+      const r = await publishSettingsSectionCore(ctx, {
+        section: row.section,
+        id: row._id,
+        row,
+        publishedByUserId: userId,
+        updatedByTokenId: updatedBy,
+      });
+      results.push(r);
+    }
+
+    return {
+      ok: true as const,
+      kind: "published" as const,
+      publishedSections: targets.map((t) => t.section),
+      results,
+    };
+  },
+});

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -1,13 +1,20 @@
-import { query, mutation, type MutationCtx } from "./_generated/server";
+import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import {
   cmsSectionValidator,
   settingsContentValidator,
 } from "./schema.shared";
-import type { Doc, Id } from "./_generated/dataModel";
 import { SETTINGS_DEFAULTS, settingsSnapshotsEqual } from "./cmsShared";
-import { requireAuthenticatedIdentity } from "./lib/auth";
-import { cmsNotFound, cmsPublishValidationFailed } from "./errors";
+import {
+  requireAuthenticatedIdentity,
+  requireCmsOwner,
+} from "./lib/auth";
+import {
+  collectSettingsPublishIssues,
+  ensureSectionRow,
+  getSectionRow,
+  publishSettingsSectionCore,
+} from "./cmsPublishHelpers";
 
 /**
  * Full section document for the admin UI (published + optional draft).
@@ -27,6 +34,7 @@ export const getSection = query({
         section: args.section,
         publishedSnapshot: SETTINGS_DEFAULTS,
         publishedAt: null,
+        publishedBy: null,
         draftSnapshot: null,
         hasDraftChanges: false,
         updatedAt: null,
@@ -38,6 +46,7 @@ export const getSection = query({
       section: row.section,
       publishedSnapshot: row.publishedSnapshot,
       publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy ?? null,
       draftSnapshot: row.draftSnapshot ?? null,
       hasDraftChanges: row.hasDraftChanges,
       updatedAt: row.updatedAt,
@@ -45,47 +54,6 @@ export const getSection = query({
     };
   },
 });
-
-async function getSectionRow(
-  ctx: MutationCtx,
-  section: Doc<"cmsSections">["section"],
-): Promise<Doc<"cmsSections"> | null> {
-  return await ctx.db
-    .query("cmsSections")
-    .withIndex("by_section", (q) => q.eq("section", section))
-    .unique();
-}
-
-async function ensureSectionRow(
-  ctx: MutationCtx,
-  section: Doc<"cmsSections">["section"],
-  updatedBy: string | undefined,
-): Promise<{ row: Doc<"cmsSections">; id: Id<"cmsSections"> }> {
-  const existing = await getSectionRow(ctx, section);
-  const now = Date.now();
-
-  if (existing) {
-    return { row: existing, id: existing._id };
-  }
-
-  if (section !== "settings") {
-    cmsNotFound("cmsSection", section, `Unknown CMS section: ${section}`);
-  }
-
-  const id = await ctx.db.insert("cmsSections", {
-    section: "settings",
-    updatedAt: now,
-    updatedBy,
-    publishedSnapshot: SETTINGS_DEFAULTS,
-    publishedAt: now,
-    hasDraftChanges: false,
-  });
-  const row = await ctx.db.get("cmsSections", id);
-  if (!row) {
-    throw new Error("Failed to load cmsSections row after insert");
-  }
-  return { row, id };
-}
 
 /**
  * Persist a working copy for a section. Does not change what public readers see.
@@ -97,7 +65,7 @@ export const saveDraft = mutation({
     content: settingsContentValidator,
   },
   handler: async (ctx, args) => {
-    const { updatedBy } = await requireAuthenticatedIdentity(ctx);
+    const { updatedBy } = await requireCmsOwner(ctx);
     const { id, row } = await ensureSectionRow(
       ctx,
       args.section,
@@ -122,54 +90,63 @@ export const saveDraft = mutation({
 });
 
 /**
- * Atomically promotes the current draft to published in one transaction, then clears
- * `draftSnapshot` so a second publish without `saveDraft` fails fast.
- * Public readers always see the previous published snapshot until this commit completes.
+ * Validates then atomically promotes draft → published in one transaction.
+ * Idempotent: if there is no draft and nothing pending, returns `already_current` without writes.
+ * Sets `publishedAt` and `publishedBy` (Clerk user id). On validation failure, throws
+ * `PUBLISH_VALIDATION_FAILED` with optional field-level `issues` (Effect-friendly via client mapping).
  */
 export const publishSection = mutation({
   args: {
     section: cmsSectionValidator,
   },
   handler: async (ctx, args) => {
-    const { updatedBy } = await requireAuthenticatedIdentity(ctx);
-    const { id, row } = await ensureSectionRow(
-      ctx,
-      args.section,
-      updatedBy,
-    );
-    const draft = row.draftSnapshot;
-    if (!draft) {
-      cmsPublishValidationFailed(
-        args.section,
-        "No draft to publish: save a draft first, or there is nothing to discard.",
-      );
-    }
-
-    const now = Date.now();
-
-    await ctx.db.patch(id, {
-      publishedSnapshot: draft,
-      publishedAt: now,
-      draftSnapshot: undefined,
-      hasDraftChanges: false,
-      updatedAt: now,
-      updatedBy,
+    const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
+    void identity;
+    const { id, row } = await ensureSectionRow(ctx, args.section, updatedBy);
+    return await publishSettingsSectionCore(ctx, {
+      section: args.section,
+      id,
+      row,
+      publishedByUserId: userId,
+      updatedByTokenId: updatedBy,
     });
+  },
+});
 
-    return { ok: true as const, section: args.section, publishedAt: now };
+/**
+ * Read-only validation for the current draft (or published snapshot if no draft).
+ * Does not write. Owner-only when `CMS_OWNER_TOKEN_IDENTIFIERS` is configured.
+ */
+export const validatePublishSection = query({
+  args: { section: cmsSectionValidator },
+  handler: async (ctx, args) => {
+    await requireCmsOwner(ctx);
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", args.section))
+      .unique();
+
+    const snapshot =
+      row?.draftSnapshot ?? row?.publishedSnapshot ?? SETTINGS_DEFAULTS;
+    const issues = collectSettingsPublishIssues(snapshot);
+    return {
+      ok: issues.length === 0,
+      section: args.section,
+      issues,
+    };
   },
 });
 
 /**
  * Drops unpublished edits and aligns the working copy with what is live.
- * Stub behavior: clears optional draft fields; no-op if there was no draft.
+ * Clears optional draft fields; no-op if there was no draft.
  */
 export const discardDraft = mutation({
   args: {
     section: cmsSectionValidator,
   },
   handler: async (ctx, args) => {
-    const { updatedBy } = await requireAuthenticatedIdentity(ctx);
+    const { updatedBy } = await requireCmsOwner(ctx);
     const row = await getSectionRow(ctx, args.section);
     if (!row) {
       return { ok: true as const, section: args.section, discarded: false };
@@ -185,6 +162,7 @@ export const discardDraft = mutation({
       section: row.section,
       publishedSnapshot: row.publishedSnapshot,
       publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy,
       updatedAt: now,
       updatedBy,
       hasDraftChanges: false,

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -162,7 +162,9 @@ export const discardDraft = mutation({
       section: row.section,
       publishedSnapshot: row.publishedSnapshot,
       publishedAt: row.publishedAt,
-      publishedBy: row.publishedBy,
+      ...(row.publishedBy !== undefined
+        ? { publishedBy: row.publishedBy }
+        : {}),
       updatedAt: now,
       updatedBy,
       hasDraftChanges: false,

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -1,0 +1,177 @@
+import type { MutationCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { SETTINGS_DEFAULTS, settingsSnapshotsEqual } from "./cmsShared";
+import { cmsNotFound, cmsPublishValidationFailed } from "./errors";
+
+export type PublishIssue = { path: string; message: string };
+
+export async function getSectionRow(
+  ctx: MutationCtx,
+  section: Doc<"cmsSections">["section"],
+): Promise<Doc<"cmsSections"> | null> {
+  return await ctx.db
+    .query("cmsSections")
+    .withIndex("by_section", (q) => q.eq("section", section))
+    .unique();
+}
+
+export async function ensureSectionRow(
+  ctx: MutationCtx,
+  section: Doc<"cmsSections">["section"],
+  updatedBy: string | undefined,
+): Promise<{ row: Doc<"cmsSections">; id: Id<"cmsSections"> }> {
+  const existing = await getSectionRow(ctx, section);
+  const now = Date.now();
+
+  if (existing) {
+    return { row: existing, id: existing._id };
+  }
+
+  if (section !== "settings") {
+    cmsNotFound("cmsSection", section, `Unknown CMS section: ${section}`);
+  }
+
+  const id = await ctx.db.insert("cmsSections", {
+    section: "settings",
+    updatedAt: now,
+    updatedBy,
+    publishedSnapshot: SETTINGS_DEFAULTS,
+    publishedAt: now,
+    hasDraftChanges: false,
+  });
+  const row = await ctx.db.get("cmsSections", id);
+  if (!row) {
+    throw new Error("Failed to load cmsSections row after insert");
+  }
+  return { row, id };
+}
+
+const trimOrEmpty = (s: string | undefined): string =>
+  s === undefined ? "" : s.trim();
+
+/** Best-effort checks before promoting `draft` to published (INF-75). */
+export function collectSettingsPublishIssues(
+  draft: Doc<"cmsSections">["publishedSnapshot"],
+): PublishIssue[] {
+  const issues: PublishIssue[] = [];
+  const title = trimOrEmpty(draft.metadata?.title);
+  if (title.length === 0) {
+    issues.push({
+      path: "metadata.title",
+      message: "Site title is required to publish.",
+    });
+  }
+  const description = trimOrEmpty(draft.metadata?.description);
+  if (description.length === 0) {
+    issues.push({
+      path: "metadata.description",
+      message: "Site description is required to publish.",
+    });
+  }
+  return issues;
+}
+
+export type PublishSectionResult =
+  | {
+      ok: true;
+      kind: "published";
+      section: Doc<"cmsSections">["section"];
+      publishedAt: number;
+      publishedBy: string;
+    }
+  | {
+      ok: true;
+      kind: "already_current";
+      section: Doc<"cmsSections">["section"];
+      publishedAt: number | null;
+      publishedBy: string | undefined;
+    };
+
+/**
+ * Single-transaction promote draft → published, or no-op when there is no draft and nothing pending.
+ */
+export async function publishSettingsSectionCore(
+  ctx: MutationCtx,
+  args: {
+    section: Doc<"cmsSections">["section"];
+    id: Id<"cmsSections">;
+    row: Doc<"cmsSections">;
+    /** Clerk `subject` — stored as `publishedBy` for audit. */
+    publishedByUserId: string;
+    updatedByTokenId: string;
+  },
+): Promise<PublishSectionResult> {
+  const { section, id, row, publishedByUserId, updatedByTokenId } = args;
+  const draft = row.draftSnapshot;
+
+  if (!draft) {
+    if (row.hasDraftChanges) {
+      cmsPublishValidationFailed(
+        section,
+        "Draft data is missing but changes are flagged. Save a draft again, then publish.",
+        [{ path: "_state", message: "Inconsistent draft state." }],
+      );
+    }
+    return {
+      ok: true,
+      kind: "already_current",
+      section,
+      publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy,
+    };
+  }
+
+  const issues = collectSettingsPublishIssues(draft);
+  if (issues.length > 0) {
+    cmsPublishValidationFailed(section, "Publish validation failed.", issues);
+  }
+
+  const now = Date.now();
+
+  await ctx.db.patch(id, {
+    publishedSnapshot: draft,
+    publishedAt: now,
+    publishedBy: publishedByUserId,
+    draftSnapshot: undefined,
+    hasDraftChanges: false,
+    updatedAt: now,
+    updatedBy: updatedByTokenId,
+  });
+
+  return {
+    ok: true,
+    kind: "published",
+    section,
+    publishedAt: now,
+    publishedBy: publishedByUserId,
+  };
+}
+
+/** Rows that have a draft different from published (site-wide publish targets). */
+export function rowsWithPublishableDraft(
+  rows: Doc<"cmsSections">[],
+): Doc<"cmsSections">[] {
+  return rows.filter(
+    (row) =>
+      row.draftSnapshot !== undefined &&
+      !settingsSnapshotsEqual(row.draftSnapshot, row.publishedSnapshot),
+  );
+}
+
+/** Aggregate validation issues across sections (preflight for `publishSite`). */
+export function collectAllPublishIssues(
+  targets: Doc<"cmsSections">[],
+): PublishIssue[] {
+  const issues: PublishIssue[] = [];
+  for (const row of targets) {
+    const d = row.draftSnapshot;
+    if (!d) continue;
+    for (const issue of collectSettingsPublishIssues(d)) {
+      issues.push({
+        path: `${row.section}.${issue.path}`,
+        message: issue.message,
+      });
+    }
+  }
+  return issues;
+}

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -29,6 +29,14 @@ export const cmsConvexErrorValidator = v.union(
     code: v.literal("PUBLISH_VALIDATION_FAILED"),
     message: v.string(),
     section: v.string(),
+    issues: v.optional(
+      v.array(
+        v.object({
+          path: v.string(),
+          message: v.string(),
+        }),
+      ),
+    ),
   }),
   v.object({
     code: v.literal("UNKNOWN"),
@@ -80,10 +88,12 @@ export function cmsConflict(message: string, reason?: string): never {
 export function cmsPublishValidationFailed(
   section: string,
   message: string,
+  issues?: Array<{ path: string; message: string }>,
 ): never {
   throw new ConvexError<CmsConvexError>({
     code: "PUBLISH_VALIDATION_FAILED",
     message,
     section,
+    ...(issues !== undefined && issues.length > 0 ? { issues } : {}),
   });
 }

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,6 +1,18 @@
 import type { QueryCtx, MutationCtx } from "../_generated/server";
 import { cmsUnauthorized } from "../errors";
 
+function parseCmsOwnerTokenIdentifiers(): string[] | null {
+  const raw = process.env.CMS_OWNER_TOKEN_IDENTIFIERS;
+  if (raw === undefined || raw.trim() === "") {
+    return null;
+  }
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return ids.length > 0 ? ids : null;
+}
+
 /**
  * CMS functions require a valid Convex identity (Clerk JWT). Any signed-in Clerk user may read/edit.
  */
@@ -14,4 +26,21 @@ export async function requireAuthenticatedIdentity(ctx: QueryCtx | MutationCtx) 
     userId: identity.subject,
     updatedBy: identity.tokenIdentifier,
   };
+}
+
+/**
+ * Restricts mutations to the studio owner when `CMS_OWNER_TOKEN_IDENTIFIERS` is set on the Convex
+ * deployment (comma-separated `identity.tokenIdentifier` values from Clerk). If unset, falls back
+ * to any authenticated user so local dev keeps working.
+ */
+export async function requireCmsOwner(ctx: QueryCtx | MutationCtx) {
+  const base = await requireAuthenticatedIdentity(ctx);
+  const allowlist = parseCmsOwnerTokenIdentifiers();
+  if (allowlist === null) {
+    return base;
+  }
+  if (!allowlist.includes(base.identity.tokenIdentifier)) {
+    cmsUnauthorized("You do not have permission to perform this action.");
+  }
+  return base;
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * CMS sections use **one row per section** (approach B):
- * - `publishedSnapshot` + `publishedAt` — what public readers see (atomic updates on publish).
+ * - `publishedSnapshot` + `publishedAt` + optional `publishedBy` (Clerk user id) — what public readers see (atomic updates on publish).
  * - `draftSnapshot` — working copy for admins; optional until first edit.
  * - `hasDraftChanges` — true when draft differs from published (cleared on publish / discard).
  *
@@ -36,6 +36,8 @@ export default defineSchema({
     updatedBy: v.optional(v.string()),
     publishedSnapshot: settingsContentValidator,
     publishedAt: v.union(v.number(), v.null()),
+    /** Clerk user id (`subject`) who last published this section. */
+    publishedBy: v.optional(v.string()),
     draftSnapshot: v.optional(settingsContentValidator),
     hasDraftChanges: v.boolean(),
   }).index("by_section", ["section"]),

--- a/convex/siteSettings.ts
+++ b/convex/siteSettings.ts
@@ -22,6 +22,7 @@ export const getPublished = query({
       metadata: row.publishedSnapshot.metadata ?? null,
       updatedAt: row.updatedAt,
       publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy ?? null,
     };
   },
 });

--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -15,14 +15,17 @@
 | Function | Role |
 |----------|------|
 | `api.cms.saveDraft` | Writes `draftSnapshot`, updates `hasDraftChanges` vs `publishedSnapshot`. |
-| `api.cms.publishSection` | Copies `draftSnapshot` → `publishedSnapshot`, sets `publishedAt`, clears `hasDraftChanges` in **one** mutation. |
+| `api.cms.publishSection` | Validates, then copies `draftSnapshot` → `publishedSnapshot`, sets `publishedAt` + `publishedBy` (Clerk user id), clears draft in **one** transaction. Idempotent when there is nothing to publish. |
+| `api.admin.publish.publish` | Same as `publishSection` (owner-gated; see `convex/admin/publish.ts`). |
+| `api.admin.publish.publishSite` | Validates **all** sections with pending drafts first; if any fail, **no** section is published. Otherwise publishes each in the same transaction. |
+| `api.cms.validatePublishSection` | Read-only preflight validation for the effective draft snapshot. |
 | `api.cms.discardDraft` | Clears `draftSnapshot` and `hasDraftChanges` via `replace` (optional fields removed). No-op if there was nothing to discard. |
 
 ## First-time publish
 
 1. **Empty environment:** run `internal.seed.seedSiteSettingsDefaults` or call `saveDraft` once (both create a row with defaults in `publishedSnapshot` and `publishedAt` set).
 2. **Editor saves:** `saveDraft` fills `draftSnapshot`; `hasDraftChanges` is true when draft ≠ published.
-3. **Publish:** `publishSection` requires an existing `draftSnapshot` (save first). It atomically promotes that snapshot to `publishedSnapshot`.
+3. **Publish:** Save a draft first. `publishSection` validates required fields, then promotes `draftSnapshot` → `publishedSnapshot`. If there is no draft and `hasDraftChanges` is false, publish is a **no-op** (safe double-click). Set **`CMS_OWNER_TOKEN_IDENTIFIERS`** on the Convex deployment (comma-separated `tokenIdentifier` values) to restrict publish to the studio owner.
 
 ## Adding a new content type (new section)
 

--- a/src/lib/effect-errors.ts
+++ b/src/lib/effect-errors.ts
@@ -28,6 +28,10 @@ export type CmsConvexErrorPayload =
       readonly code: "PUBLISH_VALIDATION_FAILED";
       readonly message: string;
       readonly section: string;
+      readonly issues?: ReadonlyArray<{
+        readonly path: string;
+        readonly message: string;
+      }>;
     }
   | { readonly code: "UNKNOWN"; readonly message: string };
 
@@ -56,6 +60,7 @@ export class PublishValidationFailed extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly section: string;
+  readonly issues?: ReadonlyArray<{ readonly path: string; readonly message: string }>;
 }> {}
 
 export type CmsAppError =
@@ -91,8 +96,18 @@ function isCmsConvexErrorPayload(
       return (
         value["reason"] === undefined || typeof value["reason"] === "string"
       );
-    case "PUBLISH_VALIDATION_FAILED":
-      return typeof value["section"] === "string";
+    case "PUBLISH_VALIDATION_FAILED": {
+      if (typeof value["section"] !== "string") return false;
+      const issues = value["issues"];
+      if (issues === undefined) return true;
+      if (!Array.isArray(issues)) return false;
+      return issues.every(
+        (item) =>
+          isRecord(item) &&
+          typeof item["path"] === "string" &&
+          typeof item["message"] === "string",
+      );
+    }
     case "UNKNOWN":
       return true;
     default:
@@ -128,6 +143,7 @@ export function fromConvexCmsError(cause: unknown): CmsAppError {
           return new PublishValidationFailed({
             message: data.message,
             section: data.section,
+            ...(data.issues !== undefined ? { issues: data.issues } : {}),
           });
         case "UNKNOWN":
           return new ValidationError({ message: data.message });
@@ -164,8 +180,13 @@ export function cmsErrorToastMessage(err: CmsAppError): string {
       return err.reason !== undefined
         ? `${err.message} — ${err.reason}`
         : err.message;
-    case "PublishValidationFailed":
-      return `[${err.section}] ${err.message}`;
+    case "PublishValidationFailed": {
+      const detail =
+        err.issues !== undefined && err.issues.length > 0
+          ? ` — ${err.issues.map((i) => `${i.path}: ${i.message}`).join("; ")}`
+          : "";
+      return `[${err.section}] ${err.message}${detail}`;
+    }
     default: {
       const _exhaustive: never = err;
       return String(_exhaustive);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the INF-75 publish pipeline: validate → single-transaction publish → audit metadata, with Effect-friendly validation errors and optional site-wide publish.

## Changes

- **Schema:** `cmsSections.publishedBy` (optional Clerk user id / `subject`) alongside `publishedAt`.
- **Validate:** `collectSettingsPublishIssues` requires non-empty trimmed `metadata.title` and `metadata.description` before any write. New read-only query `api.cms.validatePublishSection` for preflight.
- **Publish:** Shared core `publishSettingsSectionCore` in `convex/cmsPublishHelpers.ts`. `api.cms.publishSection` and `api.admin.publish.publish` use it. **Idempotent:** no draft and `hasDraftChanges` false → returns `{ kind: "already_current" }` without patching.
- **Site-wide:** `api.admin.publish.publishSite` loads up to 50 `cmsSections` rows in one read batch, validates **all** pending drafts first; on failure throws `PUBLISH_VALIDATION_FAILED` with **no** partial publishes.
- **Audit:** On successful publish, sets `publishedAt`, `publishedBy`, and `updatedBy` (token identifier). `api.siteSettings.getPublished` now includes `publishedBy` for consumers that need it.
- **Owner gate:** `requireCmsOwner` in `convex/lib/auth.ts` — when Convex env `CMS_OWNER_TOKEN_IDENTIFIERS` (comma-separated `tokenIdentifier` values) is set, **saveDraft**, **discardDraft**, **publish**, and **validatePublishSection** require an allowlisted identity; unset preserves previous “any signed-in user” behavior for local dev.
- **Effect:** `PUBLISH_VALIDATION_FAILED` may include optional `issues: { path, message }[]`; `PublishValidationFailed` and `fromConvexCmsError` / toast messaging updated accordingly.

## Follow-up (Codex review)

- **discardDraft:** Only include `publishedBy` in the `db.replace` payload when it is defined, so Convex does not reject `undefined` for rows that have never been published.

## Docs / env

- `docs/cms-publish.md` updated with the new mutations and env var.
- `.env.example` documents `CMS_OWNER_TOKEN_IDENTIFIERS` (Convex deployment only).

## Testing

- `bun run lint`
- `bunx tsc --noEmit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-75](https://linear.app/only-football-fans/issue/INF-75/lls-publish-pipeline-validate-publish-audit-fields)

<div><a href="https://cursor.com/agents/bc-ccde768d-decf-4c0c-b735-b855c240c55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccde768d-decf-4c0c-b735-b855c240c55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

