### PR TITLE
INF-80: CMS unauthorized handling + effect error tests

### DIFF
--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -8,6 +8,9 @@ export const cmsConvexErrorValidator = v.union(
   v.object({
     code: v.literal("UNAUTHORIZED"),
     message: v.string(),
+    kind: v.optional(
+      v.union(v.literal("sign_in_required"), v.literal("forbidden")),
+    ),
   }),
   v.object({
     code: v.literal("VALIDATION_ERROR"),
@@ -46,10 +49,14 @@ export const cmsConvexErrorValidator = v.union(
 
 export type CmsConvexError = Infer<typeof cmsConvexErrorValidator>;
 
-export function cmsUnauthorized(message: string): never {
+export function cmsUnauthorized(
+  message: string,
+  kind?: "sign_in_required" | "forbidden",
+): never {
   throw new ConvexError<CmsConvexError>({
     code: "UNAUTHORIZED",
     message,
+    ...(kind !== undefined ? { kind } : {}),
   });
 }
 

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -19,7 +19,7 @@ function parseCmsOwnerTokenIdentifiers(): string[] | null {
 export async function requireAuthenticatedIdentity(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (identity === null) {
-    cmsUnauthorized("Sign in required to access the CMS.");
+    cmsUnauthorized("Sign in required to access the CMS.", "sign_in_required");
   }
   return {
     identity,
@@ -40,7 +40,10 @@ export async function requireCmsOwner(ctx: QueryCtx | MutationCtx) {
     return base;
   }
   if (!allowlist.includes(base.identity.tokenIdentifier)) {
-    cmsUnauthorized("You do not have permission to perform this action.");
+    cmsUnauthorized(
+      "You do not have permission to perform this action.",
+      "forbidden",
+    );
   }
   return base;
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "bun test",
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy"
   },

--- a/src/lib/admin-run-effect.ts
+++ b/src/lib/admin-run-effect.ts
@@ -25,7 +25,9 @@ export async function runAdminEffect<A, E extends CmsAppError>(
       err.kind === "sign_in_required" &&
       typeof window !== "undefined"
     ) {
-      window.location.assign("/sign-in");
+      window.location.assign(
+        `/sign-in?redirect_url=${encodeURIComponent(window.location.href)}`,
+      );
       return undefined;
     }
     const msg = cmsErrorToastMessage(err);

--- a/src/lib/admin-run-effect.ts
+++ b/src/lib/admin-run-effect.ts
@@ -19,7 +19,16 @@ export async function runAdminEffect<A, E extends CmsAppError>(
 ): Promise<A | undefined> {
   const result = await pipe(effect, Effect.either, Effect.runPromise);
   if (Either.isLeft(result)) {
-    const msg = cmsErrorToastMessage(result.left);
+    const err = result.left;
+    if (
+      err._tag === "Unauthorized" &&
+      err.kind === "sign_in_required" &&
+      typeof window !== "undefined"
+    ) {
+      window.location.assign("/sign-in");
+      return undefined;
+    }
+    const msg = cmsErrorToastMessage(err);
     toast.error(msg);
     options?.onErrorMessage?.(msg);
     return undefined;

--- a/src/lib/effect-errors.test.ts
+++ b/src/lib/effect-errors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { ConvexError } from "convex/values";
+import {
+  cmsErrorToastMessage,
+  fromConvexCmsError,
+} from "@/lib/effect-errors";
+
+describe("fromConvexCmsError", () => {
+  test("maps UNAUTHORIZED with explicit kind sign_in_required", () => {
+    const err = fromConvexCmsError(
+      new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Sign in required to access the CMS.",
+        kind: "sign_in_required",
+      }),
+    );
+    expect(err._tag).toBe("Unauthorized");
+    if (err._tag === "Unauthorized") {
+      expect(err.kind).toBe("sign_in_required");
+    }
+  });
+
+  test("maps UNAUTHORIZED with explicit kind forbidden", () => {
+    const err = fromConvexCmsError(
+      new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "You do not have permission to perform this action.",
+        kind: "forbidden",
+      }),
+    );
+    expect(err._tag).toBe("Unauthorized");
+    if (err._tag === "Unauthorized") {
+      expect(err.kind).toBe("forbidden");
+    }
+  });
+
+  test("infers forbidden from message when kind omitted (legacy payloads)", () => {
+    const err = fromConvexCmsError(
+      new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "You do not have permission to perform this action.",
+      }),
+    );
+    expect(err._tag).toBe("Unauthorized");
+    if (err._tag === "Unauthorized") {
+      expect(err.kind).toBe("forbidden");
+    }
+  });
+});
+
+describe("cmsErrorToastMessage", () => {
+  test("does not surface raw server strings for Unauthorized", () => {
+    const forbidden = fromConvexCmsError(
+      new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "You do not have permission to perform this action.",
+        kind: "forbidden",
+      }),
+    );
+    expect(cmsErrorToastMessage(forbidden)).toBe(
+      "You are not allowed to do this.",
+    );
+
+    const signIn = fromConvexCmsError(
+      new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Sign in required to access the CMS.",
+        kind: "sign_in_required",
+      }),
+    );
+    expect(cmsErrorToastMessage(signIn)).toBe("Please sign in to continue.");
+  });
+});

