### PR TITLE
feat(convex): Convex errors to Sentry with safe context (INF-82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ ADMIN_ENABLED=
 CMS_OWNER_TOKEN_IDENTIFIERS=
 
 # Sentry — browser events use NEXT_PUBLIC_SENTRY_DSN if set, otherwise SENTRY_DSN is exposed
-# as a safe public DSN at build time.
+# as a safe public DSN at build time. Also set SENTRY_DSN on each Convex deployment if you
+# use convex/sentryNodeReport (see README → Convex backend).
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
 # Optional override for non-Vercel environments (defaults to VERCEL_ENV or NODE_ENV).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ For a quick non-production verification, hit these routes and confirm the return
 - `/api/dev/sentry/node`
 - `/api/dev/sentry/edge`
 
+### Convex backend
+
+Uncaught and selected handled errors can be forwarded from Convex using an internal Node action (`convex/sentryNodeReport.ts`) that calls `@sentry/node` with tags `convex_function`, `convex_deployment` (derived from `CONVEX_CLOUD_URL`), and a SHA-256 prefix of the Clerk `tokenIdentifier` as the Sentry user id. Set `SENTRY_DSN` on the Convex deployment (dashboard → Deployment Settings → Environment Variables). Optional: `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`.
+
+To verify from a dev deployment, set `CONVEX_SENTRY_TEST_MUTATION=true` and run the `observability:devForceSentryError` mutation (Convex dashboard or `bunx convex run observability:devForceSentryError`). The event should include tag `convex_function` = `observability:devForceSentryError`.
+
+**Built-in alternative:** Convex Pro can send exceptions to Sentry automatically from the dashboard (see [Exception reporting](https://docs.convex.dev/production/integrations/exception-reporting)); that path does not run the full Sentry SDK in your function bundle. This repository’s Node action is a code-level supplement with explicit context control.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ For a quick non-production verification, hit these routes and confirm the return
 
 ### Convex backend
 
-Uncaught and selected handled errors can be forwarded from Convex using an internal Node action (`convex/sentryNodeReport.ts`) that calls `@sentry/node` with tags `convex_function`, `convex_deployment` (derived from `CONVEX_CLOUD_URL`), and a SHA-256 prefix of the Clerk `tokenIdentifier` as the Sentry user id. Set `SENTRY_DSN` on the Convex deployment (dashboard → Deployment Settings → Environment Variables). Optional: `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`.
-
-To verify from a dev deployment, set `CONVEX_SENTRY_TEST_MUTATION=true` and run the `observability:devForceSentryError` mutation (Convex dashboard or `bunx convex run observability:devForceSentryError`). The event should include tag `convex_function` = `observability:devForceSentryError`.
+Uncaught and selected handled errors can be forwarded from Convex using an internal Node action (`convex/sentryNodeReport.ts`) that calls `@sentry/node` with tags `convex_function`, `convex_deployment` (derived from `CONVEX_CLOUD_URL`), and a SHA-256 prefix of the Clerk `tokenIdentifier` as the Sentry user id. Set `SENTRY_DSN` on the Convex deployment (dashboard → Deployment Settings → Environment Variables). Optional: `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`. From mutations, call `scheduleConvexSentryException` from `convex/lib/sentryConvex.ts` (or `internal.observability.reportHandledFailure` for handled-only paths).
 
 **Built-in alternative:** Convex Pro can send exceptions to Sentry automatically from the dashboard (see [Exception reporting](https://docs.convex.dev/production/integrations/exception-reporting)); that path does not run the full Sentry SDK in your function bundle. This repository’s Node action is a code-level supplement with explicit context control.
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@clerk/themes": "^2.4.57",
         "@clerk/ui": "^1.5.1",
         "@sentry/nextjs": "^10.48.0",
+        "@sentry/node": "10.48.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "class-variance-authority": "^0.7.1",

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,8 +16,10 @@ import type * as cmsShared from "../cmsShared.js";
 import type * as errors from "../errors.js";
 import type * as inquiries from "../inquiries.js";
 import type * as lib_auth from "../lib/auth.js";
+import type * as observability from "../observability.js";
 import type * as public_ from "../public.js";
 import type * as seed from "../seed.js";
+import type * as sentryNodeReport from "../sentryNodeReport.js";
 import type * as siteSettingsPreviewDraft from "../siteSettingsPreviewDraft.js";
 
 import type {
@@ -35,8 +37,10 @@ declare const fullApi: ApiFromModules<{
   errors: typeof errors;
   inquiries: typeof inquiries;
   "lib/auth": typeof lib_auth;
+  observability: typeof observability;
   public: typeof public_;
   seed: typeof seed;
+  sentryNodeReport: typeof sentryNodeReport;
   siteSettingsPreviewDraft: typeof siteSettingsPreviewDraft;
 }>;
 

--- a/convex/lib/sentryConvex.ts
+++ b/convex/lib/sentryConvex.ts
@@ -44,7 +44,11 @@ function normalizeUnknownError(error: unknown): { message: string; stack?: strin
     return { message: error };
   }
   try {
-    return { message: JSON.stringify(error) };
+    const serialized = JSON.stringify(error);
+    if (typeof serialized === "string") {
+      return { message: serialized };
+    }
+    return { message: String(error) };
   } catch {
     return { message: String(error) };
   }

--- a/convex/lib/sentryConvex.ts
+++ b/convex/lib/sentryConvex.ts
@@ -1,0 +1,101 @@
+import { internal } from "../_generated/api";
+import type { MutationCtx } from "../_generated/server";
+
+const SAMPLE_RATE = 1;
+
+const RATE_LIMIT_MS = 10_000;
+const lastSentAtByKey = new Map<string, number>();
+
+function deploymentKeyFromCloudUrl(): string {
+  const url = process.env.CONVEX_CLOUD_URL;
+  if (!url) return "unknown-deployment";
+  try {
+    const host = new URL(url).hostname;
+    const match = /^([^.]+)\.convex\.cloud$/i.exec(host);
+    return match?.[1] ?? host;
+  } catch {
+    return "unknown-deployment";
+  }
+}
+
+export function convexDeploymentName(): string {
+  return deploymentKeyFromCloudUrl();
+}
+
+export async function sha256Short(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(digest);
+  let hex = "";
+  for (let i = 0; i < 8; i++) {
+    hex += bytes[i]!.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function normalizeUnknownError(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      message: error.message || "Error",
+      stack: truncateStack(error.stack),
+    };
+  }
+  if (typeof error === "string") {
+    return { message: error };
+  }
+  try {
+    return { message: JSON.stringify(error) };
+  } catch {
+    return { message: String(error) };
+  }
+}
+
+function truncateStack(stack: string | undefined): string | undefined {
+  if (!stack) return undefined;
+  const max = 12_000;
+  return stack.length <= max ? stack : `${stack.slice(0, max)}…`;
+}
+
+function shouldSendSampled(): boolean {
+  return Math.random() < SAMPLE_RATE;
+}
+
+function shouldSendRateLimited(key: string): boolean {
+  const now = Date.now();
+  const last = lastSentAtByKey.get(key) ?? 0;
+  if (now - last < RATE_LIMIT_MS) return false;
+  lastSentAtByKey.set(key, now);
+  return true;
+}
+
+export type ConvexSentryReportKind = "unhandled" | "handled";
+
+/**
+ * Queue a Sentry event via an internal Node action. Safe to call from mutations:
+ * only derived identifiers and error text are passed; no JWTs or env secrets.
+ */
+export async function scheduleConvexSentryException(
+  ctx: MutationCtx,
+  options: {
+    functionName: string;
+    error: unknown;
+    kind: ConvexSentryReportKind;
+  },
+): Promise<void> {
+  if (!shouldSendSampled()) return;
+
+  const { message, stack } = normalizeUnknownError(options.error);
+  const rateKey = `${options.functionName}:${message}`;
+  if (!shouldSendRateLimited(rateKey)) return;
+
+  const identity = await ctx.auth.getUserIdentity();
+  const userIdHash = await sha256Short(identity?.tokenIdentifier ?? "anonymous");
+
+  await ctx.scheduler.runAfter(0, internal.sentryNodeReport.captureFromConvex, {
+    functionName: options.functionName,
+    errorMessage: message,
+    errorStack: stack,
+    userIdHash,
+    kind: options.kind,
+  });
+}

--- a/convex/observability.ts
+++ b/convex/observability.ts
@@ -1,35 +1,6 @@
-import { internalMutation, mutation } from "./_generated/server";
+import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { scheduleConvexSentryException } from "./lib/sentryConvex";
-
-/**
- * Enqueues a Sentry report for a synthetic error, then returns (mutation commits so
- * the scheduled action runs). Enable only on trusted dev deployments:
- * Convex dashboard → Deployment Settings → Environment Variables →
- * `CONVEX_SENTRY_TEST_MUTATION` = `true`
- *
- * Run from the Convex dashboard ("Functions" → this mutation) or `bunx convex run`.
- * The event is sent by `internal.sentryNodeReport.captureFromConvex` with tag
- * `convex_function` = `observability:devForceSentryError`.
- */
-export const devForceSentryError = mutation({
-  args: {},
-  handler: async (ctx) => {
-    if (process.env.CONVEX_SENTRY_TEST_MUTATION !== "true") {
-      throw new Error(
-        "devForceSentryError is disabled. Set CONVEX_SENTRY_TEST_MUTATION=true on this deployment to enable.",
-      );
-    }
-
-    const testError = new Error("forced dev sentry test error (convex)");
-
-    await scheduleConvexSentryException(ctx, {
-      functionName: "observability:devForceSentryError",
-      error: testError,
-      kind: "unhandled",
-    });
-  },
-});
 
 /**
  * Optional: report a handled failure from server code without rethrowing.

--- a/convex/observability.ts
+++ b/convex/observability.ts
@@ -3,7 +3,8 @@ import { v } from "convex/values";
 import { scheduleConvexSentryException } from "./lib/sentryConvex";
 
 /**
- * Throws after enqueueing a Sentry report. Enable only on trusted dev deployments:
+ * Enqueues a Sentry report for a synthetic error, then returns (mutation commits so
+ * the scheduled action runs). Enable only on trusted dev deployments:
  * Convex dashboard → Deployment Settings → Environment Variables →
  * `CONVEX_SENTRY_TEST_MUTATION` = `true`
  *
@@ -27,8 +28,6 @@ export const devForceSentryError = mutation({
       error: testError,
       kind: "unhandled",
     });
-
-    throw testError;
   },
 });
 

--- a/convex/observability.ts
+++ b/convex/observability.ts
@@ -1,0 +1,55 @@
+import { internalMutation, mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { scheduleConvexSentryException } from "./lib/sentryConvex";
+
+/**
+ * Throws after enqueueing a Sentry report. Enable only on trusted dev deployments:
+ * Convex dashboard → Deployment Settings → Environment Variables →
+ * `CONVEX_SENTRY_TEST_MUTATION` = `true`
+ *
+ * Run from the Convex dashboard ("Functions" → this mutation) or `bunx convex run`.
+ * The event is sent by `internal.sentryNodeReport.captureFromConvex` with tag
+ * `convex_function` = `observability:devForceSentryError`.
+ */
+export const devForceSentryError = mutation({
+  args: {},
+  handler: async (ctx) => {
+    if (process.env.CONVEX_SENTRY_TEST_MUTATION !== "true") {
+      throw new Error(
+        "devForceSentryError is disabled. Set CONVEX_SENTRY_TEST_MUTATION=true on this deployment to enable.",
+      );
+    }
+
+    const testError = new Error("forced dev sentry test error (convex)");
+
+    await scheduleConvexSentryException(ctx, {
+      functionName: "observability:devForceSentryError",
+      error: testError,
+      kind: "unhandled",
+    });
+
+    throw testError;
+  },
+});
+
+/**
+ * Optional: report a handled failure from server code without rethrowing.
+ * Call via `ctx.runMutation(internal.observability.reportHandledFailure, ...)`.
+ */
+export const reportHandledFailure = internalMutation({
+  args: {
+    functionName: v.string(),
+    message: v.string(),
+    stack: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await scheduleConvexSentryException(ctx, {
+      functionName: args.functionName,
+      error: Object.assign(new Error(args.message), {
+        stack: args.stack,
+      }),
+      kind: "handled",
+    });
+    return null;
+  },
+});

--- a/convex/sentryNodeReport.ts
+++ b/convex/sentryNodeReport.ts
@@ -1,0 +1,73 @@
+"use node";
+
+import * as Sentry from "@sentry/node";
+import { internalAction } from "./_generated/server";
+import { v } from "convex/values";
+import { convexDeploymentName } from "./lib/sentryConvex";
+
+let sentryInitialized = false;
+
+function ensureSentry(): boolean {
+  const dsn = process.env.SENTRY_DSN?.trim();
+  if (!dsn) return false;
+
+  if (!sentryInitialized) {
+    Sentry.init({
+      dsn,
+      defaultIntegrations: false,
+      release: process.env.SENTRY_RELEASE?.trim(),
+      environment: process.env.SENTRY_ENVIRONMENT?.trim(),
+      tracesSampleRate: 0,
+      beforeSend(event) {
+        delete event.request;
+        if (event.contexts?.trace) {
+          delete event.contexts.trace;
+        }
+        return event;
+      },
+    });
+    sentryInitialized = true;
+  }
+  return true;
+}
+
+export const captureFromConvex = internalAction({
+  args: {
+    functionName: v.string(),
+    errorMessage: v.string(),
+    errorStack: v.optional(v.string()),
+    userIdHash: v.string(),
+    kind: v.union(v.literal("unhandled"), v.literal("handled")),
+  },
+  handler: async (_ctx, args) => {
+    if (!ensureSentry()) {
+      console.warn(
+        "[sentryNodeReport] SENTRY_DSN is not set; skipping Sentry upload.",
+      );
+      return null;
+    }
+
+    const deploymentName = convexDeploymentName();
+    const err = new Error(args.errorMessage);
+    if (args.errorStack) {
+      err.stack = args.errorStack;
+    }
+
+    Sentry.captureException(err, {
+      user: { id: args.userIdHash },
+      tags: {
+        convex_function: args.functionName,
+        convex_deployment: deploymentName,
+        convex_error_kind: args.kind,
+      },
+      extra: {
+        convex_function: args.functionName,
+        convex_deployment: deploymentName,
+        convex_error_kind: args.kind,
+      },
+    });
+
+    await Sentry.flush(2000);
+    return null;
+  },
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@clerk/themes": "^2.4.57",
     "@clerk/ui": "^1.5.1",
     "@sentry/nextjs": "^10.48.0",
+    "@sentry/node": "10.48.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements optional Convex → Sentry reporting using Convex’s supported **Node** action runtime (`"use node"`) and `@sentry/node`, with explicit ops context and no secrets in event extras.

## Changes

- **`convex/sentryNodeReport.ts`**: internal action `captureFromConvex` initializes Sentry with `defaultIntegrations: false`, strips `request` from `beforeSend`, and sends `captureException` with tags `convex_function`, `convex_deployment`, `convex_error_kind`, and `user.id` = SHA-256 prefix of Clerk `tokenIdentifier` (or anonymous).
- **`convex/lib/sentryConvex.ts`**: `scheduleConvexSentryException` for mutations (scheduler → internal action) so the mutation transaction is not blocked; deployment name derived from `CONVEX_CLOUD_URL`; simple per-key rate limit + sampling hook (currently 100% sample).
- **`convex/observability.ts`**: `reportHandledFailure` internal mutation for optional handled paths only (dev-only force-error mutation removed after verification).
- **Docs**: README section on Convex + link to [Convex exception reporting](https://docs.convex.dev/production/integrations/exception-reporting) (built-in Pro integration vs code-level SDK).
- **Deps**: `@sentry/node@10.48.0` aligned with `@sentry/nextjs`.

## Configuration

On each Convex deployment: set `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`). Use `scheduleConvexSentryException` from mutations for reporting, or `internal.observability.reportHandledFailure` for handled-only reporting.

## Notes

- Events avoid attaching `request` or env blobs; only whitelisted strings/stacks.
- Convex Pro dashboard integration is documented as the platform-native path without bundling the full SDK in queries/mutations.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-82](https://linear.app/only-football-fans/issue/INF-82/lls-convex-errors-sentry-context-no-secrets)

<div><a href="https://cursor.com/agents/bc-07a5a59b-ed9e-412b-83df-7ddce5e39c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a5a59b-ed9e-412b-83df-7ddce5e39c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

