### PR TITLE
feat: preview mode for marketing site (owner-only)

### DIFF
--- a/convex/siteSettings.ts
+++ b/convex/siteSettings.ts
@@ -1,4 +1,6 @@
 import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import { SETTINGS_DEFAULTS } from "./cmsShared";
 
 /**
  * Published site settings only (flags + shared metadata). Safe for anonymous clients.
@@ -23,6 +25,54 @@ export const getPublished = query({
       updatedAt: row.updatedAt,
       publishedAt: row.publishedAt,
       publishedBy: row.publishedBy ?? null,
+    };
+  },
+});
+
+/**
+ * Preview site settings for owner-only access. Returns the draft snapshot
+ * (falling back to published snapshot / defaults) so the owner can preview
+ * unpublished changes on the real marketing site.
+ *
+ * Returns `null` for unauthenticated or non-owner callers — never leaks drafts.
+ */
+export const getPreview = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "settings"))
+      .unique();
+
+    if (!row) {
+      return {
+        flags: SETTINGS_DEFAULTS.flags,
+        metadata: SETTINGS_DEFAULTS.metadata ?? null,
+        updatedAt: null,
+        publishedAt: null,
+        publishedBy: null,
+        hasDraftChanges: false,
+      };
+    }
+
+    const snapshot = row.draftSnapshot ?? row.publishedSnapshot;
+
+    return {
+      flags: snapshot.flags,
+      metadata: snapshot.metadata ?? null,
+      updatedAt: row.updatedAt,
+      publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy ?? null,
+      hasDraftChanges: row.hasDraftChanges,
     };
   },
 });

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
+import Link from "next/link";
 
 type SettingsContent = {
   flags: { priceTabEnabled: boolean };
@@ -255,6 +256,14 @@ function SettingsForm() {
         >
           Discard draft
         </button>
+
+        <Link
+          href="/preview"
+          target="_blank"
+          className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-600 transition hover:bg-amber-500/20 dark:text-amber-400"
+        >
+          Preview Site ↗
+        </Link>
       </div>
 
       <AlertDialog

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,71 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Header } from "@/components/header";
-import { Hero } from "@/components/hero";
-import { TheSpace } from "@/components/the-space";
-import { EquipmentSpecs } from "@/components/equipment-specs";
-import { AmenitiesNearby } from "@/components/amenities-nearby";
-import { FAQ } from "@/components/faq";
-import { ArtistInquiries } from "@/components/artist-inquiries";
-
-function calculateLogoScale(scrollY: number): number {
-  return Math.max(0.7, 1 - scrollY * 0.0008);
-}
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { HomepageShell } from "@/components/homepage-shell";
 
 export default function Home() {
-  const [scrollY, setScrollY] = useState(0);
-  const mainRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let ticking = false;
-    function onScroll() {
-      if (!ticking) {
-        requestAnimationFrame(() => {
-          setScrollY(window.scrollY);
-          ticking = false;
-        });
-        ticking = true;
-      }
-    }
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  // IntersectionObserver for scroll-triggered reveal animations
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("in-view");
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.15, rootMargin: "0px 0px -60px 0px" }
-    );
-
-    const reveals = document.querySelectorAll(".reveal");
-    reveals.forEach((el) => observer.observe(el));
-
-    return () => observer.disconnect();
-  }, []);
-
-  const logoScale = calculateLogoScale(scrollY);
-
-  return (
-    <div ref={mainRef} className="min-h-screen bg-washed-black relative grain-overlay">
-      <Header scrollY={scrollY} />
-      <Hero logoScale={logoScale} />
-
-      <div className="relative z-10">
-        <TheSpace />
-        <EquipmentSpecs />
-        <AmenitiesNearby />
-        <FAQ />
-        <ArtistInquiries />
-      </div>
-    </div>
-  );
+  const settings = useQuery(api.siteSettings.getPublished);
+  return <HomepageShell settings={settings ?? null} />;
 }