--- a/src/lib/effect-errors.ts
+++ b/src/lib/effect-errors.ts
@@ -7,7 +7,11 @@ import { ConvexError } from "convex/values";
 
 /** Convex `ConvexError` payload shape (mirrors `convex/errors.ts`). */
 export type CmsConvexErrorPayload =
-  | { readonly code: "UNAUTHORIZED"; readonly message: string }
+  | {
+      readonly code: "UNAUTHORIZED";
+      readonly message: string;
+      readonly kind?: "sign_in_required" | "forbidden";
+    }
   | {
       readonly code: "VALIDATION_ERROR";
       readonly message: string;
@@ -37,6 +41,7 @@ export type CmsConvexErrorPayload =
 
 export class Unauthorized extends Data.TaggedError("Unauthorized")<{
   readonly message: string;
+  readonly kind?: "sign_in_required" | "forbidden";
 }> {}
 
 export class ValidationError extends Data.TaggedError("ValidationError")<{
@@ -83,7 +88,11 @@ function isCmsConvexErrorPayload(
   if (typeof value["message"] !== "string") return false;
   switch (code) {
     case "UNAUTHORIZED":
-      return true;
+      return (
+        value["kind"] === undefined ||
+        value["kind"] === "sign_in_required" ||
+        value["kind"] === "forbidden"
+      );
     case "VALIDATION_ERROR":
       return (
         value["field"] === undefined || typeof value["field"] === "string"
@@ -121,8 +130,14 @@ export function fromConvexCmsError(cause: unknown): CmsAppError {
     const data: unknown = cause.data;
     if (isCmsConvexErrorPayload(data)) {
       switch (data.code) {
-        case "UNAUTHORIZED":
-          return new Unauthorized({ message: data.message });
+        case "UNAUTHORIZED": {
+          const kind: "sign_in_required" | "forbidden" =
+            data.kind ??
+            (/permission|not allowed/i.test(data.message)
+              ? "forbidden"
+              : "sign_in_required");
+          return new Unauthorized({ message: data.message, kind });
+        }
         case "VALIDATION_ERROR":
           return new ValidationError({
             message: data.message,
@@ -169,7 +184,9 @@ export function convexMutationEffect<A>(
 export function cmsErrorToastMessage(err: CmsAppError): string {
   switch (err._tag) {
     case "Unauthorized":
-      return err.message;
+      return err.kind === "forbidden"
+        ? "You are not allowed to do this."
+        : "Please sign in to continue.";
     case "ValidationError":
       return err.field !== undefined
         ? `${err.message} (${err.field})`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the remaining **INF-80** acceptance items for the only live CMS admin mutation surface today (`SettingsEditor` already uses `runAdminEffect` + `convexMutationEffect`).

## Changes

- **Convex `UNAUTHORIZED` payload:** optional `kind` (`sign_in_required` | `forbidden`) so the client does not need to guess intent from free-form server messages.
- **`requireAuthenticatedIdentity` / `requireCmsOwner`:** pass the appropriate `kind` when throwing `cmsUnauthorized`.
- **`fromConvexCmsError` / `Unauthorized`:** carry `kind`; when `kind` is absent, infer `forbidden` from legacy messages that mention permission / not allowed (deployments not yet on the new payload).
- **`cmsErrorToastMessage`:** fixed user-facing strings for unauthorized cases — **no raw Convex message in toasts** for these errors.
- **`runAdminEffect`:** for `sign_in_required`, **redirect to `/sign-in`** (no error toast, avoids flashing a toast before navigation).
- **`package.json`:** `bun run test` → `bun test`.
- **Tests:** `src/lib/effect-errors.test.ts` covers mapping + toast message sanitization.

## Notes

Other admin routes (pricing, gear, photos, videos, audio, about) are still “coming soon” placeholders with **no mutations**; settings remains the single mutation path until those editors land.

## How to verify

- `bun run test`
- `bun run lint`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-80](https://linear.app/only-football-fans/issue/INF-80/lls-cms-mutations-effect-pipelines-user-facing-errors)

<div><a href="https://cursor.com/agents/bc-4dfdfafb-930d-42fc-9304-6349418230d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dfdfafb-930d-42fc-9304-6349418230d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

