### PR TITLE
feat(admin): CMS draft indicators, publish, preview (INF-79)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as cms from "../cms.js";
+import type * as cmsPublishHelpers from "../cmsPublishHelpers.js";
 import type * as cmsShared from "../cmsShared.js";
 import type * as errors from "../errors.js";
 import type * as inquiries from "../inquiries.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
   cms: typeof cms;
+  cmsPublishHelpers: typeof cmsPublishHelpers;
   cmsShared: typeof cmsShared;
   errors: typeof errors;
   inquiries: typeof inquiries;

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -7,23 +7,15 @@ import {
   useQuery,
   useMutation,
 } from "convex/react";
+import { useUser } from "@clerk/nextjs";
 import { api } from "../../../../convex/_generated/api";
 import { useCallback, useState } from "react";
 import { Effect, pipe } from "effect";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import Link from "next/link";
+import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 
 type SettingsContent = {
   flags: { priceTabEnabled: boolean };
@@ -54,6 +46,7 @@ export function SettingsEditor() {
 }
 
 function SettingsForm() {
+  const { user } = useUser();
   const section = useQuery(api.cms.getSection, { section: "settings" });
   const saveDraft = useMutation(api.cms.saveDraft);
   const publish = useMutation(api.cms.publishSection);
@@ -61,7 +54,7 @@ function SettingsForm() {
 
   const [localDraft, setLocalDraft] = useState<SettingsContent | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
-  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const [inlineError, setInlineError] = useState<string | null>(null);
 
   const source: SettingsContent | undefined =
     localDraft ??
@@ -72,6 +65,7 @@ function SettingsForm() {
   const updateField = useCallback(
     <K extends keyof SettingsContent>(key: K, value: SettingsContent[K]) => {
       if (!source) return;
+      setInlineError(null);
       setLocalDraft({ ...source, [key]: value });
     },
     [source],
@@ -79,8 +73,11 @@ function SettingsForm() {
 
   const runAction = useCallback(
     async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
+      setInlineError(null);
       setBusy(label);
-      const outcome = await runAdminEffect(program);
+      const outcome = await runAdminEffect(program, {
+        onErrorMessage: setInlineError,
+      });
       if (outcome !== undefined) {
         setLocalDraft(null);
       }
@@ -92,24 +89,26 @@ function SettingsForm() {
 
   const hasDraftOnServer = section?.hasDraftChanges ?? false;
 
-  const confirmDiscard = useCallback(async () => {
+  const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
+    setInlineError(null);
     if (hasDraftOnServer) {
       setBusy("Discarding…");
       const outcome = await runAdminEffect(
         convexMutationEffect(() => discard({ section: "settings" })),
+        { onErrorMessage: setInlineError },
       );
       setBusy(null);
       if (outcome === undefined) {
-        return;
+        return false;
       }
     }
     setLocalDraft(null);
-    setDiscardDialogOpen(false);
     toast.success(
       hasDraftOnServer
         ? "Draft discarded. The editor now matches the published site."
         : "Unsaved changes discarded.",
     );
+    return true;
   }, [discard, hasDraftOnServer]);
 
   if (section === undefined) {
@@ -123,6 +122,9 @@ function SettingsForm() {
   }
 
   const hasLocalEdits = localDraft !== null;
+
+  const publishedByLabel =
+    section.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
 
   return (
     <div className="space-y-8">
@@ -180,133 +182,51 @@ function SettingsForm() {
         </label>
       </fieldset>
 
-      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-        {hasDraftOnServer && (
-          <span className="rounded bg-primary/15 px-2 py-0.5 text-primary">
-            Unpublished draft on server
-          </span>
-        )}
-        {hasLocalEdits && (
-          <span className="rounded bg-muted px-2 py-0.5 text-muted-foreground">
-            Unsaved local edits
-          </span>
-        )}
-        {section.publishedAt && (
-          <span>
-            Last published{" "}
-            {new Date(section.publishedAt).toLocaleString()}
-          </span>
-        )}
-      </div>
-
-      <div className="flex flex-wrap gap-3">
-        <button
-          disabled={!hasLocalEdits || busy !== null}
-          onClick={() =>
-            runAction(
-              "Saving…",
-              convexMutationEffect(() =>
-                saveDraft({
-                  section: "settings",
-                  content: {
-                    flags: source.flags,
-                    metadata: source.metadata,
-                  },
-                }),
-              ),
-            )
-          }
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {busy === "Saving…" ? "Saving…" : "Save Draft"}
-        </button>
-
-        <button
-          disabled={(!hasDraftOnServer && !hasLocalEdits) || busy !== null}
-          onClick={() => {
-            const publishOnce = convexMutationEffect(() =>
-              publish({ section: "settings" }),
-            );
-            const program = hasLocalEdits
-              ? pipe(
-                  convexMutationEffect(() =>
-                    saveDraft({
-                      section: "settings",
-                      content: {
-                        flags: source.flags,
-                        metadata: source.metadata,
-                      },
-                    }),
-                  ),
-                  Effect.flatMap(() => publishOnce),
-                )
-              : publishOnce;
-            return runAction("Publishing…", program);
-          }}
-          className="rounded-md border border-border bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition hover:bg-secondary/80 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {busy === "Publishing…" ? "Publishing…" : "Publish"}
-        </button>
-
-        <button
-          type="button"
-          disabled={(!hasDraftOnServer && !hasLocalEdits) || busy !== null}
-          onClick={() => setDiscardDialogOpen(true)}
-          className="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          Discard draft
-        </button>
-
-        <Link
-          href="/preview"
-          target="_blank"
-          className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-600 transition hover:bg-amber-500/20 dark:text-amber-400"
-        >
-          Preview Site ↗
-        </Link>
-      </div>
-
-      <AlertDialog
-        open={discardDialogOpen}
-        onOpenChange={(open, eventDetails) => {
-          if (!open && busy === "Discarding…") {
-            eventDetails.cancel();
-            return;
-          }
-          setDiscardDialogOpen(open);
+      <CmsPublishToolbar
+        section="settings"
+        sectionLabel="site settings"
+        hasDraftOnServer={hasDraftOnServer}
+        hasLocalEdits={hasLocalEdits}
+        publishedAt={section.publishedAt ?? null}
+        publishedByLabel={publishedByLabel}
+        busy={busy}
+        inlineError={inlineError}
+        onSaveDraft={() =>
+          void runAction(
+            "Saving…",
+            convexMutationEffect(() =>
+              saveDraft({
+                section: "settings",
+                content: {
+                  flags: source.flags,
+                  metadata: source.metadata,
+                },
+              }),
+            ),
+          )
+        }
+        onPublish={() => {
+          const publishOnce = convexMutationEffect(() =>
+            publish({ section: "settings" }),
+          );
+          const program = hasLocalEdits
+            ? pipe(
+                convexMutationEffect(() =>
+                  saveDraft({
+                    section: "settings",
+                    content: {
+                      flags: source.flags,
+                      metadata: source.metadata,
+                    },
+                  }),
+                ),
+                Effect.flatMap(() => publishOnce),
+              )
+            : publishOnce;
+          return void runAction("Publishing…", program);
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Discard draft changes?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {hasDraftOnServer
-                ? "This removes unpublished edits from the server and resets the editor to the last published settings. The live site is not changed."
-                : "This clears unsaved edits in your browser and shows the last published settings again."}
-              {!section.publishedAt && hasDraftOnServer ? (
-                <>
-                  {" "}
-                  Nothing has been published yet, so you will see the same default
-                  baseline stored for the site until you publish.
-                </>
-              ) : null}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={busy === "Discarding…"}>
-              Cancel
-            </AlertDialogCancel>
-            <button
-              type="button"
-              disabled={busy === "Discarding…"}
-              onClick={() => void confirmDiscard()}
-              className="inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-transparent bg-destructive/10 px-2.5 text-sm font-medium text-destructive outline-none transition hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-3 focus-visible:ring-destructive/20 disabled:pointer-events-none disabled:opacity-50 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40"
-            >
-              {busy === "Discarding…" ? "Discarding…" : "Discard"}
-            </button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onDiscardConfirm={handleDiscardConfirm}
+      />
     </div>
   );
 }

--- a/src/components/admin/cms-publish-toolbar.tsx
+++ b/src/components/admin/cms-publish-toolbar.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { DraftStatusBadge } from "@/components/admin/draft-status-badge";
+import { DiscardDraftDialog } from "@/components/admin/discard-draft-dialog";
+
+export interface CmsPublishToolbarProps {
+  /** CMS section key (e.g. `settings`) — used for context in labels. */
+  readonly section: string;
+  /** Human label for tooltips (e.g. “Site settings”). */
+  readonly sectionLabel: string;
+  readonly hasDraftOnServer: boolean;
+  readonly hasLocalEdits: boolean;
+  readonly publishedAt: number | null;
+  readonly publishedByLabel?: string;
+  readonly busy: string | null;
+  readonly onSaveDraft: () => void;
+  readonly onPublish: () => void;
+  /**
+   * Return `true` when the discard dialog should close (success).
+   * Return `false` when the operation failed (e.g. toast already shown).
+   */
+  readonly onDiscardConfirm: () => Promise<boolean>;
+  readonly previewHref?: string;
+  /** Optional inline error below actions (toast still recommended). */
+  readonly inlineError?: string | null;
+}
+
+const actionButtonClass =
+  "w-full min-w-0 justify-center sm:w-auto sm:min-w-[9rem]";
+
+/**
+ * Shared draft/publish actions and status for CMS admin sections.
+ */
+export function CmsPublishToolbar({
+  section,
+  sectionLabel,
+  hasDraftOnServer,
+  hasLocalEdits,
+  publishedAt,
+  publishedByLabel,
+  busy,
+  onSaveDraft,
+  onPublish,
+  onDiscardConfirm,
+  previewHref = "/preview",
+  inlineError,
+}: CmsPublishToolbarProps) {
+  const [discardOpen, setDiscardOpen] = useState(false);
+
+  const handleDiscardConfirm = useCallback(async () => {
+    const ok = await onDiscardConfirm();
+    if (ok) {
+      setDiscardOpen(false);
+    }
+  }, [onDiscardConfirm]);
+
+  const hasPublished = publishedAt !== null;
+  const isBusy = busy !== null;
+
+  return (
+    <div className="space-y-4" data-cms-section={section}>
+      <DraftStatusBadge
+        hasDraftOnServer={hasDraftOnServer}
+        hasLocalEdits={hasLocalEdits}
+        publishedAt={publishedAt}
+        publishedByLabel={publishedByLabel}
+      />
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-3">
+        <Tooltip>
+          <TooltipTrigger
+            delay={400}
+            render={
+              <Button
+                type="button"
+                variant="default"
+                className={actionButtonClass}
+                disabled={(!hasDraftOnServer && !hasLocalEdits) || isBusy}
+                onClick={() => onPublish()}
+              >
+                {busy === "Publishing…" ? "Publishing…" : "Publish"}
+              </Button>
+            }
+          />
+          <TooltipContent className="max-w-xs">
+            Push the current draft live for {sectionLabel}. Unsaved edits are
+            saved first.
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            delay={400}
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                className={actionButtonClass}
+                disabled={!hasLocalEdits || isBusy}
+                onClick={() => onSaveDraft()}
+              >
+                {busy === "Saving…" ? "Saving…" : "Save draft"}
+              </Button>
+            }
+          />
+          <TooltipContent className="max-w-xs">
+            Store changes on the server without updating the live site.
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            delay={400}
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                className={cn(actionButtonClass, "border border-border")}
+                disabled={(!hasDraftOnServer && !hasLocalEdits) || isBusy}
+                onClick={() => setDiscardOpen(true)}
+              >
+                Discard
+              </Button>
+            }
+          />
+          <TooltipContent className="max-w-xs">
+            Drop unpublished edits and match the last published version.
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            delay={400}
+            render={
+              <Link
+                href={previewHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "default" }),
+                  actionButtonClass,
+                  "inline-flex items-center gap-1.5 border-amber-500/30 bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 dark:text-amber-300",
+                )}
+              >
+                Preview site
+                <ExternalLink className="size-3.5 shrink-0 opacity-80" aria-hidden />
+              </Link>
+            }
+          />
+          <TooltipContent className="max-w-xs">
+            Open the marketing site in a new tab with preview content (signed in).
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {inlineError ? (
+        <p
+          role="alert"
+          className="text-sm text-destructive"
+        >
+          {inlineError}
+        </p>
+      ) : null}
+
+      <DiscardDraftDialog
+        open={discardOpen}
+        onOpenChange={setDiscardOpen}
+        hasDraftOnServer={hasDraftOnServer}
+        hasPublished={hasPublished}
+        busy={busy === "Discarding…"}
+        onConfirm={() => void handleDiscardConfirm()}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/discard-draft-dialog.tsx
+++ b/src/components/admin/discard-draft-dialog.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+export interface DiscardDraftDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly hasDraftOnServer: boolean;
+  readonly hasPublished: boolean;
+  readonly busy: boolean;
+  readonly onConfirm: () => void;
+}
+
+/**
+ * Confirms discarding local and/or server draft CMS edits without affecting the live site.
+ */
+export function DiscardDraftDialog({
+  open,
+  onOpenChange,
+  hasDraftOnServer,
+  hasPublished,
+  busy,
+  onConfirm,
+}: DiscardDraftDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen, eventDetails) => {
+        if (!nextOpen && busy) {
+          eventDetails.cancel();
+          return;
+        }
+        onOpenChange(nextOpen);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard draft changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {hasDraftOnServer
+              ? "This removes unpublished edits from the server and resets the editor to the last published version. The live site is not changed."
+              : "This clears unsaved edits in your browser and shows the last published version again."}
+            {!hasPublished && hasDraftOnServer ? (
+              <>
+                {" "}
+                Nothing has been published yet, so you will see the same default
+                baseline stored for the site until you publish.
+              </>
+            ) : null}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={busy}
+            onClick={() => onConfirm()}
+          >
+            {busy ? "Discarding…" : "Discard"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/admin/draft-status-badge.tsx
+++ b/src/components/admin/draft-status-badge.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export interface DraftStatusBadgeProps {
+  readonly hasDraftOnServer: boolean;
+  readonly hasLocalEdits: boolean;
+  readonly publishedAt: number | null;
+  /** Short label for who published (e.g. “You”) when known. */
+  readonly publishedByLabel?: string;
+}
+
+/**
+ * Draft vs published indicators for CMS sections: unpublished changes, local edits,
+ * and last published time with an optional “by” line.
+ */
+export function DraftStatusBadge({
+  hasDraftOnServer,
+  hasLocalEdits,
+  publishedAt,
+  publishedByLabel,
+}: DraftStatusBadgeProps) {
+  const fullPublished =
+    publishedAt !== null
+      ? new Date(publishedAt).toLocaleString(undefined, {
+          dateStyle: "full",
+          timeStyle: "short",
+        })
+      : null;
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      {hasDraftOnServer && (
+        <Badge variant="draft">Unpublished changes</Badge>
+      )}
+      {hasLocalEdits && (
+        <Badge variant="muted">Unsaved local edits</Badge>
+      )}
+      {publishedAt !== null && (
+        <Tooltip>
+          <TooltipTrigger
+            type="button"
+            className="inline-flex max-w-full min-w-0 cursor-default border-0 bg-transparent p-0 text-left font-normal text-inherit underline-offset-2 hover:underline"
+          >
+            <span className="min-w-0 truncate text-muted-foreground">
+              Last published{" "}
+              {new Date(publishedAt).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+              {publishedByLabel ? (
+                <>
+                  {" "}
+                  <span className="text-foreground/80">· {publishedByLabel}</span>
+                </>
+              ) : null}
+            </span>
+          </TooltipTrigger>
+          {fullPublished !== null && (
+            <TooltipContent side="top" align="start" className="max-w-sm">
+              {fullPublished}
+              {publishedByLabel ? (
+                <>
+                  <br />
+                  <span className="opacity-90">{publishedByLabel}</span>
+                </>
+              ) : null}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&_svg]:pointer-events-none [&_svg]:size-3 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline: "text-foreground",
+        draft:
+          "border-transparent bg-primary/15 text-primary hover:bg-primary/20",
+        muted:
+          "border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/lib/admin-run-effect.ts
+++ b/src/lib/admin-run-effect.ts
@@ -5,15 +5,23 @@ import {
   cmsErrorToastMessage,
 } from "@/lib/effect-errors";
 
+export type RunAdminEffectOptions = {
+  /** Optional inline error (e.g. below a form) in addition to the toast. */
+  readonly onErrorMessage?: (message: string) => void;
+};
+
 /**
  * Run an admin `Effect` to completion: success returns `A`, failure shows sonner toast.
  */
 export async function runAdminEffect<A, E extends CmsAppError>(
   effect: Effect.Effect<A, E, never>,
+  options?: RunAdminEffectOptions,
 ): Promise<A | undefined> {
   const result = await pipe(effect, Effect.either, Effect.runPromise);
   if (Either.isLeft(result)) {
-    toast.error(cmsErrorToastMessage(result.left));
+    const msg = cmsErrorToastMessage(result.left);
+    toast.error(msg);
+    options?.onErrorMessage?.(msg);
     return undefined;
   }
   return result.right;


### PR DESCRIPTION
## Summary

Shared CMS toolbar for draft/publish/preview across admin: `DraftStatusBadge`, `DiscardDraftDialog`, and `CmsPublishToolbar` (shadcn Button, Badge, Tooltip). Refactors the settings editor to use it and extends `runAdminEffect` with optional inline error messaging alongside Sonner toasts.

## Ticket

INF-79

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI refactoring and shared-component extraction; behavior changes are limited to admin publishing controls and optional inline error display.
> 
> **Overview**
> Adds a reusable admin CMS action bar (`CmsPublishToolbar`) with draft status indicators (`DraftStatusBadge`), a standardized discard confirmation modal (`DiscardDraftDialog`), and a new `Badge` UI component to support consistent draft/publish/preview workflows.
> 
> Refactors the settings editor to use the shared toolbar, including showing “published by” as "You" via Clerk user ID matching, and adds per-form inline error display by extending `runAdminEffect` to optionally surface toast error messages in the UI. Also updates the generated Convex API typings to include `cmsPublishHelpers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a991f48103badb26448c7e36641834ebc37be2e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->