--- a/src/app/preview/layout.tsx
+++ b/src/app/preview/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  robots: "noindex, nofollow",
+  referrer: "no-referrer",
+};
+
+export default function PreviewLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <>{children}</>;
+}

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { HomepageShell } from "@/components/homepage-shell";
+import { PreviewBanner } from "@/components/preview-banner";
+
+function PreviewContent() {
+  const settings = useQuery(api.siteSettings.getPreview);
+
+  if (settings === undefined) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-washed-black">
+        <p className="text-ivory/60">Loading preview…</p>
+      </div>
+    );
+  }
+
+  if (settings === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-washed-black">
+        <p className="text-ivory/60">
+          Preview is not available. You may not have permission to view draft content.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <HomepageShell
+      settings={settings}
+      banner={<PreviewBanner hasDraftChanges={settings.hasDraftChanges} />}
+    />
+  );
+}
+
+export default function PreviewPage() {
+  return (
+    <>
+      <AuthLoading>
+        <div className="flex min-h-screen items-center justify-center bg-washed-black">
+          <p className="text-ivory/60">Authenticating…</p>
+        </div>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <div className="flex min-h-screen items-center justify-center bg-washed-black">
+          <p className="text-ivory/60">Sign in required to preview draft content.</p>
+        </div>
+      </Unauthenticated>
+
+      <Authenticated>
+        <PreviewContent />
+      </Authenticated>
+    </>
+  );
+}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Header } from "@/components/header";
+import { Hero } from "@/components/hero";
+import { TheSpace } from "@/components/the-space";
+import { EquipmentSpecs } from "@/components/equipment-specs";
+import { AmenitiesNearby } from "@/components/amenities-nearby";
+import { FAQ } from "@/components/faq";
+import { ArtistInquiries } from "@/components/artist-inquiries";
+import { ServicesAndPricing } from "@/components/services-pricing";
+import type { SiteSettings } from "@/lib/site-settings";
+
+function calculateLogoScale(scrollY: number): number {
+  return Math.max(0.7, 1 - scrollY * 0.0008);
+}
+
+interface HomepageShellProps {
+  readonly settings: SiteSettings | null;
+  readonly banner?: React.ReactNode;
+}
+
+export function HomepageShell({ settings, banner }: HomepageShellProps) {
+  const [scrollY, setScrollY] = useState(0);
+
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+
+    let ticking = false;
+    function onScroll() {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          setScrollY(window.scrollY);
+          ticking = false;
+        });
+        ticking = true;
+      }
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("in-view");
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -60px 0px" },
+    );
+    const reveals = node.querySelectorAll(".reveal");
+    reveals.forEach((el) => observer.observe(el));
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      observer.disconnect();
+    };
+  }, []);
+
+  const showPricing = settings?.flags.priceTabEnabled ?? false;
+  const logoScale = calculateLogoScale(scrollY);
+
+  return (
+    <div ref={containerRef} className="min-h-screen bg-washed-black relative grain-overlay">
+      {banner}
+      <Header scrollY={scrollY} />
+      <Hero logoScale={logoScale} />
+
+      <div className="relative z-10">
+        <TheSpace />
+        <EquipmentSpecs />
+        {showPricing && <ServicesAndPricing />}
+        <AmenitiesNearby />
+        <FAQ />
+        <ArtistInquiries />
+      </div>
+    </div>
+  );
+}

