### PR TITLE
feat(sentry): distinguish preview vs prod with tags and scrubbed URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,9 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: sentryEnvironment,
     NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease,
     NEXT_PUBLIC_SENTRY_ENABLED: sentryEnabledPublic,
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? "",
+    NEXT_PUBLIC_VERCEL_URL: process.env.VERCEL_URL ?? "",
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA ?? "",
   },
   images: {
     remotePatterns: [

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import {
+  applyRouteToSentryScope,
+  createSentryInitialScopeUpdater,
   getClientSentryDsn,
   getSentryEnvironment,
   getSentryRelease,
@@ -18,10 +20,28 @@ if (dsn && isSentryEnabled()) {
     release: getSentryRelease(),
     sendDefaultPii: false,
     tracesSampleRate: getTracesSampleRate(),
+    initialScope: createSentryInitialScopeUpdater(),
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
     beforeBreadcrumb: scrubSentryBreadcrumb,
   });
 }
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+export function onRouterTransitionStart(
+  href: string,
+  navigationType: string,
+) {
+  try {
+    const path =
+      typeof window !== "undefined"
+        ? new URL(href, window.location.origin).pathname
+        : undefined;
+    applyRouteToSentryScope(Sentry.getCurrentScope(), path);
+  } catch {
+    applyRouteToSentryScope(
+      Sentry.getCurrentScope(),
+      typeof window !== "undefined" ? window.location.pathname : undefined,
+    );
+  }
+  Sentry.captureRouterTransitionStart(href, navigationType);
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -26,7 +26,10 @@ function isRecord(value: unknown): value is JsonRecord {
 
 /** Vercel preview deployments (distinct from production traffic on the prod domain). */
 export function isPreviewDeployment(): boolean {
-  return readNonEmptyEnv(process.env.VERCEL_ENV) === "preview";
+  const env =
+    readNonEmptyEnv(process.env.VERCEL_ENV) ??
+    readNonEmptyEnv(process.env.NEXT_PUBLIC_VERCEL_ENV);
+  return env === "preview";
 }
 
 export function isPreviewPathname(pathname: string | undefined): boolean {
@@ -253,6 +256,8 @@ function enrichSentryEvent<T extends Event>(event: T): void {
   const section = inferSectionFromPathname(pathname);
   if (section) {
     event.tags.section = section;
+  } else {
+    delete event.tags.section;
   }
 
   const deployment = getDeploymentLabel();
@@ -283,10 +288,6 @@ export function scrubSentryEvent<T extends Event>(event: T): T {
 }
 
 export function scrubSentryBreadcrumb<T extends Breadcrumb>(breadcrumb: T): T {
-  if (typeof breadcrumb.message === "string") {
-    breadcrumb.message = scrubUrlString(breadcrumb.message);
-  }
-
   if (isRecord(breadcrumb.data)) {
     scrubRecord(breadcrumb.data);
   }
@@ -308,14 +309,13 @@ export function createSentryInitialScopeUpdater(): (scope: Scope) => Scope {
 }
 
 /** Sets `preview`, optional `section`, and `deployment_info` from a pathname (client). */
-export function applyRouteToSentryScope(
-  scope: Pick<Scope, "setTag" | "setContext">,
-  pathname: string | undefined,
-): void {
+export function applyRouteToSentryScope(scope: Scope, pathname: string | undefined): void {
   scope.setTag("preview", computePreviewTag(pathname));
   const section = inferSectionFromPathname(pathname);
   if (section) {
     scope.setTag("section", section);
+  } else {
+    delete scope.getScopeData().tags.section;
   }
   scope.setContext("deployment_info", {
     route: pathname ?? "",

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -116,6 +116,21 @@ function scrubUrlString(value: string): string {
   return stripUrlQuery(value);
 }
 
+/** Only scrub `?…` from strings that look like URLs; avoids corrupting plain text (e.g. console crumbs). */
+function shouldStripQueryFromMessage(message: string): boolean {
+  const t = message.trim();
+  if (!t.includes("?")) {
+    return false;
+  }
+  if (/^https?:\/\//i.test(t)) {
+    return true;
+  }
+  if (t.startsWith("/") || t.startsWith("//")) {
+    return true;
+  }
+  return false;
+}
+
 function scrubQueryStringValue(): string {
   return REDACTED;
 }
@@ -288,6 +303,13 @@ export function scrubSentryEvent<T extends Event>(event: T): T {
 }
 
 export function scrubSentryBreadcrumb<T extends Breadcrumb>(breadcrumb: T): T {
+  if (
+    typeof breadcrumb.message === "string" &&
+    shouldStripQueryFromMessage(breadcrumb.message)
+  ) {
+    breadcrumb.message = scrubUrlString(breadcrumb.message);
+  }
+
   if (isRecord(breadcrumb.data)) {
     scrubRecord(breadcrumb.data);
   }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,17 +1,19 @@
+import type { Breadcrumb, Event, Scope } from "@sentry/core";
+
 const REDACTED = "[Filtered]";
 const SENSITIVE_KEY_PATTERN =
   /(authorization|cookie|token|secret|password|clerk|session|request[_-]?body|response[_-]?body)/i;
 
+/**
+ * Safe Sentry attachment policy (tags, contexts, breadcrumbs):
+ * - Tags: boolean-like strings such as `preview`, and coarse route buckets like `section`
+ *   (no free-form user or draft copy).
+ * - Contexts: non-PII deployment metadata only (`route` pathname, deployment host/id, git SHA).
+ *   Never put draft body text, CMS fields, signed media URLs, or raw query strings here.
+ * - Breadcrumbs: rely on scrubbing below; avoid attaching user-entered text or full URLs with secrets.
+ */
+
 type JsonRecord = Record<string, unknown>;
-
-type SentryLikeEvent = {
-  request?: unknown;
-  user?: unknown;
-};
-
-type SentryLikeBreadcrumb = {
-  data?: unknown;
-};
 
 function readNonEmptyEnv(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -22,10 +24,126 @@ function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Vercel preview deployments (distinct from production traffic on the prod domain). */
+export function isPreviewDeployment(): boolean {
+  return readNonEmptyEnv(process.env.VERCEL_ENV) === "preview";
+}
+
+export function isPreviewPathname(pathname: string | undefined): boolean {
+  if (!pathname) {
+    return false;
+  }
+  return pathname === "/preview" || pathname.startsWith("/preview/");
+}
+
+/**
+ * `preview` tag for Sentry issue search (`preview:true` / `preview:false`).
+ * True when URL is under `/preview` or the app runs on a Vercel preview deployment.
+ */
+export function computePreviewTag(pathname: string | undefined): "true" | "false" {
+  return isPreviewPathname(pathname) || isPreviewDeployment() ? "true" : "false";
+}
+
+/**
+ * Coarse site section for admin and public routes (no draft content).
+ */
+export function inferSectionFromPathname(
+  pathname: string | undefined,
+): string | undefined {
+  if (!pathname) {
+    return undefined;
+  }
+
+  const path = pathname.split("?")[0] ?? pathname;
+
+  if (path === "/" || path === "/preview" || path.startsWith("/preview/")) {
+    return "home";
+  }
+
+  const adminSection = /^\/admin\/([^/?#]+)/.exec(path);
+  if (adminSection) {
+    return adminSection[1];
+  }
+  if (path.startsWith("/admin")) {
+    return "admin";
+  }
+  if (path.startsWith("/sign-in")) {
+    return "sign-in";
+  }
+  if (path.startsWith("/sign-up")) {
+    return "sign-up";
+  }
+
+  return undefined;
+}
+
+export function getDeploymentLabel(): string | undefined {
+  return (
+    readNonEmptyEnv(process.env.VERCEL_URL) ??
+    readNonEmptyEnv(process.env.NEXT_PUBLIC_VERCEL_URL)
+  );
+}
+
+export function getGitShaForSentry(): string | undefined {
+  return (
+    readNonEmptyEnv(process.env.VERCEL_GIT_COMMIT_SHA) ??
+    readNonEmptyEnv(process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA)
+  );
+}
+
+function stripUrlQuery(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  try {
+    const u = new URL(trimmed, "http://local.invalid");
+    u.search = "";
+    if (u.origin === "http://local.invalid") {
+      return `${u.pathname}${u.hash}`;
+    }
+    return `${u.origin}${u.pathname}${u.hash}`;
+  } catch {
+    const q = trimmed.indexOf("?");
+    return q === -1 ? trimmed : trimmed.slice(0, q);
+  }
+}
+
+function scrubUrlString(value: string): string {
+  return stripUrlQuery(value);
+}
+
+function scrubQueryStringValue(): string {
+  return REDACTED;
+}
+
+function pathnameFromRequestUrl(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    return new URL(url).pathname;
+  } catch {
+    const pathPart = url.split("?")[0]?.split("#")[0];
+    return pathPart || undefined;
+  }
+}
+
 function scrubRecord(record: JsonRecord): void {
   for (const [key, value] of Object.entries(record)) {
     if (SENSITIVE_KEY_PATTERN.test(key)) {
       record[key] = REDACTED;
+      continue;
+    }
+
+    if (
+      (key === "url" ||
+        key === "href" ||
+        key === "from" ||
+        key === "to") &&
+      typeof value === "string"
+    ) {
+      record[key] = scrubUrlString(value);
       continue;
     }
 
@@ -34,10 +152,7 @@ function scrubRecord(record: JsonRecord): void {
       continue;
     }
 
-    if (
-      (key === "request" || key === "response") &&
-      isRecord(value)
-    ) {
+    if ((key === "request" || key === "response") && isRecord(value)) {
       scrubRequest(value);
     }
   }
@@ -45,6 +160,14 @@ function scrubRecord(record: JsonRecord): void {
 
 function scrubRequest(request: JsonRecord): void {
   scrubRecord(request);
+
+  if (typeof request.url === "string") {
+    request.url = scrubUrlString(request.url);
+  }
+
+  if ("query_string" in request) {
+    request.query_string = scrubQueryStringValue();
+  }
 
   if ("data" in request) {
     request.data = REDACTED;
@@ -64,6 +187,7 @@ export function getSentryEnvironment(): string {
     readNonEmptyEnv(process.env.SENTRY_ENVIRONMENT) ??
     readNonEmptyEnv(process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT) ??
     readNonEmptyEnv(process.env.VERCEL_ENV) ??
+    readNonEmptyEnv(process.env.NEXT_PUBLIC_VERCEL_ENV) ??
     readNonEmptyEnv(process.env.NODE_ENV) ??
     "development"
   );
@@ -74,6 +198,7 @@ export function getSentryRelease(): string | undefined {
     readNonEmptyEnv(process.env.NEXT_PUBLIC_SENTRY_RELEASE) ??
     readNonEmptyEnv(process.env.SENTRY_RELEASE) ??
     readNonEmptyEnv(process.env.VERCEL_GIT_COMMIT_SHA) ??
+    readNonEmptyEnv(process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA) ??
     readNonEmptyEnv(process.env.VERCEL_DEPLOYMENT_ID)
   );
 }
@@ -111,7 +236,39 @@ export function getTracesSampleRate(): number {
   return process.env.NODE_ENV === "development" ? 1 : 0.1;
 }
 
-export function scrubSentryEvent<T extends SentryLikeEvent>(event: T): T {
+function enrichSentryEvent<T extends Event>(event: T): void {
+  let pathname: string | undefined;
+
+  if (isRecord(event.request) && typeof event.request.url === "string") {
+    pathname = pathnameFromRequestUrl(event.request.url);
+  }
+
+  if (!pathname && typeof event.transaction === "string") {
+    pathname = event.transaction.split("?")[0];
+  }
+
+  event.tags = { ...event.tags };
+  event.tags.preview = computePreviewTag(pathname);
+
+  const section = inferSectionFromPathname(pathname);
+  if (section) {
+    event.tags.section = section;
+  }
+
+  const deployment = getDeploymentLabel();
+  const gitSha = getGitShaForSentry();
+
+  event.contexts = { ...event.contexts };
+  event.contexts.deployment_info = {
+    route: pathname ?? "",
+    deployment: deployment ?? "",
+    git_sha: gitSha ?? "",
+  };
+}
+
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  enrichSentryEvent(event);
+
   if (isRecord(event.request)) {
     scrubRequest(event.request);
   }
@@ -125,9 +282,11 @@ export function scrubSentryEvent<T extends SentryLikeEvent>(event: T): T {
   return event;
 }
 
-export function scrubSentryBreadcrumb<T extends SentryLikeBreadcrumb>(
-  breadcrumb: T
-): T {
+export function scrubSentryBreadcrumb<T extends Breadcrumb>(breadcrumb: T): T {
+  if (typeof breadcrumb.message === "string") {
+    breadcrumb.message = scrubUrlString(breadcrumb.message);
+  }
+
   if (isRecord(breadcrumb.data)) {
     scrubRecord(breadcrumb.data);
   }
@@ -137,4 +296,30 @@ export function scrubSentryBreadcrumb<T extends SentryLikeBreadcrumb>(
 
 export function isProductionSentryEnvironment(): boolean {
   return getSentryEnvironment() === "production";
+}
+
+export function createSentryInitialScopeUpdater(): (scope: Scope) => Scope {
+  return (scope) => {
+    const pathname =
+      typeof window !== "undefined" ? window.location.pathname : undefined;
+    applyRouteToSentryScope(scope, pathname);
+    return scope;
+  };
+}
+
+/** Sets `preview`, optional `section`, and `deployment_info` from a pathname (client). */
+export function applyRouteToSentryScope(
+  scope: Pick<Scope, "setTag" | "setContext">,
+  pathname: string | undefined,
+): void {
+  scope.setTag("preview", computePreviewTag(pathname));
+  const section = inferSectionFromPathname(pathname);
+  if (section) {
+    scope.setTag("section", section);
+  }
+  scope.setContext("deployment_info", {
+    route: pathname ?? "",
+    deployment: getDeploymentLabel() ?? "",
+    git_sha: getGitShaForSentry() ?? "",
+  });
 }

--- a/src/sentry.edge.config.ts
+++ b/src/sentry.edge.config.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import {
+  createSentryInitialScopeUpdater,
   getSentryEnvironment,
   getSentryRelease,
   getServerSentryDsn,
@@ -18,6 +19,7 @@ if (dsn && isSentryEnabled()) {
     release: getSentryRelease(),
     sendDefaultPii: false,
     tracesSampleRate: getTracesSampleRate(),
+    initialScope: createSentryInitialScopeUpdater(),
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
     beforeBreadcrumb: scrubSentryBreadcrumb,

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import {
+  createSentryInitialScopeUpdater,
   getSentryEnvironment,
   getSentryRelease,
   getServerSentryDsn,
@@ -18,6 +19,7 @@ if (dsn && isSentryEnabled()) {
     release: getSentryRelease(),
     sendDefaultPii: false,
     tracesSampleRate: getTracesSampleRate(),
+    initialScope: createSentryInitialScopeUpdater(),
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
     beforeBreadcrumb: scrubSentryBreadcrumb,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry events are tagged for preview traffic versus production (`preview` tag), include a coarse `section` tag when the pathname maps to a known area (for example admin sub-routes), and attach non-PII `deployment_info` context with pathname, deployment host, and git SHA. `beforeSend` and breadcrumb scrubbing strip URL query strings (including signed preview tokens) and continue to redact sensitive keys and bodies.

## Follow-up (review)

- Client bundles now treat `NEXT_PUBLIC_VERCEL_ENV === "preview"` the same as server `VERCEL_ENV`, so preview deployments tag `preview:true` for frontend errors outside `/preview`.
- The `section` tag is removed when navigating to a route with no mapped section (avoids stale scope tags).
- Breadcrumb `message` query stripping runs only when the message looks like a URL with a query string, so plain-text crumbs are not rewritten.

## Testing

- `bun run lint`
- `bun run build`

## Staging verification

After deploy to a non-production Sentry environment, call `/api/dev/sentry/node` or `/api/dev/sentry/edge` on a Vercel preview deployment and confirm in Sentry: `preview:true`, `deployment_info`, and no query strings on request or breadcrumb URLs.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-81](https://linear.app/only-football-fans/issue/INF-81/lls-sentry-distinguish-preview-vs-prod-tags-env)

<div><a href="https://cursor.com/agents/bc-2a0e11eb-0688-4aa9-baed-e609afcf7ea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0e11eb-0688-4aa9-baed-e609afcf7ea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

