### PR TITLE
feat(admin): wire pricing editor route with skeleton (INF-84)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "lula-lake-sound",
@@ -116,19 +116,19 @@
 
     "@base-ui/utils": ["@base-ui/utils@0.2.7", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA=="],
 
-    "@clerk/backend": ["@clerk/backend@3.2.9", "", { "dependencies": { "@clerk/shared": "^4.7.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-59h6F9wo4RrulOUh9u3Dm35VHA6k86OwU8qL4giaAMKpWcsKS+zAI7GFgVAvEMDWXam8DyTKy4/npOFT2dWlAg=="],
+    "@clerk/backend": ["@clerk/backend@3.2.12", "", { "dependencies": { "@clerk/shared": "^4.8.2", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-pTuD3+3IvLrjx9XMYdbqpttTltrWc7npxkOIDzhtID5/+IOomxZAzsnxU1G1hvOeBoR1Jl68ZgKQw66aZ+DRFQ=="],
 
-    "@clerk/localizations": ["@clerk/localizations@4.4.1", "", { "dependencies": { "@clerk/shared": "^4.7.0" } }, "sha512-tFn06jR4/5OQplFfwrS7geEQHlqCDZ3taBV/pwdykamjVigruFj2j8sM3kEI3qMGzFrs7ngoVhUWP9kOUEnHqQ=="],
+    "@clerk/localizations": ["@clerk/localizations@4.5.2", "", { "dependencies": { "@clerk/shared": "^4.8.2" } }, "sha512-fhYrhbgJxfysjVw9PLWBcDz5JDO5SORcPUVbQ+u7U2LsD6fNvoIOmWnMr2V8jBKRQJ78Rbnn2Y/XTYa0Mg0ewA=="],
 
-    "@clerk/nextjs": ["@clerk/nextjs@7.1.0", "", { "dependencies": { "@clerk/backend": "^3.2.9", "@clerk/react": "^6.3.0", "@clerk/shared": "^4.7.0", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-DrvCTKmc9vECjopYW6IDXP70ltVrvpNUwRzP0nlQOCrwMBhYaC/7t1HijvzzPaPcMQ7p3A7xeYwL1ffqize1zQ=="],
+    "@clerk/nextjs": ["@clerk/nextjs@7.2.2", "", { "dependencies": { "@clerk/backend": "^3.2.12", "@clerk/react": "^6.4.2", "@clerk/shared": "^4.8.2", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-kFQ+sXD5qAxL8C53hDgpKJT+KithlOFDlkMK5Bwv/YNFy/Sf5Tzkxdh4y/AfAgJlDU0ksvu0Hn7mtB2QT8t9bg=="],
 
-    "@clerk/react": ["@clerk/react@6.3.0", "", { "dependencies": { "@clerk/shared": "^4.7.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-etqEqdP5WlVn1Bb1NF2Drgvn3UzBSXmrkKtluObTQeqOoCsTO0uFv40oDi7QBs9WQWY1tvavI5aIHzY+uHKcdw=="],
+    "@clerk/react": ["@clerk/react@6.4.2", "", { "dependencies": { "@clerk/shared": "^4.8.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-l43pon5wcM0n4e3gnRP7MWdvAXAa3M7BOF6aeNwEuITxgy6MU6ypej9tPeGmXxPicL/Hd6E/VRgiEipEKDqyCQ=="],
 
-    "@clerk/shared": ["@clerk/shared@4.7.0", "", { "dependencies": { "@tanstack/query-core": "5.90.16", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-pm2dpxHS2teY87jmpatprG2uBAuuXuHHWvuezL3a5pRoUiIWXgWlLvwRZRgKXwDeIkIT9UCAIQBkcjueSEzqHA=="],
+    "@clerk/shared": ["@clerk/shared@4.8.2", "", { "dependencies": { "@tanstack/query-core": "5.90.16", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg=="],
 
     "@clerk/themes": ["@clerk/themes@2.4.57", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" } }, "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w=="],
 
-    "@clerk/ui": ["@clerk/ui@1.5.1", "", { "dependencies": { "@clerk/localizations": "^4.4.1", "@clerk/shared": "^4.7.0", "@emotion/cache": "11.11.0", "@emotion/react": "11.11.1", "@floating-ui/react": "0.27.12", "@formkit/auto-animate": "^0.8.2", "@solana/wallet-adapter-base": "0.9.27", "@solana/wallet-adapter-react": "0.15.39", "@solana/wallet-standard": "1.1.4", "@swc/helpers": "0.5.17", "copy-to-clipboard": "3.3.3", "core-js": "3.47.0", "csstype": "3.1.3", "dequal": "2.0.3", "input-otp": "1.4.2", "qrcode.react": "4.2.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-ubQF/6lyyuTMrj3FdjuCpqsX/VJEsf09Im9aCuSn/JBe+w4xDAUP2nGEsNLiFqYSuzgBNP4yXqTYIJWfl63Cdg=="],
+    "@clerk/ui": ["@clerk/ui@1.6.2", "", { "dependencies": { "@clerk/localizations": "^4.5.2", "@clerk/shared": "^4.8.2", "@emotion/cache": "11.11.0", "@emotion/react": "11.11.1", "@floating-ui/react": "0.27.12", "@formkit/auto-animate": "^0.8.2", "@solana/wallet-adapter-base": "0.9.27", "@solana/wallet-adapter-react": "0.15.39", "@solana/wallet-standard": "1.1.4", "@swc/helpers": "0.5.21", "copy-to-clipboard": "3.3.3", "core-js": "3.47.0", "csstype": "3.1.3", "dequal": "2.0.3", "input-otp": "1.4.2", "qrcode.react": "4.2.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-WgVEbt7EHvzr2sKPuDQaIldJlZlpCy3qsV8C0J03VxV0wHoeBZIts1tr3wPfUCywv2czeP1WwUsa/SPo86fQ4w=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
@@ -300,15 +300,15 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw=="],
 
-    "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
 
-    "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA=="],
 
-    "@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+    "@inquirer/core": ["@inquirer/core@11.1.8", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA=="],
 
-    "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
 
-    "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
@@ -372,7 +372,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
 
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
@@ -524,17 +524,17 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
-    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0" } }, "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA=="],
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0" } }, "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w=="],
 
-    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0" } }, "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ=="],
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0" } }, "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ=="],
 
-    "@sentry-internal/replay": ["@sentry-internal/replay@10.48.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.48.0", "@sentry/core": "10.48.0" } }, "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA=="],
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.49.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.49.0", "@sentry/core": "10.49.0" } }, "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg=="],
 
-    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.48.0", "", { "dependencies": { "@sentry-internal/replay": "10.48.0", "@sentry/core": "10.48.0" } }, "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q=="],
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.49.0", "", { "dependencies": { "@sentry-internal/replay": "10.49.0", "@sentry/core": "10.49.0" } }, "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA=="],
 
     "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.2.0", "", {}, "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg=="],
 
-    "@sentry/browser": ["@sentry/browser@10.48.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.48.0", "@sentry-internal/feedback": "10.48.0", "@sentry-internal/replay": "10.48.0", "@sentry-internal/replay-canvas": "10.48.0", "@sentry/core": "10.48.0" } }, "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw=="],
+    "@sentry/browser": ["@sentry/browser@10.49.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.49.0", "@sentry-internal/feedback": "10.49.0", "@sentry-internal/replay": "10.49.0", "@sentry-internal/replay-canvas": "10.49.0", "@sentry/core": "10.49.0" } }, "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA=="],
 
     "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.2.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.2.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w=="],
 
@@ -556,19 +556,19 @@
 
     "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.5", "", { "os": "win32", "cpu": "x64" }, "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg=="],
 
-    "@sentry/core": ["@sentry/core@10.48.0", "", {}, "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g=="],
+    "@sentry/core": ["@sentry/core@10.49.0", "", {}, "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g=="],
 
-    "@sentry/nextjs": ["@sentry/nextjs@10.48.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@rollup/plugin-commonjs": "28.0.1", "@sentry-internal/browser-utils": "10.48.0", "@sentry/bundler-plugin-core": "^5.2.0", "@sentry/core": "10.48.0", "@sentry/node": "10.48.0", "@sentry/opentelemetry": "10.48.0", "@sentry/react": "10.48.0", "@sentry/vercel-edge": "10.48.0", "@sentry/webpack-plugin": "^5.2.0", "rollup": "^4.35.0", "stacktrace-parser": "^0.1.11" }, "peerDependencies": { "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0" } }, "sha512-SEuRQMd4RskbK/1daw3zdjEadu+T6IxoYDVoA6ladF1VaawT0zF9KscEqHTbBKWyckGbTCfccDOiRRspgcIYvA=="],
+    "@sentry/nextjs": ["@sentry/nextjs@10.49.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@rollup/plugin-commonjs": "28.0.1", "@sentry-internal/browser-utils": "10.49.0", "@sentry/bundler-plugin-core": "^5.2.0", "@sentry/core": "10.49.0", "@sentry/node": "10.49.0", "@sentry/opentelemetry": "10.49.0", "@sentry/react": "10.49.0", "@sentry/vercel-edge": "10.49.0", "@sentry/webpack-plugin": "^5.2.0", "rollup": "^4.35.0", "stacktrace-parser": "^0.1.11" }, "peerDependencies": { "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0" } }, "sha512-oVSbTbedZUfDFdgrkNpV9tclSAYF/bs+3rxKNH0KXte2dXj4nrvoinzA/3PTjbfjfgDYfInDHSPdlJv6Ev7lmA=="],
 
     "@sentry/node": ["@sentry/node@10.48.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/context-async-hooks": "^2.6.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/instrumentation-undici": "0.24.0", "@opentelemetry/resources": "^2.6.1", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.48.0", "@sentry/node-core": "10.48.0", "@sentry/opentelemetry": "10.48.0", "import-in-the-middle": "^3.0.0" } }, "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw=="],
 
     "@sentry/node-core": ["@sentry/node-core@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0", "@sentry/opentelemetry": "10.48.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/resources": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/context-async-hooks", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/resources", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw=="],
 
-    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A=="],
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w=="],
 
-    "@sentry/react": ["@sentry/react@10.48.0", "", { "dependencies": { "@sentry/browser": "10.48.0", "@sentry/core": "10.48.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw=="],
+    "@sentry/react": ["@sentry/react@10.49.0", "", { "dependencies": { "@sentry/browser": "10.49.0", "@sentry/core": "10.49.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA=="],
 
-    "@sentry/vercel-edge": ["@sentry/vercel-edge@10.48.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/resources": "^2.6.1", "@sentry/core": "10.48.0" } }, "sha512-W9hq7MaM+VjEOvfMWpIbNEiqHKn4qaG2yOV7zftwTciE3dCzyGr608vD3E9afNckTHWmg/uNwfny/v4GwwU++w=="],
+    "@sentry/vercel-edge": ["@sentry/vercel-edge@10.49.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/resources": "^2.6.1", "@sentry/core": "10.49.0" } }, "sha512-CL2Ggl5jFc5q3+tLhapRJMR7Ya9l/OxvnK55OG/FAwvhjfODz4V/Hf5bdOqU9LrsXXg4gWKqag/v5CBDDun8jg=="],
 
     "@sentry/webpack-plugin": ["@sentry/webpack-plugin@5.2.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.0" }, "peerDependencies": { "webpack": ">=5.0.0" } }, "sha512-ssV/uJK3ixf8UHBrNdLBXcnprUwppJNilbFv+19I81KTH4gVwzKXsVTMO91j6lyAXtk2mORwmEFwxZqScFfc7g=="],
 
@@ -576,13 +576,13 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@solana-mobile/mobile-wallet-adapter-protocol": ["@solana-mobile/mobile-wallet-adapter-protocol@2.2.7", "", { "dependencies": { "@solana/codecs-strings": "^6.0.0", "@solana/wallet-standard-features": "^1.3.0", "@solana/wallet-standard-util": "^1.1.2", "@wallet-standard/core": "^1.1.1", "js-base64": "^3.7.5" }, "peerDependencies": { "react-native": ">0.74" } }, "sha512-Rl9VIfnRUYqOOXjhOQXkHXsU+LnVvkJzkV3+if4BPP8v/Y4028H6SLJwFunIAqugNCDyV2XVhlwAQ9JOwnqdrg=="],
+    "@solana-mobile/mobile-wallet-adapter-protocol": ["@solana-mobile/mobile-wallet-adapter-protocol@2.2.8", "", { "dependencies": { "@solana/codecs-strings": "^6.0.0", "@solana/wallet-standard-features": "^1.3.0", "@solana/wallet-standard-util": "^1.1.2", "@wallet-standard/core": "^1.1.1", "js-base64": "^3.7.5" }, "peerDependencies": { "react-native": ">0.74" } }, "sha512-c3FQsrM7nV62DqVaHGKtr2osE2w5gS3/wjy8ILF0zczS/s1mERX+JTmf+UHd8xgESmEj/IM7q+U2Qhrmac1PdA=="],
 
-    "@solana-mobile/mobile-wallet-adapter-protocol-web3js": ["@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.7", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.7", "bs58": "^6.0.0", "js-base64": "^3.7.5" }, "peerDependencies": { "@solana/web3.js": "^1.98.4" } }, "sha512-en0v+0fIB4MWix+pxVeWi2DMjLaQSivdxqr9GQ4mVj1OhhEeYqqR/jETgfan/a3T5DKyDCGTs5AQfz909tEwfA=="],
+    "@solana-mobile/mobile-wallet-adapter-protocol-web3js": ["@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.8", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8", "bs58": "^6.0.0", "js-base64": "^3.7.5" }, "peerDependencies": { "@solana/web3.js": "^1.98.4" } }, "sha512-W9DbsFvl5lSOe7KT3dJX4tjbxfYIoOtOTJpvLMgkojyRU0UKChQ4vHvbOZQ3GkUJ8wOIS4qdrM0Yytd1Vy+YQQ=="],
 
-    "@solana-mobile/wallet-adapter-mobile": ["@solana-mobile/wallet-adapter-mobile@2.2.7", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.7", "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.7", "@solana-mobile/wallet-standard-mobile": "^0.5.1", "@solana/wallet-adapter-base": "^0.9.27", "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/core": "^1.1.1", "bs58": "^6.0.0", "js-base64": "^3.7.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@react-native-async-storage/async-storage": "^1.17.7" }, "peerDependencies": { "@solana/web3.js": "^1.98.4", "react-native": ">0.74" } }, "sha512-v1ORNrDtsIFI5Mi//g5yMrgsAHS2H0AGtAbCi8F6S5iOV4KNme9YZb5F/Ut6BMaDt0sGEysobYLwkLlY9xDTSg=="],
+    "@solana-mobile/wallet-adapter-mobile": ["@solana-mobile/wallet-adapter-mobile@2.2.8", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8", "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.8", "@solana-mobile/wallet-standard-mobile": "^0.5.2", "@solana/wallet-adapter-base": "^0.9.27", "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/core": "^1.1.1", "bs58": "^6.0.0", "js-base64": "^3.7.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@react-native-async-storage/async-storage": "^1.17.7" }, "peerDependencies": { "@solana/web3.js": "^1.98.4", "react-native": ">0.74" } }, "sha512-ZbXY3/0+UnnyS0hvArpO1b1pYzaQAiVIp+HBUm11aLEkE5+ISvHTRPr/bCEUXZfPkez/1n9zH3H0leK25Lj6Nw=="],
 
-    "@solana-mobile/wallet-standard-mobile": ["@solana-mobile/wallet-standard-mobile@0.5.1", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.7", "@solana/wallet-standard-chains": "^1.1.1", "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/base": "^1.0.1", "@wallet-standard/features": "^1.0.3", "@wallet-standard/wallet": "^1.1.0", "bs58": "^6.0.0", "js-base64": "^3.7.5", "qrcode": "^1.5.4", "tslib": "^2.8.1" }, "optionalDependencies": { "@react-native-async-storage/async-storage": "^1.17.7" } }, "sha512-9L5OA4DE9Mi5aw7VzDAnV3/kLyoKQnQfEMyv6D43zYdmvbGPW5YLgiHYI7XCz1ZIPNLshqyMjQfy+5CjJjGEYg=="],
+    "@solana-mobile/wallet-standard-mobile": ["@solana-mobile/wallet-standard-mobile@0.5.2", "", { "dependencies": { "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8", "@solana/wallet-standard-chains": "^1.1.1", "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/base": "^1.0.1", "@wallet-standard/features": "^1.0.3", "@wallet-standard/wallet": "^1.1.0", "bs58": "^6.0.0", "js-base64": "^3.7.5", "qrcode": "^1.5.4", "tslib": "^2.8.1" }, "optionalDependencies": { "@react-native-async-storage/async-storage": "^1.17.7" } }, "sha512-orEGv4N/Ttd0umwfWUzGcEnVc9eJDTgRSEcDitvFWpIf2D968h6128L0rq9/y7sUw88Gvu/lU0euoC2ASEijqQ=="],
 
     "@solana/buffer-layout": ["@solana/buffer-layout@4.0.1", "", { "dependencies": { "buffer": "~6.0.3" } }, "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA=="],
 
@@ -622,7 +622,7 @@
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
-    "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
+    "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.10", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "enhanced-resolve": "^5.18.1", "jiti": "^2.4.2", "lightningcss": "1.30.1", "magic-string": "^0.30.17", "source-map-js": "^1.2.1", "tailwindcss": "4.1.10" } }, "sha512-2ACf1znY5fpRBwRhMgj9ZXvb2XZW8qs+oTfotJ2C5xR0/WNL7UHZ7zXl6s+rUqedL1mNi+0O+WQr5awGowS3PQ=="],
 
@@ -691,6 +691,8 @@
     "@types/react": ["@types/react@19.1.8", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.6", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw=="],
+
+    "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
@@ -1058,7 +1060,7 @@
 
     "effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1174,7 +1176,13 @@
 
     "fast-stable-stringify": ["fast-stable-stringify@1.0.0", "", {}, "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -1182,7 +1190,7 @@
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+    "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
@@ -1276,7 +1284,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
+    "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
 
     "hermes-compiler": ["hermes-compiler@250829098.0.10", "", {}, "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w=="],
 
@@ -1286,7 +1294,7 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
-    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1584,9 +1592,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msw": ["msw@2.13.3", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w=="],
+    "msw": ["msw@2.13.4", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA=="],
 
-    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1688,7 +1696,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -1830,6 +1838,8 @@
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
@@ -1838,7 +1848,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "shadcn": ["shadcn@4.2.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-ZDuV340itidaUd4Gi1BxQX+Y7Ush6BHp6URZBM2RyxUUBZ6yFtOWIr4nVY+Ro+YRSpo82v7JrsmtcU5xoBCMJQ=="],
+    "shadcn": ["shadcn@4.3.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-7vhnBh2LVLyxOd1ZQWwXv7OATCnQcxdqc8FbZdNigZriNOwDsHklQmPpvPt1jcrFK5mzMI+cyuAYv8WzERx2Og=="],
 
     "sharp": ["sharp@0.34.2", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.4", "semver": "^7.7.2" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.2", "@img/sharp-darwin-x64": "0.34.2", "@img/sharp-libvips-darwin-arm64": "1.1.0", "@img/sharp-libvips-darwin-x64": "1.1.0", "@img/sharp-libvips-linux-arm": "1.1.0", "@img/sharp-libvips-linux-arm64": "1.1.0", "@img/sharp-libvips-linux-ppc64": "1.1.0", "@img/sharp-libvips-linux-s390x": "1.1.0", "@img/sharp-libvips-linux-x64": "1.1.0", "@img/sharp-libvips-linuxmusl-arm64": "1.1.0", "@img/sharp-libvips-linuxmusl-x64": "1.1.0", "@img/sharp-linux-arm": "0.34.2", "@img/sharp-linux-arm64": "0.34.2", "@img/sharp-linux-s390x": "0.34.2", "@img/sharp-linux-x64": "0.34.2", "@img/sharp-linuxmusl-arm64": "0.34.2", "@img/sharp-linuxmusl-x64": "0.34.2", "@img/sharp-wasm32": "0.34.2", "@img/sharp-win32-arm64": "0.34.2", "@img/sharp-win32-ia32": "0.34.2", "@img/sharp-win32-x64": "0.34.2" } }, "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg=="],
 
@@ -2062,7 +2072,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -2088,8 +2098,6 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
-
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
@@ -2098,7 +2106,7 @@
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@clerk/themes/@clerk/shared": ["@clerk/shared@3.47.3", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw=="],
+    "@clerk/themes/@clerk/shared": ["@clerk/shared@3.47.4", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -2124,15 +2132,13 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
-    "@jridgewell/remapping/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
-
-    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
     "@jridgewell/source-map/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/source-map/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
@@ -2140,7 +2146,13 @@
 
     "@react-native/codegen/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "@react-native/community-cli-plugin/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "@react-native/community-cli-plugin/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "@react-native/debugger-shell/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@react-native/dev-middleware/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
@@ -2153,6 +2165,16 @@
     "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "@sentry/nextjs/@sentry/node": ["@sentry/node@10.49.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/instrumentation-undici": "0.24.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.49.0", "@sentry/node-core": "10.49.0", "@sentry/opentelemetry": "10.49.0", "import-in-the-middle": "^3.0.0" } }, "sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ=="],
+
+    "@sentry/node/@sentry/core": ["@sentry/core@10.48.0", "", {}, "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g=="],
+
+    "@sentry/node/@sentry/opentelemetry": ["@sentry/opentelemetry@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A=="],
+
+    "@sentry/node-core/@sentry/core": ["@sentry/core@10.48.0", "", {}, "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g=="],
+
+    "@sentry/node-core/@sentry/opentelemetry": ["@sentry/opentelemetry@10.48.0", "", { "dependencies": { "@sentry/core": "10.48.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A=="],
 
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
@@ -2204,8 +2226,6 @@
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
@@ -2220,13 +2240,19 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
+    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "is-bun-module/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
@@ -2256,6 +2282,8 @@
 
     "merge-options/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
+    "metro/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
@@ -2267,6 +2295,8 @@
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro-config/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "metro-file-map/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "metro-file-map/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
@@ -2310,11 +2340,7 @@
 
     "react-native/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "require-in-the-middle/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
-    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
@@ -2336,13 +2362,11 @@
 
     "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "terser/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "terser-webpack-plugin/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "webpack/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -2382,6 +2406,10 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
+    "@react-native/codegen/tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "@react-native/codegen/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -2391,6 +2419,8 @@
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "@sentry/cli/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@sentry/nextjs/@sentry/node/@sentry/node-core": ["@sentry/node-core@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0", "@sentry/opentelemetry": "10.49.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA=="],
 
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
@@ -2450,6 +2480,10 @@
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "react-native/tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "react-native/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
@@ -2473,6 +2507,8 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "qrcode/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,9 @@
     "@vercel/speed-insights",
     "unrs-resolver",
   ],
+  "overrides": {
+    "import-in-the-middle": "3.0.1",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -2371,8 +2374,6 @@
 
     "@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.212.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg=="],
 
-    "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
-
     "@fastify/otel/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -2380,8 +2381,6 @@
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
-
-    "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as inquiries from "../inquiries.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_sentryConvex from "../lib/sentryConvex.js";
 import type * as observability from "../observability.js";
+import type * as pricingPreviewDraft from "../pricingPreviewDraft.js";
 import type * as public_ from "../public.js";
 import type * as publicSettingsSnapshot from "../publicSettingsSnapshot.js";
 import type * as seed from "../seed.js";
@@ -41,6 +42,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/sentryConvex": typeof lib_sentryConvex;
   observability: typeof observability;
+  pricingPreviewDraft: typeof pricingPreviewDraft;
   public: typeof public_;
   publicSettingsSnapshot: typeof publicSettingsSnapshot;
   seed: typeof seed;

--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -16,7 +16,7 @@ import { cmsPublishValidationFailed } from "../errors";
 import {
   collectAllPublishIssues,
   ensureSectionRow,
-  publishSettingsSectionCore,
+  publishSectionCore,
   rowsWithPublishableDraft,
 } from "../cmsPublishHelpers";
 
@@ -26,7 +26,7 @@ export const publish = mutation({
     const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
     void identity;
     const { id, row } = await ensureSectionRow(ctx, args.section, updatedBy);
-    return await publishSettingsSectionCore(ctx, {
+    return await publishSectionCore(ctx, {
       section: args.section,
       id,
       row,
@@ -62,11 +62,10 @@ export const publishSite = mutation({
       );
     }
 
-    const results: Awaited<ReturnType<typeof publishSettingsSectionCore>>[] =
-      [];
+    const results: Awaited<ReturnType<typeof publishSectionCore>>[] = [];
 
     for (const row of targets) {
-      const r = await publishSettingsSectionCore(ctx, {
+      const r = await publishSectionCore(ctx, {
         section: row.section,
         id: row._id,
         row,

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -2,23 +2,28 @@ import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import {
   cmsSectionValidator,
+  pricingContentValidator,
   settingsContentValidator,
 } from "./schema.shared";
-import { SETTINGS_DEFAULTS, settingsSnapshotsEqual } from "./cmsShared";
+import {
+  cmsSnapshotsEqual,
+  defaultSnapshotForSection,
+} from "./cmsShared";
 import {
   requireAuthenticatedIdentity,
   requireCmsOwner,
 } from "./lib/auth";
 import {
-  collectSettingsPublishIssues,
+  collectPublishIssues,
   ensureSectionRow,
   getSectionRow,
-  publishSettingsSectionCore,
+  publishSectionCore,
 } from "./cmsPublishHelpers";
+import { cmsValidationError } from "./errors";
 
 /**
  * Full section document for the admin UI (published + optional draft).
- * Requires a valid Convex identity; returns SETTINGS_DEFAULTS when no row exists yet.
+ * Requires a valid Convex identity; returns per-section defaults when no row exists yet.
  */
 export const getSection = query({
   args: { section: cmsSectionValidator },
@@ -32,7 +37,7 @@ export const getSection = query({
     if (!row) {
       return {
         section: args.section,
-        publishedSnapshot: SETTINGS_DEFAULTS,
+        publishedSnapshot: defaultSnapshotForSection(args.section),
         publishedAt: null,
         publishedBy: null,
         draftSnapshot: null,
@@ -58,22 +63,53 @@ export const getSection = query({
 /**
  * Persist a working copy for a section. Does not change what public readers see.
  * First save on a new environment creates the singleton row (same defaults as seed).
+ *
+ * `content` is a discriminated union keyed by `section` so the validator only
+ * accepts the shape that belongs to the target section.
  */
 export const saveDraft = mutation({
   args: {
     section: cmsSectionValidator,
-    content: settingsContentValidator,
+    content: v.union(settingsContentValidator, pricingContentValidator),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
-    const { id, row } = await ensureSectionRow(
-      ctx,
-      args.section,
-      updatedBy,
-    );
+
+    // Runtime guard: the `content` union lets either shape through, but we
+    // enforce that the payload matches the target section so a settings row
+    // can never end up with a pricing payload (or vice versa).
+    if (args.section === "settings") {
+      if (!("metadata" in args.content) && !("flags" in args.content)) {
+        cmsValidationError(
+          "Settings content must include metadata.",
+          "content",
+        );
+      }
+      if ("flags" in args.content && !("metadata" in args.content)) {
+        cmsValidationError(
+          "Settings content cannot be a pricing payload.",
+          "content",
+        );
+      }
+    } else {
+      if (!("flags" in args.content)) {
+        cmsValidationError(
+          "Pricing content must include flags.priceTabEnabled.",
+          "content",
+        );
+      }
+      if ("metadata" in args.content) {
+        cmsValidationError(
+          "Pricing content cannot include metadata.",
+          "content",
+        );
+      }
+    }
+
+    const { id, row } = await ensureSectionRow(ctx, args.section, updatedBy);
     const now = Date.now();
 
-    const hasDraftChanges = !settingsSnapshotsEqual(
+    const hasDraftChanges = !cmsSnapshotsEqual(
       args.content,
       row.publishedSnapshot,
     );
@@ -103,7 +139,7 @@ export const publishSection = mutation({
     const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
     void identity;
     const { id, row } = await ensureSectionRow(ctx, args.section, updatedBy);
-    return await publishSettingsSectionCore(ctx, {
+    return await publishSectionCore(ctx, {
       section: args.section,
       id,
       row,
@@ -127,8 +163,10 @@ export const validatePublishSection = query({
       .unique();
 
     const snapshot =
-      row?.draftSnapshot ?? row?.publishedSnapshot ?? SETTINGS_DEFAULTS;
-    const issues = collectSettingsPublishIssues(snapshot);
+      row?.draftSnapshot ??
+      row?.publishedSnapshot ??
+      defaultSnapshotForSection(args.section);
+    const issues = collectPublishIssues(args.section, snapshot);
     return {
       ok: issues.length === 0,
       section: args.section,

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -1,13 +1,22 @@
 import type { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
-import { SETTINGS_DEFAULTS, settingsSnapshotsEqual } from "./cmsShared";
-import { cmsNotFound, cmsPublishValidationFailed } from "./errors";
+import {
+  PRICING_DEFAULTS,
+  SETTINGS_DEFAULTS,
+  cmsSnapshotsEqual,
+  defaultSnapshotForSection,
+  type CmsSection,
+  type CmsSnapshot,
+  type PricingSnapshot,
+  type SettingsSnapshot,
+} from "./cmsShared";
+import { cmsPublishValidationFailed } from "./errors";
 
 export type PublishIssue = { path: string; message: string };
 
 export async function getSectionRow(
   ctx: MutationCtx,
-  section: Doc<"cmsSections">["section"],
+  section: CmsSection,
 ): Promise<Doc<"cmsSections"> | null> {
   return await ctx.db
     .query("cmsSections")
@@ -15,31 +24,52 @@ export async function getSectionRow(
     .unique();
 }
 
+/**
+ * Resolve the initial published snapshot for a brand new row.
+ *
+ * For `pricing`, we opportunistically backfill from any legacy `flags`
+ * stored on the existing `settings` row so the first write doesn’t reset
+ * the user’s previously-published value.
+ */
+async function initialSnapshotForSection(
+  ctx: MutationCtx,
+  section: CmsSection,
+): Promise<CmsSnapshot> {
+  if (section === "pricing") {
+    const legacy = await getSectionRow(ctx, "settings");
+    const legacyFlags = (legacy?.publishedSnapshot as SettingsSnapshot | undefined)
+      ?.flags;
+    if (legacyFlags) {
+      return { flags: legacyFlags } satisfies PricingSnapshot;
+    }
+    return PRICING_DEFAULTS;
+  }
+  return SETTINGS_DEFAULTS;
+}
+
 export async function ensureSectionRow(
   ctx: MutationCtx,
-  section: Doc<"cmsSections">["section"],
+  section: CmsSection,
   updatedBy: string | undefined,
 ): Promise<{ row: Doc<"cmsSections">; id: Id<"cmsSections"> }> {
   const existing = await getSectionRow(ctx, section);
-  const now = Date.now();
 
   if (existing) {
     return { row: existing, id: existing._id };
   }
 
-  if (section !== "settings") {
-    cmsNotFound("cmsSection", section, `Unknown CMS section: ${section}`);
-  }
+  const now = Date.now();
+  const publishedSnapshot = await initialSnapshotForSection(ctx, section);
 
   const id = await ctx.db.insert("cmsSections", {
-    section: "settings",
+    section,
     updatedAt: now,
     updatedBy,
-    publishedSnapshot: SETTINGS_DEFAULTS,
+    publishedSnapshot,
     publishedAt: now,
     hasDraftChanges: false,
   });
-  const row = await ctx.db.get("cmsSections", id);
+  const row = await ctx.db.get(id);
   if (!row) {
     throw new Error("Failed to load cmsSections row after insert");
   }
@@ -49,10 +79,7 @@ export async function ensureSectionRow(
 const trimOrEmpty = (s: string | undefined): string =>
   s === undefined ? "" : s.trim();
 
-/** Best-effort checks before promoting `draft` to published (INF-75). */
-export function collectSettingsPublishIssues(
-  draft: Doc<"cmsSections">["publishedSnapshot"],
-): PublishIssue[] {
+function collectSettingsIssues(draft: SettingsSnapshot): PublishIssue[] {
   const issues: PublishIssue[] = [];
   const title = trimOrEmpty(draft.metadata?.title);
   if (title.length === 0) {
@@ -71,18 +98,50 @@ export function collectSettingsPublishIssues(
   return issues;
 }
 
+function collectPricingIssues(draft: PricingSnapshot): PublishIssue[] {
+  const issues: PublishIssue[] = [];
+  if (typeof draft.flags?.priceTabEnabled !== "boolean") {
+    issues.push({
+      path: "flags.priceTabEnabled",
+      message: "Pricing visibility flag must be a boolean.",
+    });
+  }
+  return issues;
+}
+
+/** Best-effort checks before promoting `draft` to published (INF-75). */
+export function collectPublishIssues(
+  section: CmsSection,
+  draft: CmsSnapshot,
+): PublishIssue[] {
+  if (section === "settings") {
+    return collectSettingsIssues(draft as SettingsSnapshot);
+  }
+  return collectPricingIssues(draft as PricingSnapshot);
+}
+
+/**
+ * @deprecated Kept for back-compat with older callers. Prefer
+ * {@link collectPublishIssues} with an explicit section.
+ */
+export function collectSettingsPublishIssues(
+  draft: SettingsSnapshot,
+): PublishIssue[] {
+  return collectSettingsIssues(draft);
+}
+
 export type PublishSectionResult =
   | {
       ok: true;
       kind: "published";
-      section: Doc<"cmsSections">["section"];
+      section: CmsSection;
       publishedAt: number;
       publishedBy: string;
     }
   | {
       ok: true;
       kind: "already_current";
-      section: Doc<"cmsSections">["section"];
+      section: CmsSection;
       publishedAt: number | null;
       publishedBy: string | undefined;
     };
@@ -90,10 +149,10 @@ export type PublishSectionResult =
 /**
  * Single-transaction promote draft → published, or no-op when there is no draft and nothing pending.
  */
-export async function publishSettingsSectionCore(
+export async function publishSectionCore(
   ctx: MutationCtx,
   args: {
-    section: Doc<"cmsSections">["section"];
+    section: CmsSection;
     id: Id<"cmsSections">;
     row: Doc<"cmsSections">;
     /** Clerk `subject` — stored as `publishedBy` for audit. */
@@ -121,7 +180,7 @@ export async function publishSettingsSectionCore(
     };
   }
 
-  const issues = collectSettingsPublishIssues(draft);
+  const issues = collectPublishIssues(section, draft);
   if (issues.length > 0) {
     cmsPublishValidationFailed(section, "Publish validation failed.", issues);
   }
@@ -147,6 +206,11 @@ export async function publishSettingsSectionCore(
   };
 }
 
+/**
+ * @deprecated Renamed to {@link publishSectionCore}. Kept for existing callers.
+ */
+export const publishSettingsSectionCore = publishSectionCore;
+
 /** Rows that have a draft different from published (site-wide publish targets). */
 export function rowsWithPublishableDraft(
   rows: Doc<"cmsSections">[],
@@ -154,7 +218,7 @@ export function rowsWithPublishableDraft(
   return rows.filter(
     (row) =>
       row.draftSnapshot !== undefined &&
-      !settingsSnapshotsEqual(row.draftSnapshot, row.publishedSnapshot),
+      !cmsSnapshotsEqual(row.draftSnapshot, row.publishedSnapshot),
   );
 }
 
@@ -166,7 +230,7 @@ export function collectAllPublishIssues(
   for (const row of targets) {
     const d = row.draftSnapshot;
     if (!d) continue;
-    for (const issue of collectSettingsPublishIssues(d)) {
+    for (const issue of collectPublishIssues(row.section, d)) {
       issues.push({
         path: `${row.section}.${issue.path}`,
         message: issue.message,
@@ -175,3 +239,6 @@ export function collectAllPublishIssues(
   }
   return issues;
 }
+
+// Preserve legacy default re-exports for callers that imported from this module.
+export { defaultSnapshotForSection };

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -1,13 +1,30 @@
+import type { Infer } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
+import type {
+  settingsContentValidator,
+  pricingContentValidator,
+} from "./schema.shared";
 
-/** Single source of truth for initial `publishedSnapshot` on new settings rows. */
-export const SETTINGS_DEFAULTS: Doc<"cmsSections">["publishedSnapshot"] = {
-  flags: { priceTabEnabled: true },
+export type CmsSection = Doc<"cmsSections">["section"];
+export type CmsSnapshot = Doc<"cmsSections">["publishedSnapshot"];
+export type SettingsSnapshot = Infer<typeof settingsContentValidator>;
+export type PricingSnapshot = Infer<typeof pricingContentValidator>;
+
+/** Per-section default snapshots used for seeding and new-row inserts. */
+export const SETTINGS_DEFAULTS: SettingsSnapshot = {
   metadata: {
     title: "Lula Lake Sound",
     description: "Music Production and Recording Services",
   },
 };
+
+export const PRICING_DEFAULTS: PricingSnapshot = {
+  flags: { priceTabEnabled: true },
+};
+
+export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
+  return section === "settings" ? SETTINGS_DEFAULTS : PRICING_DEFAULTS;
+}
 
 function deepEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) {
@@ -47,10 +64,13 @@ function deepEqual(a: unknown, b: unknown): boolean {
   return true;
 }
 
-/** Deep equality for settings snapshots without relying on `JSON.stringify` key order. */
-export function settingsSnapshotsEqual(
-  a: Doc<"cmsSections">["publishedSnapshot"],
-  b: Doc<"cmsSections">["publishedSnapshot"],
-): boolean {
+/** Deep equality for section snapshots without relying on `JSON.stringify` key order. */
+export function cmsSnapshotsEqual(a: CmsSnapshot, b: CmsSnapshot): boolean {
   return deepEqual(a, b);
 }
+
+/**
+ * Legacy alias kept so existing imports keep working.
+ * @deprecated Use {@link cmsSnapshotsEqual}.
+ */
+export const settingsSnapshotsEqual = cmsSnapshotsEqual;

--- a/convex/pricingPreviewDraft.ts
+++ b/convex/pricingPreviewDraft.ts
@@ -1,0 +1,51 @@
+import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import { publishedPricingFromRows } from "./publicSettingsSnapshot";
+
+/**
+ * Preview pricing flags for owner-only access. Resolves **draft** when present
+ * on the `pricing` section, else published. Also consults the legacy `settings`
+ * row's flags so preview keeps working during migration.
+ *
+ * Returns `null` for unauthenticated or non-owner callers — never leaks drafts.
+ * `hasDraftChanges` reflects only the `pricing` section.
+ */
+export const getPreviewPricingFlags = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const [pricingRow, settingsRow] = await Promise.all([
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", "pricing"))
+        .unique(),
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", "settings"))
+        .unique(),
+    ]);
+
+    const effectivePricing = pricingRow
+      ? {
+          ...pricingRow,
+          publishedSnapshot:
+            pricingRow.draftSnapshot ?? pricingRow.publishedSnapshot,
+        }
+      : null;
+
+    const resolved = publishedPricingFromRows(effectivePricing, settingsRow);
+
+    return {
+      ...resolved,
+      hasDraftChanges: pricingRow?.hasDraftChanges ?? false,
+    };
+  },
+});

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -1,12 +1,15 @@
 import { query } from "./_generated/server";
-import { publishedSettingsFromRow } from "./publicSettingsSnapshot";
+import {
+  publishedPricingFromRows,
+  publishedSettingsFromRow,
+} from "./publicSettingsSnapshot";
 
 /**
  * **Public (anonymous) site reads** — published snapshot only.
  *
  * Add new landing-page queries here (one entry point per domain). Each handler must
  * read only `publishedSnapshot` (or other published columns), never `draftSnapshot`.
- * For owner preview / draft overlay, use `siteSettingsPreviewDraft` (see `siteSettingsPreviewDraft.ts`).
+ * For owner preview / draft overlay, use `pricingPreviewDraft` / `siteSettingsPreviewDraft`.
  */
 export const getPublishedSiteSettings = query({
   args: {},
@@ -16,10 +19,32 @@ export const getPublishedSiteSettings = query({
       .withIndex("by_section", (q) => q.eq("section", "settings"))
       .unique();
 
-    const parsed = publishedSettingsFromRow(row);
-    if (!parsed) {
-      return null;
-    }
-    return { flags: parsed.flags };
+    return publishedSettingsFromRow(row);
+  },
+});
+
+/**
+ * Published pricing feature flags.
+ *
+ * Resolves the `pricing` section's `publishedSnapshot.flags`. If that row
+ * has not yet been written (legacy deployments that still store flags on
+ * the `settings` row), the helper falls back to `settings.flags` and then
+ * to the seeded defaults, so the marketing site always renders.
+ */
+export const getPublishedPricingFlags = query({
+  args: {},
+  handler: async (ctx) => {
+    const [pricingRow, settingsRow] = await Promise.all([
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", "pricing"))
+        .unique(),
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", "settings"))
+        .unique(),
+    ]);
+
+    return publishedPricingFromRows(pricingRow, settingsRow);
   },
 });

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -1,7 +1,13 @@
 import type { Doc } from "./_generated/dataModel";
-import { SETTINGS_DEFAULTS } from "./cmsShared";
+import {
+  PRICING_DEFAULTS,
+  SETTINGS_DEFAULTS,
+  type PricingSnapshot,
+  type SettingsSnapshot,
+} from "./cmsShared";
 
-type SettingsFlags = Doc<"cmsSections">["publishedSnapshot"]["flags"];
+type SettingsFlags = PricingSnapshot["flags"];
+type SettingsMetadata = NonNullable<SettingsSnapshot["metadata"]>;
 
 function isValidFlags(value: unknown): value is SettingsFlags {
   return (
@@ -13,25 +19,72 @@ function isValidFlags(value: unknown): value is SettingsFlags {
 }
 
 /**
- * Returns safe published settings flags for public readers: never throws if
- * `publishedSnapshot` is partially invalid; falls back to seeded defaults.
+ * Returns safe published pricing flags for public readers.
+ *
+ * Resolution order:
+ * 1. `pricing` row's `publishedSnapshot.flags` (new split schema), when valid.
+ * 2. Legacy `settings` row's `publishedSnapshot.flags` (pre-split), when valid.
+ * 3. `PRICING_DEFAULTS`.
+ *
+ * Falling back to legacy is what keeps the site rendering correctly for
+ * deployments that haven't yet written to the pricing section.
+ */
+export function publishedPricingFromRows(
+  pricingRow: Doc<"cmsSections"> | null,
+  settingsRow: Doc<"cmsSections"> | null,
+): { flags: SettingsFlags } {
+  const pricingSnap = pricingRow?.publishedSnapshot as unknown;
+  if (pricingSnap && typeof pricingSnap === "object") {
+    const rawFlags = (pricingSnap as { flags?: unknown }).flags;
+    if (isValidFlags(rawFlags)) {
+      return { flags: rawFlags };
+    }
+  }
+
+  const settingsSnap = settingsRow?.publishedSnapshot as unknown;
+  if (settingsSnap && typeof settingsSnap === "object") {
+    const rawFlags = (settingsSnap as { flags?: unknown }).flags;
+    if (isValidFlags(rawFlags)) {
+      return { flags: rawFlags };
+    }
+  }
+
+  return { flags: PRICING_DEFAULTS.flags };
+}
+
+/**
+ * Returns safe published site metadata. Never throws if `publishedSnapshot`
+ * is partially invalid; falls back to seeded defaults.
  */
 export function publishedSettingsFromRow(
   row: Doc<"cmsSections"> | null,
-): { flags: SettingsFlags } | null {
-  if (!row) {
-    return null;
+): { metadata: SettingsMetadata } {
+  const snap = row?.publishedSnapshot as unknown;
+  const defaults = SETTINGS_DEFAULTS.metadata ?? {
+    title: "",
+    description: "",
+  };
+  if (!snap || typeof snap !== "object") {
+    return { metadata: defaults };
   }
 
-  const snap = row.publishedSnapshot as unknown;
-  if (typeof snap !== "object" || snap === null) {
-    return {
-      flags: SETTINGS_DEFAULTS.flags,
-    };
+  const rawMetadata = (snap as { metadata?: unknown }).metadata;
+  if (
+    rawMetadata === null ||
+    rawMetadata === undefined ||
+    typeof rawMetadata !== "object"
+  ) {
+    return { metadata: defaults };
   }
 
-  const rawFlags = (snap as { flags?: unknown }).flags;
-  const flags = isValidFlags(rawFlags) ? rawFlags : SETTINGS_DEFAULTS.flags;
-
-  return { flags };
+  const m = rawMetadata as { title?: unknown; description?: unknown };
+  return {
+    metadata: {
+      title: typeof m.title === "string" ? m.title : defaults.title,
+      description:
+        typeof m.description === "string"
+          ? m.description
+          : defaults.description,
+    },
+  };
 }

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -3,21 +3,46 @@ import { v } from "convex/values";
 /**
  * Shared validators imported by `schema.ts` and mutations so args stay in sync.
  * See `docs/cms-publish.md` for how to add a new section.
+ *
+ * Sections today:
+ * - `settings`  — site metadata (title, description; extend as CMS grows).
+ * - `pricing`   — feature flags that govern pricing surfaces on the marketing site.
  */
 export const siteFlagsValidator = v.object({
   priceTabEnabled: v.boolean(),
 });
 
 export const siteMetadataValidator = v.object({
-  /** Shared site copy / SEO-style fields; extend as CMS grows. */
   title: v.optional(v.string()),
   description: v.optional(v.string()),
 });
 
-/** One "slice" of site settings (used as both draft and published snapshot). */
+/**
+ * "settings" section snapshot — site-wide metadata.
+ *
+ * `flags` is retained as optional purely to keep legacy rows (pre-split)
+ * schema-valid. New writes from the settings editor never populate it;
+ * pricing flags live in the `pricing` section. Remove after legacy rows
+ * have been migrated.
+ */
 export const settingsContentValidator = v.object({
-  flags: siteFlagsValidator,
   metadata: v.optional(siteMetadataValidator),
+  /** @deprecated Moved to the `pricing` section. Kept optional for legacy rows. */
+  flags: v.optional(siteFlagsValidator),
 });
 
-export const cmsSectionValidator = v.literal("settings");
+/** "pricing" section snapshot — flags only. */
+export const pricingContentValidator = v.object({
+  flags: siteFlagsValidator,
+});
+
+/** Any section's snapshot payload — discriminated at runtime by the row's `section`. */
+export const cmsSnapshotValidator = v.union(
+  settingsContentValidator,
+  pricingContentValidator,
+);
+
+export const cmsSectionValidator = v.union(
+  v.literal("settings"),
+  v.literal("pricing"),
+);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,7 +2,7 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 import {
   cmsSectionValidator,
-  settingsContentValidator,
+  cmsSnapshotValidator,
 } from "./schema.shared";
 
 // Draft/publish model: see docs/cms-publish.md (INF-70).
@@ -13,6 +13,7 @@ import {
  * - `draftSnapshot` — working copy for admins; optional until first edit.
  * - `hasDraftChanges` — true when draft differs from published (cleared on publish / discard).
  *
+ * Snapshots are a union across sections; consumers must narrow via the row's `section` field.
  * First-time publish: `publishedSnapshot` may be a seeded default; saving draft populates
  * `draftSnapshot`; publish copies `draftSnapshot` → `publishedSnapshot` in one `patch`.
  */
@@ -27,18 +28,18 @@ export default defineSchema({
   }),
   /**
    * Per-section CMS documents. `section` is the primary key for the singleton pattern
-   * (e.g. one row with section === "settings").
+   * (one row per section literal, e.g. `settings`, `pricing`).
    */
   cmsSections: defineTable({
     section: cmsSectionValidator,
     updatedAt: v.number(),
     /** Clerk user id (`subject`) when the last write was authenticated. */
     updatedBy: v.optional(v.string()),
-    publishedSnapshot: settingsContentValidator,
+    publishedSnapshot: cmsSnapshotValidator,
     publishedAt: v.union(v.number(), v.null()),
     /** Clerk user id (`subject`) who last published this section. */
     publishedBy: v.optional(v.string()),
-    draftSnapshot: v.optional(settingsContentValidator),
+    draftSnapshot: v.optional(cmsSnapshotValidator),
     hasDraftChanges: v.boolean(),
   }).index("by_section", ["section"]),
 });

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,8 +1,14 @@
 import { internalMutation } from "./_generated/server";
-import { SETTINGS_DEFAULTS } from "./cmsShared";
+import {
+  PRICING_DEFAULTS,
+  SETTINGS_DEFAULTS,
+  type CmsSection,
+  type CmsSnapshot,
+} from "./cmsShared";
 
 /**
- * Idempotent seed for local dev: creates the singleton `cmsSections` settings row if missing.
+ * Idempotent seed for local dev: creates both CMS rows (`settings`, `pricing`)
+ * if missing, so admin editors and public queries have a consistent baseline.
  *
  * Run once after deploying schema:
  * `bunx convex run internal.seed.seedSiteSettingsDefaults` (or from dashboard → Functions → internal).
@@ -10,25 +16,36 @@ import { SETTINGS_DEFAULTS } from "./cmsShared";
 export const seedSiteSettingsDefaults = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const existing = await ctx.db
-      .query("cmsSections")
-      .withIndex("by_section", (q) => q.eq("section", "settings"))
-      .unique();
-
     const now = Date.now();
 
-    if (existing) {
-      return { status: "already_seeded" as const, id: existing._id };
+    async function ensureSeeded(
+      section: CmsSection,
+      snapshot: CmsSnapshot,
+    ): Promise<{ section: CmsSection; status: "already_seeded" | "inserted" }> {
+      const existing = await ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", section))
+        .unique();
+      if (existing) {
+        return { section, status: "already_seeded" };
+      }
+      await ctx.db.insert("cmsSections", {
+        section,
+        updatedAt: now,
+        publishedSnapshot: snapshot,
+        publishedAt: now,
+        hasDraftChanges: false,
+      });
+      return { section, status: "inserted" };
     }
 
-    const id = await ctx.db.insert("cmsSections", {
-      section: "settings",
-      updatedAt: now,
-      publishedSnapshot: SETTINGS_DEFAULTS,
-      publishedAt: now,
-      hasDraftChanges: false,
-    });
+    const results = await Promise.all([
+      ensureSeeded("settings", SETTINGS_DEFAULTS),
+      ensureSeeded("pricing", PRICING_DEFAULTS),
+    ]);
 
-    return { status: "inserted" as const, id };
+    return {
+      results,
+    };
   },
 });

--- a/convex/siteSettingsPreviewDraft.ts
+++ b/convex/siteSettingsPreviewDraft.ts
@@ -1,10 +1,9 @@
 import { query } from "./_generated/server";
 import { requireCmsOwner } from "./lib/auth";
-import { SETTINGS_DEFAULTS } from "./cmsShared";
 import { publishedSettingsFromRow } from "./publicSettingsSnapshot";
 
 /**
- * Preview site settings for owner-only access. Resolves **draft** when present,
+ * Preview site metadata for owner-only access. Resolves **draft** when present,
  * else published (same effective snapshot as the editor).
  *
  * Returns `null` for unauthenticated or non-owner callers — never leaks drafts.
@@ -28,7 +27,7 @@ export const getPreviewSiteSettings = query({
 
     if (!row) {
       return {
-        flags: SETTINGS_DEFAULTS.flags,
+        ...publishedSettingsFromRow(null),
         hasDraftChanges: false,
       };
     }
@@ -37,13 +36,9 @@ export const getPreviewSiteSettings = query({
       ...row,
       publishedSnapshot: row.draftSnapshot ?? row.publishedSnapshot,
     };
-    const base = publishedSettingsFromRow(effectiveRow);
-    if (!base) {
-      return null;
-    }
 
     return {
-      flags: base.flags,
+      ...publishedSettingsFromRow(effectiveRow),
       hasDraftChanges: row.hasDraftChanges,
     };
   },

--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -7,8 +7,21 @@
 
 | Audience | Data |
 |----------|------|
-| Anonymous / marketing site | `publishedSnapshot` only (e.g. `api.public.getPublishedSiteSettings`) |
-| Studio / preview | `api.siteSettingsPreviewDraft.getPreviewSiteSettings` (draft when present, else published; owner-gated) |
+| Anonymous / marketing site — metadata | `publishedSnapshot` only (`api.public.getPublishedSiteSettings`) |
+| Anonymous / marketing site — pricing flags | `publishedSnapshot` only (`api.public.getPublishedPricingFlags`) |
+| Studio / preview — metadata | `api.siteSettingsPreviewDraft.getPreviewSiteSettings` (draft when present, else published; owner-gated) |
+| Studio / preview — pricing flags | `api.pricingPreviewDraft.getPreviewPricingFlags` (draft when present, else published; owner-gated) |
+
+### Sections
+
+| Section | Shape | Admin editor |
+|---------|-------|--------------|
+| `settings` | `{ metadata?: { title, description } }` | `/admin/settings` |
+| `pricing`  | `{ flags: { priceTabEnabled } }`         | `/admin/pricing` |
+
+Each section has its own `cmsSections` row and therefore its own independent draft / publish lifecycle. Publishing one section never publishes another (except via `api.admin.publish.publishSite`, which explicitly iterates all sections with pending drafts).
+
+> Legacy rows whose `settings.publishedSnapshot` still contains `flags` remain schema-valid thanks to an optional `flags` field on `settingsContentValidator`. Public / preview pricing queries fall back to that legacy location when the `pricing` row hasn’t been written yet, so no migration is required before deploy.
 
 ## Mutations (shared pattern)
 

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "@tailwindcss/oxide",
     "@vercel/speed-insights",
     "unrs-resolver"
-  ]
+  ],
+  "overrides": {
+    "import-in-the-middle": "3.0.1"
+  }
 }

--- a/src/app/admin/pricing/page.tsx
+++ b/src/app/admin/pricing/page.tsx
@@ -1,5 +1,13 @@
+import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { PricingEditorSkeleton } from "./pricing-editor-skeleton";
+
+const PricingEditor = dynamic(
+  () =>
+    import("./pricing-editor").then((m) => ({ default: m.PricingEditor })),
+  { loading: () => <PricingEditorSkeleton /> },
+);
 
 export const metadata: Metadata = {
   title: "Pricing",
@@ -10,12 +18,8 @@ export default function PricingPage() {
     <>
       <AdminHeader title="Pricing" />
       <div className="flex-1 p-6">
-        <div className="mx-auto max-w-4xl">
-          <div className="rounded-lg border border-border bg-muted/50 p-8 text-center">
-            <p className="body-text text-muted-foreground">
-              Pricing management coming soon.
-            </p>
-          </div>
+        <div className="mx-auto max-w-3xl">
+          <PricingEditor />
         </div>
       </div>
     </>

--- a/src/app/admin/pricing/pricing-editor-skeleton.tsx
+++ b/src/app/admin/pricing/pricing-editor-skeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Form-shaped skeleton for pricing editor (route loading + dynamic import fallback). */
+export function PricingEditorSkeleton() {
+  return (
+    <div className="space-y-8">
+      <fieldset className="space-y-3">
+        <Skeleton className="h-3 w-20" />
+        <div className="flex items-start gap-3">
+          <Skeleton className="h-4 w-4 rounded" />
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-56" />
+            <Skeleton className="h-3 w-72" />
+          </div>
+        </div>
+      </fieldset>
+      <div className="flex flex-wrap gap-3">
+        <Skeleton className="h-9 w-28 rounded-md" />
+        <Skeleton className="h-9 w-24 rounded-md" />
+        <Skeleton className="h-9 w-36 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -12,18 +12,35 @@ import { api } from "../../../../convex/_generated/api";
 import { useCallback, useState } from "react";
 import { Effect, pipe } from "effect";
 import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 
-type SettingsContent = {
-  metadata?: { title?: string; description?: string };
+type PricingContent = {
+  flags: { priceTabEnabled: boolean };
 };
 
-const fieldClass =
-  "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/50";
+/** Narrow the unioned snapshot returned by `api.cms.getSection` to the pricing shape. */
+function toPricingContent(raw: unknown): PricingContent {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "flags" in raw &&
+    typeof (raw as { flags?: { priceTabEnabled?: unknown } }).flags
+      ?.priceTabEnabled === "boolean"
+  ) {
+    return {
+      flags: {
+        priceTabEnabled: (raw as { flags: { priceTabEnabled: boolean } }).flags
+          .priceTabEnabled,
+      },
+    };
+  }
+  return { flags: { priceTabEnabled: true } };
+}
 
-export function SettingsEditor() {
+export function PricingEditor() {
   return (
     <>
       <AuthLoading>
@@ -32,53 +49,42 @@ export function SettingsEditor() {
 
       <Unauthenticated>
         <p className="body-text text-muted-foreground">
-          Sign in to manage site settings.
+          Sign in to manage pricing visibility.
         </p>
       </Unauthenticated>
 
       <Authenticated>
-        <SettingsForm />
+        <PricingForm />
       </Authenticated>
     </>
   );
 }
 
-/**
- * Normalize whatever is stored on the `settings` row (which may still contain
- * legacy `flags`) into the metadata-only shape the editor manages.
- */
-function toSettingsContent(raw: {
-  metadata?: { title?: string; description?: string };
-}): SettingsContent {
-  return { metadata: raw.metadata };
-}
-
-function SettingsForm() {
+function PricingForm() {
   const { user } = useUser();
-  const section = useQuery(api.cms.getSection, { section: "settings" });
+  const section = useQuery(api.cms.getSection, { section: "pricing" });
   const saveDraft = useMutation(api.cms.saveDraft);
   const publish = useMutation(api.cms.publishSection);
   const discard = useMutation(api.cms.discardDraft);
 
-  const [localDraft, setLocalDraft] = useState<SettingsContent | null>(null);
+  const [localDraft, setLocalDraft] = useState<PricingContent | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [inlineError, setInlineError] = useState<string | null>(null);
 
-  const source: SettingsContent | undefined =
+  const source: PricingContent | undefined =
     localDraft ??
     (section
-      ? toSettingsContent(
-          (section.draftSnapshot ?? section.publishedSnapshot) as {
-            metadata?: { title?: string; description?: string };
-          },
-        )
+      ? toPricingContent(section.draftSnapshot ?? section.publishedSnapshot)
       : undefined);
 
-  const updateMetadata = useCallback(
-    (metadata: SettingsContent["metadata"]) => {
+  const setPriceTabEnabled = useCallback(
+    (checked: boolean) => {
       if (!source) return;
       setInlineError(null);
-      setLocalDraft({ ...source, metadata });
+      setLocalDraft({
+        ...source,
+        flags: { ...source.flags, priceTabEnabled: checked },
+      });
     },
     [source],
   );
@@ -106,7 +112,7 @@ function SettingsForm() {
     if (hasDraftOnServer) {
       setBusy("Discarding…");
       const outcome = await runAdminEffect(
-        convexMutationEffect(() => discard({ section: "settings" })),
+        convexMutationEffect(() => discard({ section: "pricing" })),
         { onErrorMessage: setInlineError },
       );
       setBusy(null);
@@ -124,12 +130,14 @@ function SettingsForm() {
   }, [discard, hasDraftOnServer]);
 
   if (section === undefined) {
-    return <p className="body-text text-muted-foreground">Loading settings…</p>;
+    return <p className="body-text text-muted-foreground">Loading pricing…</p>;
   }
 
   if (!source) {
     return (
-      <p className="body-text text-muted-foreground">No settings data available.</p>
+      <p className="body-text text-muted-foreground">
+        No pricing settings available.
+      </p>
     );
   }
 
@@ -141,67 +149,59 @@ function SettingsForm() {
   return (
     <div className="space-y-8">
       <fieldset className="space-y-3">
-        <legend className="label-text text-muted-foreground">Site Metadata</legend>
-        <label className="block space-y-1">
-          <span className="body-text-small text-muted-foreground">Title</span>
-          <input
-            type="text"
-            value={source.metadata?.title ?? ""}
-            onChange={(e) =>
-              updateMetadata({
-                ...source.metadata,
-                title: e.target.value,
-              })
-            }
-            className={fieldClass}
+        <legend className="label-text text-muted-foreground">Visibility</legend>
+        <div className="flex items-start gap-3">
+          <Switch
+            id="pricing-price-tab-enabled"
+            checked={source.flags.priceTabEnabled}
+            onCheckedChange={setPriceTabEnabled}
           />
-        </label>
-        <label className="block space-y-1">
-          <span className="body-text-small text-muted-foreground">Description</span>
-          <textarea
-            rows={3}
-            value={source.metadata?.description ?? ""}
-            onChange={(e) =>
-              updateMetadata({
-                ...source.metadata,
-                description: e.target.value,
-              })
-            }
-            className={fieldClass}
-          />
-        </label>
+          <div className="space-y-1">
+            <label
+              htmlFor="pricing-price-tab-enabled"
+              className="body-text-small cursor-pointer text-foreground"
+            >
+              Show pricing on marketing site
+            </label>
+            <p className="body-text-small text-muted-foreground">
+              Hides pricing on the public site when off. Preview still shows
+              the draft value.
+            </p>
+          </div>
+        </div>
       </fieldset>
 
       <CmsPublishToolbar
-        section="settings"
-        sectionLabel="site settings"
+        section="pricing"
+        sectionLabel="pricing visibility"
         hasDraftOnServer={hasDraftOnServer}
         hasLocalEdits={hasLocalEdits}
         publishedAt={section.publishedAt ?? null}
         publishedByLabel={publishedByLabel}
         busy={busy}
         inlineError={inlineError}
+        previewHref="/preview#services-pricing"
         onSaveDraft={() =>
           void runAction(
             "Saving…",
             convexMutationEffect(() =>
               saveDraft({
-                section: "settings",
-                content: { metadata: source.metadata },
+                section: "pricing",
+                content: { flags: source.flags },
               }),
             ),
           )
         }
         onPublish={() => {
           const publishOnce = convexMutationEffect(() =>
-            publish({ section: "settings" }),
+            publish({ section: "pricing" }),
           );
           const program = hasLocalEdits
             ? pipe(
                 convexMutationEffect(() =>
                   saveDraft({
-                    section: "settings",
-                    content: { metadata: source.metadata },
+                    section: "pricing",
+                    content: { flags: source.flags },
                   }),
                 ),
                 Effect.flatMap(() => publishOnce),

--- a/src/app/admin/settings/settings-editor-skeleton.tsx
+++ b/src/app/admin/settings/settings-editor-skeleton.tsx
@@ -5,13 +5,6 @@ export function SettingsEditorSkeleton() {
   return (
     <div className="space-y-8">
       <fieldset className="space-y-3">
-        <Skeleton className="h-3 w-24" />
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-4 w-4 rounded" />
-          <Skeleton className="h-4 w-40" />
-        </div>
-      </fieldset>
-      <fieldset className="space-y-3">
         <Skeleton className="h-3 w-28" />
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-20 w-full" />

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -18,6 +18,8 @@ import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 
 type SettingsContent = {
   metadata?: { title?: string; description?: string };
+  /** Carried through from legacy `settings` rows until a `pricing` row exists. */
+  flags?: { priceTabEnabled: boolean };
 };
 
 const fieldClass =
@@ -45,12 +47,21 @@ export function SettingsEditor() {
 
 /**
  * Normalize whatever is stored on the `settings` row (which may still contain
- * legacy `flags`) into the metadata-only shape the editor manages.
+ * legacy `flags`) for the editor. Metadata is editable; legacy `flags` are
+ * preserved on save/publish so public reads do not fall back to defaults.
  */
 function toSettingsContent(raw: {
   metadata?: { title?: string; description?: string };
+  flags?: { priceTabEnabled?: boolean };
 }): SettingsContent {
-  return { metadata: raw.metadata };
+  const out: SettingsContent = { metadata: raw.metadata };
+  if (
+    raw.flags &&
+    typeof raw.flags.priceTabEnabled === "boolean"
+  ) {
+    out.flags = { priceTabEnabled: raw.flags.priceTabEnabled };
+  }
+  return out;
 }
 
 function SettingsForm() {
@@ -70,6 +81,7 @@ function SettingsForm() {
       ? toSettingsContent(
           (section.draftSnapshot ?? section.publishedSnapshot) as {
             metadata?: { title?: string; description?: string };
+            flags?: { priceTabEnabled?: boolean };
           },
         )
       : undefined);
@@ -187,7 +199,7 @@ function SettingsForm() {
             convexMutationEffect(() =>
               saveDraft({
                 section: "settings",
-                content: { metadata: source.metadata },
+                content: source,
               }),
             ),
           )
@@ -201,7 +213,7 @@ function SettingsForm() {
                 convexMutationEffect(() =>
                   saveDraft({
                     section: "settings",
-                    content: { metadata: source.metadata },
+                    content: source,
                   }),
                 ),
                 Effect.flatMap(() => publishOnce),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,6 @@ import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
 
 export default function Home() {
-  const settings = useQuery(api.public.getPublishedSiteSettings);
-  return <HomepageShell settings={settings ?? null} />;
+  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
+  return <HomepageShell pricingFlags={pricingFlags ?? null} />;
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -7,11 +7,11 @@ import { HomepageShell } from "@/components/homepage-shell";
 import { PreviewBanner } from "@/components/preview-banner";
 
 function PreviewContent() {
-  const settings = useQuery(
-    api.siteSettingsPreviewDraft.getPreviewSiteSettings,
+  const pricingFlags = useQuery(
+    api.pricingPreviewDraft.getPreviewPricingFlags,
   );
 
-  if (settings === undefined) {
+  if (pricingFlags === undefined) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">Loading preview…</p>
@@ -19,7 +19,7 @@ function PreviewContent() {
     );
   }
 
-  if (settings === null) {
+  if (pricingFlags === null) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">
@@ -31,8 +31,10 @@ function PreviewContent() {
 
   return (
     <HomepageShell
-      settings={settings}
-      banner={<PreviewBanner hasDraftChanges={settings.hasDraftChanges} />}
+      pricingFlags={{ flags: pricingFlags.flags }}
+      banner={
+        <PreviewBanner hasDraftChanges={pricingFlags.hasDraftChanges} />
+      }
     />
   );
 }

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -9,18 +9,18 @@ import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { FAQ } from "@/components/faq";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { ServicesAndPricing } from "@/components/services-pricing";
-import type { SiteSettings } from "@/lib/site-settings";
+import type { PricingFlags } from "@/lib/site-settings";
 
 function calculateLogoScale(scrollY: number): number {
   return Math.max(0.7, 1 - scrollY * 0.0008);
 }
 
 interface HomepageShellProps {
-  readonly settings: SiteSettings | null;
+  readonly pricingFlags: PricingFlags | null;
   readonly banner?: React.ReactNode;
 }
 
-export function HomepageShell({ settings, banner }: HomepageShellProps) {
+export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
   const [scrollY, setScrollY] = useState(0);
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
@@ -58,7 +58,7 @@ export function HomepageShell({ settings, banner }: HomepageShellProps) {
     };
   }, []);
 
-  const showPricing = settings?.flags.priceTabEnabled ?? false;
+  const showPricing = pricingFlags?.flags.priceTabEnabled ?? false;
   const logoScale = calculateLogoScale(scrollY);
 
   return (

--- a/src/lib/route-prewarm.ts
+++ b/src/lib/route-prewarm.ts
@@ -88,6 +88,11 @@ export function prewarmAdminNavigation(
       makeRouteQuerySpec(api.cms.getSection, { section: "settings" }),
     ]);
   }
+  if (href === "/admin/pricing") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.cms.getSection, { section: "pricing" }),
+    ]);
+  }
 }
 
 type PrewarmFn = () => void | Promise<void>;

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -1,4 +1,4 @@
-/** Shape returned by `api.public.getPublishedSiteSettings` (landing: flags only). */
-export type SiteSettings = {
+/** Shape returned by `api.public.getPublishedPricingFlags` (marketing pricing gate). */
+export type PricingFlags = {
   flags: { priceTabEnabled: boolean };
 };


### PR DESCRIPTION
Hook up /admin/pricing to the new PricingEditor via dynamic import with a form-shaped loading skeleton. Also pin import-in-the-middle@3.0.1 via a Bun override to silence Turbopack's "Package can't be external" warnings from nested @fastify/otel and @prisma/instrumentation OTel copies.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CMS snapshot schema and public homepage/preview data sources, so regressions could hide/show pricing incorrectly or break draft/publish flows despite legacy fallbacks and runtime guards.
> 
> **Overview**
> Splits CMS content into multiple sections by introducing a new `pricing` section (for `flags.priceTabEnabled`) alongside `settings` (now metadata-focused), updating schema validators/types, publish/validation helpers, and seeding to support per-section draft/publish lifecycles with legacy fallbacks.
> 
> Wires up `/admin/pricing` to a new client-side `PricingEditor` (dynamic import + skeleton) that uses the shared draft/publish toolbar, and updates the marketing home + preview routes to read pricing visibility from new `getPublishedPricingFlags` / owner-gated `getPreviewPricingFlags` instead of the old settings flags path.
> 
> Adds a Bun/package override pinning `import-in-the-middle@3.0.1` (and associated lockfile churn) to avoid tooling warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8fb37343b196662605a7421d0ea97859ad14f65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->