--- a/src/components/preview-banner.tsx
+++ b/src/components/preview-banner.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+
+interface PreviewBannerProps {
+  readonly hasDraftChanges: boolean;
+}
+
+/**
+ * Floating banner shown on `/preview` pages to indicate the owner
+ * is viewing draft (unpublished) content.
+ */
+export function PreviewBanner({ hasDraftChanges }: PreviewBannerProps) {
+  return (
+    <div className="fixed bottom-4 left-1/2 z-[100] -translate-x-1/2">
+      <div className="flex items-center gap-3 rounded-full border border-amber-500/30 bg-amber-950/90 px-5 py-2.5 text-sm text-amber-200 shadow-lg backdrop-blur-sm">
+        <span className="relative flex h-2.5 w-2.5">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-amber-400" />
+        </span>
+        <span className="font-medium">
+          Preview Mode
+          {hasDraftChanges ? " — viewing draft changes" : " — no unpublished changes"}
+        </span>
+        <Link
+          href="/"
+          className="ml-1 rounded-full bg-amber-500/20 px-3 py-0.5 text-xs font-medium text-amber-100 transition hover:bg-amber-500/30"
+        >
+          Exit Preview
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -1,0 +1,12 @@
+/** Shape returned by `siteSettings.getPublished` and `siteSettings.getPreview`. */
+export type SiteSettings = {
+  flags: { priceTabEnabled: boolean };
+  metadata: { title?: string; description?: string } | null;
+  updatedAt: number | null;
+  publishedAt: number | null;
+  publishedBy: string | null;
+};
+
+export type PreviewSiteSettings = SiteSettings & {
+  hasDraftChanges: boolean;
+};

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -6,7 +6,3 @@ export type SiteSettings = {
   publishedAt: number | null;
   publishedBy: string | null;
 };
-
-export type PreviewSiteSettings = SiteSettings & {
-  hasDraftChanges: boolean;
-};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
+const isPreviewRoute = createRouteMatcher(["/preview(.*)"]);
 
 // Next.js Link prefetch (RSC) uses the app path (e.g. /admin/pricing), not _next/static,
 // so it matches this middleware. Authenticated users pass auth.protect(); unauthenticated
@@ -14,6 +15,10 @@ export default clerkMiddleware(async (auth, req) => {
         status: 404,
       });
     }
+    await auth.protect();
+  }
+
+  if (isPreviewRoute(req)) {
     await auth.protect();
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements owner-only preview mode for the marketing site, allowing the studio owner to see draft CMS content on the real site before publishing.

## What changed

### Convex backend
- **`siteSettings.getPreview`** — New public query that returns the draft snapshot (falling back to published/defaults). Checks CMS owner identity server-side via `requireCmsOwner`; returns `null` for unauthenticated or non-owner callers so drafts are never leaked.

### Next.js routes
- **`/preview`** — New dynamic route that renders the marketing homepage with draft content. Uses `Authenticated`/`Unauthenticated`/`AuthLoading` from Convex React to show appropriate states.
- **`/preview/layout.tsx`** — Forces `dynamic = "force-dynamic"` to prevent CDN caching of draft content. Sets `robots: noindex, nofollow` and `referrer: no-referrer`.

### Middleware
- `/preview(.*)` routes now require Clerk authentication via `auth.protect()` — unauthenticated users are redirected to sign-in.

### Component refactoring
- **`HomepageShell`** — Extracted shared homepage rendering component used by both `/` (published) and `/preview` (draft). Accepts `settings` prop and optional `banner` slot.
- **`PreviewBanner`** — Floating amber banner at the bottom of preview pages showing "Preview Mode" status with draft indicator and "Exit Preview" link.
- **Homepage (`/`)** now fetches published settings from Convex (`siteSettings.getPublished`) and conditionally renders the pricing section based on `priceTabEnabled` flag.

### Admin UI
- Added "Preview Site" button to the settings editor that opens the preview page in a new tab.

## Security

| Concern | Mitigation |
|---------|-----------|
| Anonymous draft access | Middleware requires Clerk session; Convex query returns `null` for non-owners |
| CDN caching of drafts | `force-dynamic` layout prevents edge caching |
| Search engine indexing | `noindex, nofollow` meta on preview layout |
| Referrer leakage | `no-referrer` meta tag on preview layout |

## Testing

- Lint passes (`bun run lint` — no warnings or errors)
- Production build succeeds (`bun run build` — `/preview` correctly marked as dynamic)
- Homepage loads correctly at `/`:

[Homepage hero section](https://cursor.com/agents/bc-badca8a7-053d-49f4-b759-a834e0967d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)

- Homepage pricing section renders based on CMS settings:

[Homepage services and pricing section](https://cursor.com/agents/bc-badca8a7-053d-49f4-b759-a834e0967d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_services_pricing.webp)

- `/preview` redirects unauthenticated users to Clerk sign-in:

[Preview page auth required](https://cursor.com/agents/bc-badca8a7-053d-49f4-b759-a834e0967d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_auth_required.webp)

- `curl` verification: anonymous requests to `/preview` return 404 (Clerk's protected rewrite) with zero draft content in response body
- `curl` verification: public homepage contains no draft data (`draftSnapshot`, `hasDraftChanges`, etc.)

## Acceptance criteria

- [x] Owner toggling preview sees draft content on homepage and key sections
- [x] Logged-out user never sees draft (curl and browser test confirmed)
- [x] Preview routes use `dynamic = force-dynamic` to avoid CDN caching draft

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-77](https://linear.app/only-football-fans/issue/INF-77/lls-preview-mode-for-marketing-site-owner-only)

<div><a href="https://cursor.com/agents/bc-badca8a7-053d-49f4-b759-a834e0967d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-badca8a7-053d-49f4-b759-a834e0967d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

