### PR TITLE
[LLS] Convex pricing metadata CRUD (draft + publish) — INF-83

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as admin_pricing from "../admin/pricing.js";
 import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as cms from "../cms.js";
@@ -32,6 +33,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "admin/pricing": typeof admin_pricing;
   "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
   cms: typeof cms;

--- a/convex/admin/pricing.ts
+++ b/convex/admin/pricing.ts
@@ -63,10 +63,11 @@ function toListShape(
   if (!row) {
     return {
       flags: PRICING_DEFAULTS.flags,
+      // Drafts get the default catalog as a starting point for the editor;
+      // the public/published view stays empty until the owner publishes,
+      // matching `publishedPricingFromRows`.
       packages:
-        which === "draft"
-          ? [...DEFAULT_PRICING_PACKAGES]
-          : [...DEFAULT_PRICING_PACKAGES],
+        which === "draft" ? [...DEFAULT_PRICING_PACKAGES] : [],
       hasDraftChanges: false,
       publishedAt: null,
       publishedBy: null,

--- a/convex/admin/pricing.ts
+++ b/convex/admin/pricing.ts
@@ -1,0 +1,252 @@
+/**
+ * Admin pricing API (INF-83).
+ *
+ * Thin convenience wrappers around the shared CMS publish pipeline
+ * (`convex/cms.ts`) that scope everything to the `pricing` section and expose
+ * a packages-centric shape for the admin editor and debugging.
+ *
+ * These queries and mutations always target the `pricing` row, so callers do
+ * not need to pass a `section` argument. All owner-gate / validation rules live
+ * in the shared helpers so behavior stays consistent with `publishSite`.
+ */
+import { v } from "convex/values";
+import type { Doc } from "../_generated/dataModel";
+import { internalQuery, mutation, query } from "../_generated/server";
+import { pricingPackageValidator, siteFlagsValidator } from "../schema.shared";
+import {
+  DEFAULT_PRICING_PACKAGES,
+  PRICING_DEFAULTS,
+  cmsSnapshotsEqual,
+  type PricingPackage,
+  type PricingSnapshot,
+} from "../cmsShared";
+import {
+  collectPublishIssues,
+  ensureSectionRow,
+  publishSectionCore,
+} from "../cmsPublishHelpers";
+import { requireCmsOwner } from "../lib/auth";
+import { cmsValidationError } from "../errors";
+import { sanitizePricingPackages } from "../publicSettingsSnapshot";
+
+type PricingListShape = {
+  flags: PricingSnapshot["flags"];
+  packages: PricingPackage[];
+  hasDraftChanges: boolean;
+  publishedAt: number | null;
+  publishedBy: string | null;
+  updatedAt: number | null;
+  updatedBy: string | null;
+};
+
+function readPricingSnapshot(raw: unknown): PricingSnapshot {
+  if (raw && typeof raw === "object" && "flags" in raw) {
+    const snap = raw as Partial<PricingSnapshot>;
+    const flags =
+      snap.flags && typeof snap.flags.priceTabEnabled === "boolean"
+        ? snap.flags
+        : PRICING_DEFAULTS.flags;
+    return {
+      flags,
+      packages: sanitizePricingPackages(
+        (snap as { packages?: unknown }).packages,
+      ),
+    };
+  }
+  return PRICING_DEFAULTS;
+}
+
+function toListShape(
+  row: Doc<"cmsSections"> | null,
+  which: "draft" | "published",
+): PricingListShape {
+  if (!row) {
+    return {
+      flags: PRICING_DEFAULTS.flags,
+      packages:
+        which === "draft"
+          ? [...DEFAULT_PRICING_PACKAGES]
+          : [...DEFAULT_PRICING_PACKAGES],
+      hasDraftChanges: false,
+      publishedAt: null,
+      publishedBy: null,
+      updatedAt: null,
+      updatedBy: null,
+    };
+  }
+  const source =
+    which === "draft" ? (row.draftSnapshot ?? row.publishedSnapshot) : row.publishedSnapshot;
+  const snap = readPricingSnapshot(source);
+  return {
+    flags: snap.flags,
+    packages: snap.packages ?? [],
+    hasDraftChanges: row.hasDraftChanges,
+    publishedAt: row.publishedAt,
+    publishedBy: row.publishedBy ?? null,
+    updatedAt: row.updatedAt,
+    updatedBy: row.updatedBy ?? null,
+  };
+}
+
+/**
+ * Draft-or-published snapshot for the admin editor. Requires owner auth so we
+ * never leak draft packages to non-owners.
+ */
+export const listDraft = query({
+  args: {},
+  handler: async (ctx): Promise<PricingListShape> => {
+    await requireCmsOwner(ctx);
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "pricing"))
+      .unique();
+    return toListShape(row, "draft");
+  },
+});
+
+/**
+ * Published-only snapshot for admin dashboards / diffing. Owner-gated so this
+ * mirrors {@link listDraft} and can safely be used side-by-side in the UI.
+ */
+export const listPublished = query({
+  args: {},
+  handler: async (ctx): Promise<PricingListShape> => {
+    await requireCmsOwner(ctx);
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "pricing"))
+      .unique();
+    return toListShape(row, "published");
+  },
+});
+
+/**
+ * Persist a new draft packages + flags payload for the `pricing` section.
+ *
+ * Accepts the full set of packages (create / edit / delete done client-side
+ * by diffing this array). Server enforces id uniqueness and basic value
+ * validation before writing so drafts never land in an unpublishable state.
+ */
+export const saveDraftPricing = mutation({
+  args: {
+    flags: siteFlagsValidator,
+    packages: v.array(pricingPackageValidator),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+
+    const seenIds = new Set<string>();
+    for (const pkg of args.packages) {
+      if (pkg.id.trim().length === 0) {
+        cmsValidationError("Each pricing package requires an id.", "id");
+      }
+      if (seenIds.has(pkg.id)) {
+        cmsValidationError(
+          `Duplicate pricing package id: ${pkg.id}`,
+          "id",
+        );
+      }
+      seenIds.add(pkg.id);
+      if (pkg.name.trim().length === 0) {
+        cmsValidationError(
+          "Pricing package display name is required.",
+          "name",
+        );
+      }
+      if (
+        !Number.isFinite(pkg.priceCents) ||
+        pkg.priceCents < 0 ||
+        !Number.isInteger(pkg.priceCents)
+      ) {
+        cmsValidationError(
+          "Pricing package price must be a non-negative whole-cent integer.",
+          "priceCents",
+        );
+      }
+      if (pkg.currency.trim().length === 0) {
+        cmsValidationError(
+          "Pricing package currency is required.",
+          "currency",
+        );
+      }
+    }
+
+    const { id, row } = await ensureSectionRow(ctx, "pricing", updatedBy);
+
+    const content: PricingSnapshot = {
+      flags: args.flags,
+      packages: args.packages,
+    };
+
+    const hasDraftChanges = !cmsSnapshotsEqual(content, row.publishedSnapshot);
+    const now = Date.now();
+
+    await ctx.db.patch(id, {
+      draftSnapshot: content,
+      hasDraftChanges,
+      updatedAt: now,
+      updatedBy,
+    });
+
+    return { ok: true as const, section: "pricing" as const, hasDraftChanges };
+  },
+});
+
+/**
+ * Promote the pricing draft to published (same transactional semantics as
+ * `api.cms.publishSection({ section: "pricing" })`). Kept here so the pricing
+ * editor can call a single, pricing-specific action.
+ */
+export const publishPricing = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { identity, userId, updatedBy } = await requireCmsOwner(ctx);
+    void identity;
+    const { id, row } = await ensureSectionRow(ctx, "pricing", updatedBy);
+    return await publishSectionCore(ctx, {
+      section: "pricing",
+      id,
+      row,
+      publishedByUserId: userId,
+      updatedByTokenId: updatedBy,
+    });
+  },
+});
+
+/**
+ * Read-only preflight: check the current pricing draft (or published if no
+ * draft) against the publish validator and return any issues.
+ */
+export const validatePricing = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "pricing"))
+      .unique();
+
+    const snapshot =
+      row?.draftSnapshot ?? row?.publishedSnapshot ?? PRICING_DEFAULTS;
+    const issues = collectPublishIssues("pricing", snapshot);
+    return {
+      ok: issues.length === 0,
+      section: "pricing" as const,
+      issues,
+    };
+  },
+});
+
+/**
+ * Internal snapshot dump for owner debugging. Mirrors
+ * `internal.admin.siteSettings.debugSnapshot`.
+ */
+export const debugSnapshot = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "pricing"))
+      .unique();
+  },
+});

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -161,6 +161,17 @@ function collectPricingIssues(draft: PricingSnapshot): PublishIssue[] {
         message: "Sort order must be a finite number.",
       });
     }
+
+    if (
+      pkg.billingCadence === "custom" &&
+      (typeof pkg.unitLabel !== "string" || pkg.unitLabel.trim().length === 0)
+    ) {
+      issues.push({
+        path: `${base}.unitLabel`,
+        message:
+          "Custom cadence requires a unit label (e.g. \"per weekend\").",
+      });
+    }
   }
 
   return issues;

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -1,7 +1,6 @@
 import type { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
-  DEFAULT_PRICING_PACKAGES,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
   cmsSnapshotsEqual,
@@ -30,7 +29,10 @@ export async function getSectionRow(
  *
  * For `pricing`, we opportunistically backfill from any legacy `flags`
  * stored on the existing `settings` row so the first write doesn’t reset
- * the user’s previously-published value.
+ * the user’s previously-published value. Packages always start empty so
+ * that creating the row from a draft save never leaks default packages
+ * to the public site — the owner must explicitly publish to populate
+ * `packages`.
  */
 async function initialSnapshotForSection(
   ctx: MutationCtx,
@@ -40,13 +42,10 @@ async function initialSnapshotForSection(
     const legacy = await getSectionRow(ctx, "settings");
     const legacyFlags = (legacy?.publishedSnapshot as SettingsSnapshot | undefined)
       ?.flags;
-    if (legacyFlags) {
-      return {
-        flags: legacyFlags,
-        packages: DEFAULT_PRICING_PACKAGES,
-      } satisfies PricingSnapshot;
-    }
-    return PRICING_DEFAULTS;
+    return {
+      flags: legacyFlags ?? PRICING_DEFAULTS.flags,
+      packages: [],
+    } satisfies PricingSnapshot;
   }
   return SETTINGS_DEFAULTS;
 }

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -1,6 +1,7 @@
 import type { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
+  DEFAULT_PRICING_PACKAGES,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
   cmsSnapshotsEqual,
@@ -40,7 +41,10 @@ async function initialSnapshotForSection(
     const legacyFlags = (legacy?.publishedSnapshot as SettingsSnapshot | undefined)
       ?.flags;
     if (legacyFlags) {
-      return { flags: legacyFlags } satisfies PricingSnapshot;
+      return {
+        flags: legacyFlags,
+        packages: DEFAULT_PRICING_PACKAGES,
+      } satisfies PricingSnapshot;
     }
     return PRICING_DEFAULTS;
   }
@@ -106,6 +110,60 @@ function collectPricingIssues(draft: PricingSnapshot): PublishIssue[] {
       message: "Pricing visibility flag must be a boolean.",
     });
   }
+
+  const packages = draft.packages ?? [];
+  const seenIds = new Set<string>();
+  for (let i = 0; i < packages.length; i++) {
+    const pkg = packages[i];
+    const base = `packages[${i}]`;
+    if (typeof pkg.id !== "string" || pkg.id.trim().length === 0) {
+      issues.push({
+        path: `${base}.id`,
+        message: "Each pricing package requires a stable id.",
+      });
+    } else if (seenIds.has(pkg.id)) {
+      issues.push({
+        path: `${base}.id`,
+        message: `Duplicate package id: ${pkg.id}`,
+      });
+    } else {
+      seenIds.add(pkg.id);
+    }
+
+    if (typeof pkg.name !== "string" || pkg.name.trim().length === 0) {
+      issues.push({
+        path: `${base}.name`,
+        message: "Display name is required.",
+      });
+    }
+
+    if (
+      typeof pkg.priceCents !== "number" ||
+      !Number.isFinite(pkg.priceCents) ||
+      pkg.priceCents < 0 ||
+      !Number.isInteger(pkg.priceCents)
+    ) {
+      issues.push({
+        path: `${base}.priceCents`,
+        message: "Price must be a non-negative whole-cent value.",
+      });
+    }
+
+    if (typeof pkg.currency !== "string" || pkg.currency.trim().length === 0) {
+      issues.push({
+        path: `${base}.currency`,
+        message: "Currency code is required (e.g. USD).",
+      });
+    }
+
+    if (typeof pkg.sortOrder !== "number" || !Number.isFinite(pkg.sortOrder)) {
+      issues.push({
+        path: `${base}.sortOrder`,
+        message: "Sort order must be a finite number.",
+      });
+    }
+  }
+
   return issues;
 }
 

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -1,14 +1,18 @@
 import type { Infer } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import type {
-  settingsContentValidator,
+  pricingBillingCadenceValidator,
   pricingContentValidator,
+  pricingPackageValidator,
+  settingsContentValidator,
 } from "./schema.shared";
 
 export type CmsSection = Doc<"cmsSections">["section"];
 export type CmsSnapshot = Doc<"cmsSections">["publishedSnapshot"];
 export type SettingsSnapshot = Infer<typeof settingsContentValidator>;
 export type PricingSnapshot = Infer<typeof pricingContentValidator>;
+export type PricingPackage = Infer<typeof pricingPackageValidator>;
+export type PricingBillingCadence = Infer<typeof pricingBillingCadenceValidator>;
 
 /** Per-section default snapshots used for seeding and new-row inserts. */
 export const SETTINGS_DEFAULTS: SettingsSnapshot = {
@@ -18,12 +22,90 @@ export const SETTINGS_DEFAULTS: SettingsSnapshot = {
   },
 };
 
+/**
+ * Default catalog shipped to brand-new deployments. Mirrors the legacy
+ * hard-coded rates on `components/services-pricing.tsx` so the public site
+ * renders the familiar pricing before the owner customizes anything.
+ */
+export const DEFAULT_PRICING_PACKAGES: PricingPackage[] = [
+  {
+    id: "pkg_recording_hourly",
+    name: "Recording — Hourly",
+    description: "Pay-as-you-go tracking time with an engineer included.",
+    priceCents: 6000,
+    currency: "USD",
+    billingCadence: "hourly",
+    highlight: false,
+    sortOrder: 0,
+    isActive: true,
+    features: [
+      "Experienced engineer included",
+      "Full analog and digital signal chain",
+      "Comfortable lounge and kitchen",
+    ],
+  },
+  {
+    id: "pkg_recording_six_hour",
+    name: "Recording — 6 Hour Block",
+    description: "Half-day recording session at a discounted block rate.",
+    priceCents: 30000,
+    currency: "USD",
+    billingCadence: "six_hour_block",
+    unitLabel: "per 6-hour block",
+    highlight: true,
+    sortOrder: 1,
+    isActive: true,
+    features: [
+      "Six continuous hours in the live room",
+      "Engineer + setup included",
+      "Ideal for EP / single tracking days",
+    ],
+  },
+  {
+    id: "pkg_mixing",
+    name: "Mixing & Mastering",
+    description: "Polish tracked material into a release-ready mix + master.",
+    priceCents: 15000,
+    currency: "USD",
+    billingCadence: "per_song",
+    highlight: false,
+    sortOrder: 2,
+    isActive: true,
+    features: [
+      "Professional mixing per song",
+      "Mastering included",
+      "Stems provided on delivery",
+    ],
+  },
+];
+
 export const PRICING_DEFAULTS: PricingSnapshot = {
   flags: { priceTabEnabled: true },
+  packages: DEFAULT_PRICING_PACKAGES,
 };
 
 export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
   return section === "settings" ? SETTINGS_DEFAULTS : PRICING_DEFAULTS;
+}
+
+/** Default user-facing label for each billing cadence. */
+export function billingCadenceLabel(cadence: PricingBillingCadence): string {
+  switch (cadence) {
+    case "hourly":
+      return "per hour";
+    case "six_hour_block":
+      return "per 6-hour block";
+    case "daily":
+      return "per day";
+    case "per_song":
+      return "per song";
+    case "per_album":
+      return "per album";
+    case "per_project":
+      return "per project";
+    case "flat":
+      return "flat rate";
+  }
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -88,7 +88,13 @@ export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
   return section === "settings" ? SETTINGS_DEFAULTS : PRICING_DEFAULTS;
 }
 
-/** Default user-facing label for each billing cadence. */
+/**
+ * Default user-facing label for each billing cadence.
+ *
+ * For the `"custom"` variant, callers should pass the package's `unitLabel`
+ * directly — this helper returns an empty string as a sentinel so ignoring
+ * the custom case is visible (never a plausible-but-wrong label).
+ */
 export function billingCadenceLabel(cadence: PricingBillingCadence): string {
   switch (cadence) {
     case "hourly":
@@ -105,6 +111,8 @@ export function billingCadenceLabel(cadence: PricingBillingCadence): string {
       return "per project";
     case "flat":
       return "flat rate";
+    case "custom":
+      return "";
   }
 }
 

--- a/convex/pricing.test.ts
+++ b/convex/pricing.test.ts
@@ -73,6 +73,39 @@ describe("collectPublishIssues(pricing)", () => {
     const issues = collectPublishIssues("pricing", snapshot);
     expect(issues).toEqual([]);
   });
+
+  test("custom cadence without unitLabel is an issue", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+      packages: [
+        {
+          ...validPackage(),
+          id: "pkg_custom",
+          billingCadence: "custom",
+        },
+      ],
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues.map((i) => i.path)).toEqual(
+      expect.arrayContaining(["packages[0].unitLabel"]),
+    );
+  });
+
+  test("custom cadence with unitLabel passes validation", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+      packages: [
+        {
+          ...validPackage(),
+          id: "pkg_custom_ok",
+          billingCadence: "custom",
+          unitLabel: "per weekend lockout",
+        },
+      ],
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues).toEqual([]);
+  });
 });
 
 describe("sanitizePricingPackages", () => {
@@ -94,6 +127,23 @@ describe("sanitizePricingPackages", () => {
       "not an object",
     ]);
     expect(sorted.map((p) => p.id)).toEqual(["pkg_1"]);
+  });
+
+  test("drops custom-cadence rows that lack a unitLabel", () => {
+    const sorted = sanitizePricingPackages([
+      {
+        ...validPackage(),
+        id: "custom_missing_label",
+        billingCadence: "custom",
+      },
+      {
+        ...validPackage(),
+        id: "custom_ok",
+        billingCadence: "custom",
+        unitLabel: "per lockout",
+      },
+    ]);
+    expect(sorted.map((p) => p.id)).toEqual(["custom_ok"]);
   });
 
   test("returns empty array for non-array input", () => {
@@ -119,5 +169,9 @@ describe("billingCadenceLabel", () => {
     expect(billingCadenceLabel("hourly")).toMatch(/hour/i);
     expect(billingCadenceLabel("six_hour_block")).toMatch(/6-hour/);
     expect(billingCadenceLabel("per_song")).toMatch(/song/);
+  });
+
+  test("returns empty string for custom so callers fall back to unitLabel", () => {
+    expect(billingCadenceLabel("custom")).toBe("");
   });
 });

--- a/convex/pricing.test.ts
+++ b/convex/pricing.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { collectPublishIssues } from "./cmsPublishHelpers";
+import type { PricingSnapshot } from "./cmsShared";
+import {
+  billingCadenceLabel,
+  DEFAULT_PRICING_PACKAGES,
+  PRICING_DEFAULTS,
+} from "./cmsShared";
+import { sanitizePricingPackages } from "./publicSettingsSnapshot";
+
+const validPackage = () => ({
+  id: "pkg_1",
+  name: "Recording — Hourly",
+  priceCents: 6000,
+  currency: "USD",
+  billingCadence: "hourly" as const,
+  highlight: true,
+  sortOrder: 0,
+  isActive: true,
+});
+
+describe("collectPublishIssues(pricing)", () => {
+  test("defaults and valid packages produce no issues", () => {
+    const issues = collectPublishIssues("pricing", PRICING_DEFAULTS);
+    expect(issues).toEqual([]);
+  });
+
+  test("detects duplicate package ids", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+      packages: [validPackage(), { ...validPackage(), name: "Dup" }],
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues.some((i) => i.message.includes("Duplicate package id"))).toBe(
+      true,
+    );
+  });
+
+  test("detects missing name and negative price", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+      packages: [
+        {
+          ...validPackage(),
+          id: "pkg_bad",
+          name: "   ",
+          priceCents: -1,
+        },
+      ],
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues.map((i) => i.path)).toEqual(
+      expect.arrayContaining([
+        "packages[0].name",
+        "packages[0].priceCents",
+      ]),
+    );
+  });
+
+  test("detects non-integer cent values", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+      packages: [{ ...validPackage(), priceCents: 99.5 }],
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues.some((i) => i.path === "packages[0].priceCents")).toBe(true);
+  });
+
+  test("missing packages array is treated as empty", () => {
+    const snapshot: PricingSnapshot = {
+      flags: { priceTabEnabled: true },
+    };
+    const issues = collectPublishIssues("pricing", snapshot);
+    expect(issues).toEqual([]);
+  });
+});
+
+describe("sanitizePricingPackages", () => {
+  test("sorts by sortOrder then name", () => {
+    const sorted = sanitizePricingPackages([
+      { ...validPackage(), id: "c", name: "Cello", sortOrder: 1 },
+      { ...validPackage(), id: "a", name: "Apple", sortOrder: 0 },
+      { ...validPackage(), id: "b", name: "Banana", sortOrder: 0 },
+    ]);
+    expect(sorted.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("drops malformed rows", () => {
+    const sorted = sanitizePricingPackages([
+      validPackage(),
+      { ...validPackage(), id: "broken", priceCents: -5 },
+      { ...validPackage(), id: "bad_cadence", billingCadence: "weekly" },
+      null,
+      "not an object",
+    ]);
+    expect(sorted.map((p) => p.id)).toEqual(["pkg_1"]);
+  });
+
+  test("returns empty array for non-array input", () => {
+    expect(sanitizePricingPackages(undefined)).toEqual([]);
+    expect(sanitizePricingPackages(null)).toEqual([]);
+    expect(sanitizePricingPackages({})).toEqual([]);
+  });
+});
+
+describe("defaults", () => {
+  test("ship with at least one highlighted package", () => {
+    expect(DEFAULT_PRICING_PACKAGES.some((p) => p.highlight)).toBe(true);
+  });
+
+  test("have unique ids", () => {
+    const ids = DEFAULT_PRICING_PACKAGES.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("billingCadenceLabel", () => {
+  test("returns a human label for every cadence", () => {
+    expect(billingCadenceLabel("hourly")).toMatch(/hour/i);
+    expect(billingCadenceLabel("six_hour_block")).toMatch(/6-hour/);
+    expect(billingCadenceLabel("per_song")).toMatch(/song/);
+  });
+});

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -27,6 +27,7 @@ const VALID_CADENCES = new Set<PricingPackage["billingCadence"]>([
   "per_album",
   "per_project",
   "flat",
+  "custom",
 ]);
 
 function isValidPackage(value: unknown): value is PricingPackage {
@@ -63,6 +64,12 @@ function isValidPackage(value: unknown): value is PricingPackage {
     typeof v.unitLabel !== "string"
   )
     return false;
+  if (
+    v.billingCadence === "custom" &&
+    (typeof v.unitLabel !== "string" || v.unitLabel.trim().length === 0)
+  ) {
+    return false;
+  }
   if (v.features !== undefined && v.features !== null) {
     if (!Array.isArray(v.features)) return false;
     if (!v.features.every((f) => typeof f === "string")) return false;

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -2,6 +2,7 @@ import type { Doc } from "./_generated/dataModel";
 import {
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
+  type PricingPackage,
   type PricingSnapshot,
   type SettingsSnapshot,
 } from "./cmsShared";
@@ -18,13 +19,85 @@ function isValidFlags(value: unknown): value is SettingsFlags {
   );
 }
 
+const VALID_CADENCES = new Set<PricingPackage["billingCadence"]>([
+  "hourly",
+  "six_hour_block",
+  "daily",
+  "per_song",
+  "per_album",
+  "per_project",
+  "flat",
+]);
+
+function isValidPackage(value: unknown): value is PricingPackage {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== "string" || v.id.trim().length === 0) return false;
+  if (typeof v.name !== "string" || v.name.trim().length === 0) return false;
+  if (
+    typeof v.priceCents !== "number" ||
+    !Number.isFinite(v.priceCents) ||
+    v.priceCents < 0
+  )
+    return false;
+  if (typeof v.currency !== "string" || v.currency.trim().length === 0)
+    return false;
+  if (
+    typeof v.billingCadence !== "string" ||
+    !VALID_CADENCES.has(v.billingCadence as PricingPackage["billingCadence"])
+  )
+    return false;
+  if (typeof v.highlight !== "boolean") return false;
+  if (typeof v.sortOrder !== "number" || !Number.isFinite(v.sortOrder))
+    return false;
+  if (typeof v.isActive !== "boolean") return false;
+  if (
+    v.description !== undefined &&
+    v.description !== null &&
+    typeof v.description !== "string"
+  )
+    return false;
+  if (
+    v.unitLabel !== undefined &&
+    v.unitLabel !== null &&
+    typeof v.unitLabel !== "string"
+  )
+    return false;
+  if (v.features !== undefined && v.features !== null) {
+    if (!Array.isArray(v.features)) return false;
+    if (!v.features.every((f) => typeof f === "string")) return false;
+  }
+  return true;
+}
+
+/** Keep only packages the public should see, sorted by `sortOrder` then name. */
+export function sanitizePricingPackages(raw: unknown): PricingPackage[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PricingPackage[] = [];
+  for (const item of raw) {
+    if (isValidPackage(item)) {
+      out.push(item);
+    }
+  }
+  out.sort((a, b) => {
+    if (a.sortOrder !== b.sortOrder) {
+      return a.sortOrder - b.sortOrder;
+    }
+    return a.name.localeCompare(b.name);
+  });
+  return out;
+}
+
 /**
- * Returns safe published pricing flags for public readers.
+ * Returns safe published pricing data for public readers.
  *
- * Resolution order:
+ * Flag resolution order:
  * 1. `pricing` row's `publishedSnapshot.flags` (new split schema), when valid.
  * 2. Legacy `settings` row's `publishedSnapshot.flags` (pre-split), when valid.
  * 3. `PRICING_DEFAULTS`.
+ *
+ * Packages come from the `pricing` row when present and valid; legacy rows
+ * never stored packages so this is always `[]` until the first pricing publish.
  *
  * Falling back to legacy is what keeps the site rendering correctly for
  * deployments that haven't yet written to the pricing section.
@@ -32,24 +105,35 @@ function isValidFlags(value: unknown): value is SettingsFlags {
 export function publishedPricingFromRows(
   pricingRow: Doc<"cmsSections"> | null,
   settingsRow: Doc<"cmsSections"> | null,
-): { flags: SettingsFlags } {
+): { flags: SettingsFlags; packages: PricingPackage[] } {
+  let flags: SettingsFlags | null = null;
+  let packages: PricingPackage[] = [];
+
   const pricingSnap = pricingRow?.publishedSnapshot as unknown;
   if (pricingSnap && typeof pricingSnap === "object") {
     const rawFlags = (pricingSnap as { flags?: unknown }).flags;
     if (isValidFlags(rawFlags)) {
-      return { flags: rawFlags };
+      flags = rawFlags;
+    }
+    packages = sanitizePricingPackages(
+      (pricingSnap as { packages?: unknown }).packages,
+    );
+  }
+
+  if (flags === null) {
+    const settingsSnap = settingsRow?.publishedSnapshot as unknown;
+    if (settingsSnap && typeof settingsSnap === "object") {
+      const rawFlags = (settingsSnap as { flags?: unknown }).flags;
+      if (isValidFlags(rawFlags)) {
+        flags = rawFlags;
+      }
     }
   }
 
-  const settingsSnap = settingsRow?.publishedSnapshot as unknown;
-  if (settingsSnap && typeof settingsSnap === "object") {
-    const rawFlags = (settingsSnap as { flags?: unknown }).flags;
-    if (isValidFlags(rawFlags)) {
-      return { flags: rawFlags };
-    }
-  }
-
-  return { flags: PRICING_DEFAULTS.flags };
+  return {
+    flags: flags ?? PRICING_DEFAULTS.flags,
+    packages,
+  };
 }
 
 /**

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -19,12 +19,17 @@ export const siteMetadataValidator = v.object({
 
 /**
  * Allowed billing cadences for a pricing package. `hourly` and `six_hour_block`
- * cover the studio's most common rate shapes; additional cadences are included
+ * cover the studio's most common rate shapes; additional presets are included
  * so mixing / mastering / production rows can describe their pricing naturally.
  *
+ * The `"custom"` variant lets the owner author any cadence string via the
+ * package's `unitLabel` field — the UI surfaces it as a "Custom…" option that
+ * pairs with the free-form unit label input, and publish validation requires
+ * `unitLabel` to be non-empty whenever `billingCadence === "custom"`.
+ *
  * Consumers should render a human label via `billingCadenceLabel` in
- * `cmsShared.ts` (or customize via the optional `unitLabel` override on the
- * package itself).
+ * `cmsShared.ts` (which returns the `unitLabel` for custom rows) or bypass it
+ * entirely by reading `unitLabel` directly.
  */
 export const pricingBillingCadenceValidator = v.union(
   v.literal("hourly"),
@@ -34,6 +39,7 @@ export const pricingBillingCadenceValidator = v.union(
   v.literal("per_album"),
   v.literal("per_project"),
   v.literal("flat"),
+  v.literal("custom"),
 );
 
 /**

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -6,7 +6,7 @@ import { v } from "convex/values";
  *
  * Sections today:
  * - `settings`  — site metadata (title, description; extend as CMS grows).
- * - `pricing`   — feature flags that govern pricing surfaces on the marketing site.
+ * - `pricing`   — feature flags and package/rate catalog that govern pricing surfaces.
  */
 export const siteFlagsValidator = v.object({
   priceTabEnabled: v.boolean(),
@@ -15,6 +15,52 @@ export const siteFlagsValidator = v.object({
 export const siteMetadataValidator = v.object({
   title: v.optional(v.string()),
   description: v.optional(v.string()),
+});
+
+/**
+ * Allowed billing cadences for a pricing package. `hourly` and `six_hour_block`
+ * cover the studio's most common rate shapes; additional cadences are included
+ * so mixing / mastering / production rows can describe their pricing naturally.
+ *
+ * Consumers should render a human label via `billingCadenceLabel` in
+ * `cmsShared.ts` (or customize via the optional `unitLabel` override on the
+ * package itself).
+ */
+export const pricingBillingCadenceValidator = v.union(
+  v.literal("hourly"),
+  v.literal("six_hour_block"),
+  v.literal("daily"),
+  v.literal("per_song"),
+  v.literal("per_album"),
+  v.literal("per_project"),
+  v.literal("flat"),
+);
+
+/**
+ * Pricing package / rate row authored in the CMS. Stored inline on the
+ * `pricing` section snapshot so publish remains a single atomic patch.
+ *
+ * - `id` is a stable client-generated identifier (e.g. `crypto.randomUUID()`)
+ *   used so the editor can track rows across edits and reorders without
+ *   depending on array position. It is NOT a Convex document id.
+ * - `priceCents` is an integer so we never have to deal with floating-point
+ *   rounding on the display side. Currency format is left to the client.
+ * - `unitLabel` optionally overrides the cadence's default display label
+ *   (e.g. "per mixed song").
+ * - `features` is an ordered bullet list rendered in the public card UI.
+ */
+export const pricingPackageValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  description: v.optional(v.string()),
+  priceCents: v.number(),
+  currency: v.string(),
+  billingCadence: pricingBillingCadenceValidator,
+  unitLabel: v.optional(v.string()),
+  highlight: v.boolean(),
+  sortOrder: v.number(),
+  isActive: v.boolean(),
+  features: v.optional(v.array(v.string())),
 });
 
 /**
@@ -31,9 +77,15 @@ export const settingsContentValidator = v.object({
   flags: v.optional(siteFlagsValidator),
 });
 
-/** "pricing" section snapshot — flags only. */
+/**
+ * "pricing" section snapshot.
+ *
+ * `packages` is optional for back-compat with legacy rows that only stored the
+ * feature `flags`; consumers should treat `undefined` as an empty array.
+ */
 export const pricingContentValidator = v.object({
   flags: siteFlagsValidator,
+  packages: v.optional(v.array(pricingPackageValidator)),
 });
 
 /** Any section's snapshot payload — discriminated at runtime by the row's `section`. */

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -13,5 +13,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["./**/*"]
+  "include": ["./**/*"],
+  "exclude": ["./**/*.test.ts"]
 }

--- a/src/app/admin/pricing/pricing-editor-skeleton.tsx
+++ b/src/app/admin/pricing/pricing-editor-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 /** Form-shaped skeleton for pricing editor (route loading + dynamic import fallback). */
 export function PricingEditorSkeleton() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       <fieldset className="space-y-3">
         <Skeleton className="h-3 w-20" />
         <div className="flex items-start gap-3">
@@ -14,6 +14,24 @@ export function PricingEditorSkeleton() {
           </div>
         </div>
       </fieldset>
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-8 w-32 rounded-md" />
+        </div>
+        <div className="space-y-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="rounded-lg border border-border p-4">
+              <div className="grid gap-3 md:grid-cols-2">
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
       <div className="flex flex-wrap gap-3">
         <Skeleton className="h-9 w-28 rounded-md" />
         <Skeleton className="h-9 w-24 rounded-md" />

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -9,35 +9,114 @@ import {
 } from "convex/react";
 import { useUser } from "@clerk/nextjs";
 import { api } from "../../../../convex/_generated/api";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Effect, pipe } from "effect";
 import { toast } from "sonner";
+import { ArrowDown, ArrowUp, Plus, Star, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 
-type PricingContent = {
-  flags: { priceTabEnabled: boolean };
+type BillingCadence =
+  | "hourly"
+  | "six_hour_block"
+  | "daily"
+  | "per_song"
+  | "per_album"
+  | "per_project"
+  | "flat";
+
+type PricingPackage = {
+  id: string;
+  name: string;
+  description?: string;
+  priceCents: number;
+  currency: string;
+  billingCadence: BillingCadence;
+  unitLabel?: string;
+  highlight: boolean;
+  sortOrder: number;
+  isActive: boolean;
+  features?: string[];
 };
 
-/** Narrow the unioned snapshot returned by `api.cms.getSection` to the pricing shape. */
-function toPricingContent(raw: unknown): PricingContent {
-  if (
-    raw &&
-    typeof raw === "object" &&
-    "flags" in raw &&
-    typeof (raw as { flags?: { priceTabEnabled?: unknown } }).flags
-      ?.priceTabEnabled === "boolean"
-  ) {
-    return {
-      flags: {
-        priceTabEnabled: (raw as { flags: { priceTabEnabled: boolean } }).flags
-          .priceTabEnabled,
-      },
-    };
+type PricingContent = {
+  flags: { priceTabEnabled: boolean };
+  packages: PricingPackage[];
+};
+
+const VALID_CADENCES: readonly BillingCadence[] = [
+  "hourly",
+  "six_hour_block",
+  "daily",
+  "per_song",
+  "per_album",
+  "per_project",
+  "flat",
+] as const;
+
+const CADENCE_LABELS: Record<BillingCadence, string> = {
+  hourly: "Per hour",
+  six_hour_block: "Per 6-hour block",
+  daily: "Per day",
+  per_song: "Per song",
+  per_album: "Per album",
+  per_project: "Per project",
+  flat: "Flat rate",
+};
+
+function isCadence(value: string): value is BillingCadence {
+  return (VALID_CADENCES as readonly string[]).includes(value);
+}
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `pkg_${crypto.randomUUID()}`;
   }
-  return { flags: { priceTabEnabled: true } };
+  return `pkg_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+function toPricingContent(raw: {
+  flags: { priceTabEnabled: boolean };
+  packages: PricingPackage[];
+}): PricingContent {
+  return {
+    flags: { priceTabEnabled: raw.flags.priceTabEnabled },
+    packages: raw.packages.map((p) => ({
+      id: p.id,
+      name: p.name,
+      description: p.description,
+      priceCents: p.priceCents,
+      currency: p.currency,
+      billingCadence: p.billingCadence,
+      unitLabel: p.unitLabel,
+      highlight: p.highlight,
+      sortOrder: p.sortOrder,
+      isActive: p.isActive,
+      features: p.features ? [...p.features] : undefined,
+    })),
+  };
+}
+
+function renumberSortOrder(packages: PricingPackage[]): PricingPackage[] {
+  return packages.map((p, idx) => ({ ...p, sortOrder: idx }));
+}
+
+function priceCentsToDisplay(cents: number): string {
+  if (!Number.isFinite(cents)) return "";
+  return (cents / 100).toFixed(2);
+}
+
+function parsePriceInput(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const num = Number(trimmed);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return Math.round(num * 100);
 }
 
 export function PricingEditor() {
@@ -49,7 +128,7 @@ export function PricingEditor() {
 
       <Unauthenticated>
         <p className="body-text text-muted-foreground">
-          Sign in to manage pricing visibility.
+          Sign in to manage pricing.
         </p>
       </Unauthenticated>
 
@@ -62,31 +141,119 @@ export function PricingEditor() {
 
 function PricingForm() {
   const { user } = useUser();
-  const section = useQuery(api.cms.getSection, { section: "pricing" });
-  const saveDraft = useMutation(api.cms.saveDraft);
-  const publish = useMutation(api.cms.publishSection);
+  const pricing = useQuery(api.admin.pricing.listDraft);
+  const saveDraft = useMutation(api.admin.pricing.saveDraftPricing);
+  const publish = useMutation(api.admin.pricing.publishPricing);
   const discard = useMutation(api.cms.discardDraft);
 
   const [localDraft, setLocalDraft] = useState<PricingContent | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [inlineError, setInlineError] = useState<string | null>(null);
 
-  const source: PricingContent | undefined =
-    localDraft ??
-    (section
-      ? toPricingContent(section.draftSnapshot ?? section.publishedSnapshot)
-      : undefined);
+  const source: PricingContent | undefined = useMemo(() => {
+    if (localDraft) return localDraft;
+    if (!pricing) return undefined;
+    return toPricingContent({
+      flags: pricing.flags,
+      packages: pricing.packages as PricingPackage[],
+    });
+  }, [localDraft, pricing]);
+
+  const mutate = useCallback(
+    (next: PricingContent) => {
+      setInlineError(null);
+      setLocalDraft(next);
+    },
+    [],
+  );
 
   const setPriceTabEnabled = useCallback(
     (checked: boolean) => {
       if (!source) return;
-      setInlineError(null);
-      setLocalDraft({
+      mutate({
         ...source,
         flags: { ...source.flags, priceTabEnabled: checked },
       });
     },
-    [source],
+    [source, mutate],
+  );
+
+  const addPackage = useCallback(() => {
+    if (!source) return;
+    const next: PricingPackage = {
+      id: generateId(),
+      name: "New package",
+      description: "",
+      priceCents: 0,
+      currency: "USD",
+      billingCadence: "hourly",
+      highlight: false,
+      sortOrder: source.packages.length,
+      isActive: true,
+      features: [],
+    };
+    mutate({
+      ...source,
+      packages: renumberSortOrder([...source.packages, next]),
+    });
+  }, [source, mutate]);
+
+  const updatePackage = useCallback(
+    (id: string, patch: Partial<PricingPackage>) => {
+      if (!source) return;
+      mutate({
+        ...source,
+        packages: source.packages.map((p) =>
+          p.id === id ? { ...p, ...patch } : p,
+        ),
+      });
+    },
+    [source, mutate],
+  );
+
+  const removePackage = useCallback(
+    (id: string) => {
+      if (!source) return;
+      mutate({
+        ...source,
+        packages: renumberSortOrder(
+          source.packages.filter((p) => p.id !== id),
+        ),
+      });
+    },
+    [source, mutate],
+  );
+
+  const movePackage = useCallback(
+    (id: string, direction: -1 | 1) => {
+      if (!source) return;
+      const idx = source.packages.findIndex((p) => p.id === id);
+      if (idx === -1) return;
+      const target = idx + direction;
+      if (target < 0 || target >= source.packages.length) return;
+      const next = [...source.packages];
+      const [moved] = next.splice(idx, 1);
+      next.splice(target, 0, moved);
+      mutate({
+        ...source,
+        packages: renumberSortOrder(next),
+      });
+    },
+    [source, mutate],
+  );
+
+  const toggleHighlight = useCallback(
+    (id: string) => {
+      if (!source) return;
+      mutate({
+        ...source,
+        packages: source.packages.map((p) => ({
+          ...p,
+          highlight: p.id === id ? !p.highlight : false,
+        })),
+      });
+    },
+    [source, mutate],
   );
 
   const runAction = useCallback(
@@ -105,7 +272,7 @@ function PricingForm() {
     [],
   );
 
-  const hasDraftOnServer = section?.hasDraftChanges ?? false;
+  const hasDraftOnServer = pricing?.hasDraftChanges ?? false;
 
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
@@ -129,7 +296,7 @@ function PricingForm() {
     return true;
   }, [discard, hasDraftOnServer]);
 
-  if (section === undefined) {
+  if (pricing === undefined) {
     return <p className="body-text text-muted-foreground">Loading pricing…</p>;
   }
 
@@ -142,12 +309,18 @@ function PricingForm() {
   }
 
   const hasLocalEdits = localDraft !== null;
-
   const publishedByLabel =
-    section.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
+    pricing.publishedBy && user?.id === pricing.publishedBy ? "You" : undefined;
+
+  const saveDraftProgram = convexMutationEffect(() =>
+    saveDraft({
+      flags: source.flags,
+      packages: source.packages,
+    }),
+  );
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       <fieldset className="space-y-3">
         <legend className="label-text text-muted-foreground">Visibility</legend>
         <div className="flex items-start gap-3">
@@ -171,41 +344,266 @@ function PricingForm() {
         </div>
       </fieldset>
 
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Packages &amp; rates</h2>
+            <p className="body-text-small text-muted-foreground">
+              Hourly, 6-hour-block, or any other cadence. The highlighted row
+              is emphasized on the public site as the recommended package.
+            </p>
+          </div>
+          <Button type="button" variant="outline" onClick={addPackage}>
+            <Plus className="mr-1 size-4" aria-hidden />
+            Add package
+          </Button>
+        </div>
+
+        {source.packages.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            No packages yet. Click “Add package” to create the first one.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {source.packages.map((pkg, idx) => (
+              <li
+                key={pkg.id}
+                className={cn(
+                  "rounded-lg border p-4 shadow-sm transition-colors",
+                  pkg.highlight
+                    ? "border-primary/60 bg-primary/5"
+                    : "border-border bg-background",
+                  !pkg.isActive && "opacity-60",
+                )}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <span className="font-mono text-xs">#{idx + 1}</span>
+                    {pkg.highlight ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
+                        <Star className="size-3" aria-hidden /> Recommended
+                      </span>
+                    ) : null}
+                    {!pkg.isActive ? (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Hidden
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Move up"
+                      disabled={idx === 0}
+                      onClick={() => movePackage(pkg.id, -1)}
+                    >
+                      <ArrowUp className="size-4" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Move down"
+                      disabled={idx === source.packages.length - 1}
+                      onClick={() => movePackage(pkg.id, 1)}
+                    >
+                      <ArrowDown className="size-4" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Delete package"
+                      onClick={() => removePackage(pkg.id)}
+                    >
+                      <Trash2 className="size-4 text-destructive" aria-hidden />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+                  <label className="block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Name
+                    </span>
+                    <Input
+                      type="text"
+                      value={pkg.name}
+                      onChange={(e) =>
+                        updatePackage(pkg.id, { name: e.target.value })
+                      }
+                      placeholder="Recording — Hourly"
+                    />
+                  </label>
+
+                  <label className="block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Cadence
+                    </span>
+                    <select
+                      value={pkg.billingCadence}
+                      onChange={(e) => {
+                        const raw = e.target.value;
+                        if (isCadence(raw)) {
+                          updatePackage(pkg.id, { billingCadence: raw });
+                        }
+                      }}
+                      className={cn(
+                        "h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm",
+                      )}
+                    >
+                      {VALID_CADENCES.map((c) => (
+                        <option key={c} value={c}>
+                          {CADENCE_LABELS[c]}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Price
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        aria-label="Price amount"
+                        value={priceCentsToDisplay(pkg.priceCents)}
+                        onChange={(e) => {
+                          const next = parsePriceInput(e.target.value);
+                          if (next === null) {
+                            if (e.target.value.trim() === "") {
+                              updatePackage(pkg.id, { priceCents: 0 });
+                            }
+                            return;
+                          }
+                          updatePackage(pkg.id, { priceCents: next });
+                        }}
+                        className="flex-1"
+                      />
+                      <Input
+                        type="text"
+                        aria-label="Currency"
+                        value={pkg.currency}
+                        maxLength={6}
+                        onChange={(e) =>
+                          updatePackage(pkg.id, {
+                            currency: e.target.value.toUpperCase(),
+                          })
+                        }
+                        className="w-20"
+                      />
+                    </div>
+                  </label>
+
+                  <label className="block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Unit label (optional)
+                    </span>
+                    <Input
+                      type="text"
+                      value={pkg.unitLabel ?? ""}
+                      onChange={(e) =>
+                        updatePackage(pkg.id, {
+                          unitLabel:
+                            e.target.value.trim() === ""
+                              ? undefined
+                              : e.target.value,
+                        })
+                      }
+                      placeholder={CADENCE_LABELS[pkg.billingCadence]}
+                    />
+                  </label>
+
+                  <label className="col-span-full block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Description
+                    </span>
+                    <textarea
+                      rows={2}
+                      value={pkg.description ?? ""}
+                      onChange={(e) =>
+                        updatePackage(pkg.id, {
+                          description:
+                            e.target.value.trim() === ""
+                              ? undefined
+                              : e.target.value,
+                        })
+                      }
+                      className="block w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+                    />
+                  </label>
+
+                  <label className="col-span-full block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Features (one per line)
+                    </span>
+                    <textarea
+                      rows={3}
+                      value={(pkg.features ?? []).join("\n")}
+                      onChange={(e) => {
+                        const lines = e.target.value
+                          .split("\n")
+                          .map((line) => line.replace(/^[•\-\*]\s*/, ""));
+                        updatePackage(pkg.id, { features: lines });
+                      }}
+                      onBlur={(e) => {
+                        const cleaned = e.target.value
+                          .split("\n")
+                          .map((line) => line.trim())
+                          .filter((line) => line.length > 0);
+                        updatePackage(pkg.id, {
+                          features: cleaned.length > 0 ? cleaned : undefined,
+                        });
+                      }}
+                      className="block w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+                      placeholder={"Experienced engineer included\nFull signal chain\nKitchen & lounge access"}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center gap-4">
+                  <label className="flex items-center gap-2 text-sm">
+                    <Switch
+                      checked={pkg.highlight}
+                      onCheckedChange={() => toggleHighlight(pkg.id)}
+                    />
+                    Recommended
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <Switch
+                      checked={pkg.isActive}
+                      onCheckedChange={(checked) =>
+                        updatePackage(pkg.id, { isActive: checked })
+                      }
+                    />
+                    Show on site
+                  </label>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
       <CmsPublishToolbar
         section="pricing"
-        sectionLabel="pricing visibility"
+        sectionLabel="pricing"
         hasDraftOnServer={hasDraftOnServer}
         hasLocalEdits={hasLocalEdits}
-        publishedAt={section.publishedAt ?? null}
+        publishedAt={pricing.publishedAt ?? null}
         publishedByLabel={publishedByLabel}
         busy={busy}
         inlineError={inlineError}
         previewHref="/preview#services-pricing"
-        onSaveDraft={() =>
-          void runAction(
-            "Saving…",
-            convexMutationEffect(() =>
-              saveDraft({
-                section: "pricing",
-                content: { flags: source.flags },
-              }),
-            ),
-          )
-        }
+        onSaveDraft={() => void runAction("Saving…", saveDraftProgram)}
         onPublish={() => {
-          const publishOnce = convexMutationEffect(() =>
-            publish({ section: "pricing" }),
-          );
+          const publishOnce = convexMutationEffect(() => publish({}));
           const program = hasLocalEdits
-            ? pipe(
-                convexMutationEffect(() =>
-                  saveDraft({
-                    section: "pricing",
-                    content: { flags: source.flags },
-                  }),
-                ),
-                Effect.flatMap(() => publishOnce),
-              )
+            ? pipe(saveDraftProgram, Effect.flatMap(() => publishOnce))
             : publishOnce;
           return void runAction("Publishing…", program);
         }}

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -12,7 +12,15 @@ import { api } from "../../../../convex/_generated/api";
 import { useCallback, useMemo, useState } from "react";
 import { Effect, pipe } from "effect";
 import { toast } from "sonner";
-import { ArrowDown, ArrowUp, Plus, Star, Trash2 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  Plus,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -442,24 +450,30 @@ function PricingForm() {
                     <span className="body-text-small text-muted-foreground">
                       Cadence
                     </span>
-                    <select
-                      value={pkg.billingCadence}
-                      onChange={(e) => {
-                        const raw = e.target.value;
-                        if (isCadence(raw)) {
-                          updatePackage(pkg.id, { billingCadence: raw });
-                        }
-                      }}
-                      className={cn(
-                        "h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm",
-                      )}
-                    >
-                      {VALID_CADENCES.map((c) => (
-                        <option key={c} value={c}>
-                          {CADENCE_LABELS[c]}
-                        </option>
-                      ))}
-                    </select>
+                    <div className="relative">
+                      <select
+                        value={pkg.billingCadence}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          if (isCadence(raw)) {
+                            updatePackage(pkg.id, { billingCadence: raw });
+                          }
+                        }}
+                        className={cn(
+                          "h-8 w-full min-w-0 appearance-none rounded-lg border border-input bg-background px-2.5 pr-8 py-1 text-sm font-medium text-foreground transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm dark:bg-input/30",
+                        )}
+                      >
+                        {VALID_CADENCES.map((c) => (
+                          <option key={c} value={c}>
+                            {CADENCE_LABELS[c]}
+                          </option>
+                        ))}
+                      </select>
+                      <ChevronDown
+                        className="pointer-events-none absolute top-1/2 right-2 size-4 -translate-y-1/2 text-muted-foreground"
+                        aria-hidden
+                      />
+                    </div>
                   </label>
 
                   <label className="block space-y-1">
@@ -537,32 +551,19 @@ function PricingForm() {
                     />
                   </label>
 
-                  <label className="col-span-full block space-y-1">
+                  <div className="col-span-full space-y-2">
                     <span className="body-text-small text-muted-foreground">
-                      Features (one per line)
+                      Features
                     </span>
-                    <textarea
-                      rows={3}
-                      value={(pkg.features ?? []).join("\n")}
-                      onChange={(e) => {
-                        const lines = e.target.value
-                          .split("\n")
-                          .map((line) => line.replace(/^[•\-\*]\s*/, ""));
-                        updatePackage(pkg.id, { features: lines });
-                      }}
-                      onBlur={(e) => {
-                        const cleaned = e.target.value
-                          .split("\n")
-                          .map((line) => line.trim())
-                          .filter((line) => line.length > 0);
+                    <FeaturesEditor
+                      features={pkg.features ?? []}
+                      onChange={(next) =>
                         updatePackage(pkg.id, {
-                          features: cleaned.length > 0 ? cleaned : undefined,
-                        });
-                      }}
-                      className="block w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
-                      placeholder={"Experienced engineer included\nFull signal chain\nKitchen & lounge access"}
+                          features: next.length > 0 ? next : undefined,
+                        })
+                      }
                     />
-                  </label>
+                  </div>
                 </div>
 
                 <div className="mt-3 flex flex-wrap items-center gap-4">
@@ -609,6 +610,80 @@ function PricingForm() {
         }}
         onDiscardConfirm={handleDiscardConfirm}
       />
+    </div>
+  );
+}
+
+interface FeaturesEditorProps {
+  readonly features: readonly string[];
+  readonly onChange: (next: string[]) => void;
+}
+
+/**
+ * One input per feature so each bullet is an obvious, focusable field. Empty
+ * rows are trimmed on blur so the stored list never contains whitespace-only
+ * entries, but the row itself stays visible while the user is typing.
+ */
+function FeaturesEditor({ features, onChange }: FeaturesEditorProps) {
+  const update = (idx: number, value: string) => {
+    const next = [...features];
+    next[idx] = value;
+    onChange(next);
+  };
+
+  const remove = (idx: number) => {
+    const next = features.filter((_, i) => i !== idx);
+    onChange(next);
+  };
+
+  const add = () => {
+    onChange([...features, ""]);
+  };
+
+  const commit = () => {
+    const cleaned = features.map((f) => f.trim()).filter((f) => f.length > 0);
+    if (cleaned.length !== features.length) {
+      onChange(cleaned);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {features.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+          No features yet. Add bullet points describing what this package
+          includes.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {features.map((feature, idx) => (
+            <li key={idx} className="flex items-center gap-2">
+              <Input
+                type="text"
+                value={feature}
+                onChange={(e) => update(idx, e.target.value)}
+                onBlur={commit}
+                placeholder={`Feature ${idx + 1}`}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove feature ${idx + 1}`}
+                onClick={() => remove(idx)}
+              >
+                <X className="size-4 text-muted-foreground" aria-hidden />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Button type="button" variant="outline" size="sm" onClick={add}>
+        <Plus className="mr-1 size-3.5" aria-hidden />
+        Add feature
+      </Button>
     </div>
   );
 }

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -36,7 +36,8 @@ type BillingCadence =
   | "per_song"
   | "per_album"
   | "per_project"
-  | "flat";
+  | "flat"
+  | "custom";
 
 type PricingPackage = {
   id: string;
@@ -65,6 +66,7 @@ const VALID_CADENCES: readonly BillingCadence[] = [
   "per_album",
   "per_project",
   "flat",
+  "custom",
 ] as const;
 
 const CADENCE_LABELS: Record<BillingCadence, string> = {
@@ -75,6 +77,7 @@ const CADENCE_LABELS: Record<BillingCadence, string> = {
   per_album: "Per album",
   per_project: "Per project",
   flat: "Flat rate",
+  custom: "Custom…",
 };
 
 function isCadence(value: string): value is BillingCadence {
@@ -455,8 +458,26 @@ function PricingForm() {
                         value={pkg.billingCadence}
                         onChange={(e) => {
                           const raw = e.target.value;
-                          if (isCadence(raw)) {
-                            updatePackage(pkg.id, { billingCadence: raw });
+                          if (!isCadence(raw)) return;
+                          // Switching to a preset clears any custom unit
+                          // label so the preset's default label shows through.
+                          // Switching to custom preseeds unitLabel from the
+                          // previous preset so the user has a starting point.
+                          if (raw === "custom") {
+                            updatePackage(pkg.id, {
+                              billingCadence: raw,
+                              unitLabel:
+                                pkg.unitLabel && pkg.unitLabel.trim().length > 0
+                                  ? pkg.unitLabel
+                                  : CADENCE_LABELS[pkg.billingCadence]
+                                      .toLowerCase()
+                                      .replace(/…$/, ""),
+                            });
+                          } else {
+                            updatePackage(pkg.id, {
+                              billingCadence: raw,
+                              unitLabel: undefined,
+                            });
                           }
                         }}
                         className={cn(
@@ -515,7 +536,9 @@ function PricingForm() {
 
                   <label className="block space-y-1">
                     <span className="body-text-small text-muted-foreground">
-                      Unit label (optional)
+                      {pkg.billingCadence === "custom"
+                        ? "Custom cadence label"
+                        : "Unit label (optional)"}
                     </span>
                     <Input
                       type="text"
@@ -523,13 +546,35 @@ function PricingForm() {
                       onChange={(e) =>
                         updatePackage(pkg.id, {
                           unitLabel:
-                            e.target.value.trim() === ""
+                            e.target.value === ""
                               ? undefined
                               : e.target.value,
                         })
                       }
-                      placeholder={CADENCE_LABELS[pkg.billingCadence]}
+                      onBlur={(e) => {
+                        const trimmed = e.target.value.trim();
+                        if (trimmed !== (pkg.unitLabel ?? "")) {
+                          updatePackage(pkg.id, {
+                            unitLabel: trimmed === "" ? undefined : trimmed,
+                          });
+                        }
+                      }}
+                      placeholder={
+                        pkg.billingCadence === "custom"
+                          ? "e.g. per weekend lockout"
+                          : CADENCE_LABELS[pkg.billingCadence]
+                      }
+                      aria-invalid={
+                        pkg.billingCadence === "custom" &&
+                        (pkg.unitLabel ?? "").trim() === ""
+                      }
                     />
+                    {pkg.billingCadence === "custom" &&
+                    (pkg.unitLabel ?? "").trim() === "" ? (
+                      <p className="text-xs text-destructive">
+                        Required for custom cadence.
+                      </p>
+                    ) : null}
                   </label>
 
                   <label className="col-span-full block space-y-1">

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -31,7 +31,10 @@ function PreviewContent() {
 
   return (
     <HomepageShell
-      pricingFlags={{ flags: pricingFlags.flags }}
+      pricingFlags={{
+        flags: pricingFlags.flags,
+        packages: pricingFlags.packages,
+      }}
       banner={
         <PreviewBanner hasDraftChanges={pricingFlags.hasDraftChanges} />
       }

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -59,6 +59,7 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
   }, []);
 
   const showPricing = pricingFlags?.flags.priceTabEnabled ?? false;
+  const pricingPackages = pricingFlags?.packages ?? [];
   const logoScale = calculateLogoScale(scrollY);
 
   return (
@@ -70,7 +71,7 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
       <div className="relative z-10">
         <TheSpace />
         <EquipmentSpecs />
-        {showPricing && <ServicesAndPricing />}
+        {showPricing && <ServicesAndPricing packages={pricingPackages} />}
         <AmenitiesNearby />
         <FAQ />
         <ArtistInquiries />

--- a/src/components/services-pricing.tsx
+++ b/src/components/services-pricing.tsx
@@ -1,157 +1,155 @@
 import { BrandButton as Button } from "@/components/ui/brand-button";
+import {
+  billingCadenceLabel,
+  formatPrice,
+  type PricingPackage,
+} from "@/lib/site-settings";
 
-// Service packages data
-const SERVICE_PACKAGES = [
-  {
-    id: "recording",
-    name: "Recording Sessions",
-    description: "Professional recording in our acoustically designed studio",
-    features: [
-      "Full day (8-hour) session",
-      "Experienced engineer included",
-      "All analog and digital equipment",
-      "Comfortable lounge area",
-      "Kitchen and refreshments"
-    ],
-    pricing: {
-      daily: "$400",
-      hourly: "$60"
-    },
-    popular: false
-  },
-  {
-    id: "mixing",
-    name: "Mixing & Mastering",
-    description: "Transform your recordings into polished, professional tracks",
-    features: [
-      "Professional mixing per song",
-      "Mastering included",
-      "Unlimited revisions",
-      "Stems provided",
-      "Fast turnaround (3-5 days)"
-    ],
-    pricing: {
-      perSong: "$150",
-      album: "$1,200"
-    },
-    popular: true
-  },
-  {
-    id: "production",
-    name: "Full Production",
-    description: "Complete album production from concept to final master",
-    features: [
-      "Pre-production consultation",
-      "Recording sessions (up to 5 days)",
-      "Mixing and mastering",
-      "Arrangement and composition help",
-      "Instrument and amp rentals included"
-    ],
-    pricing: {
-      album: "$3,500",
-      ep: "$1,800"
-    },
-    popular: false
-  }
-] as const;
+interface ServicesAndPricingProps {
+  readonly packages?: PricingPackage[];
+}
 
-const ADDITIONAL_SERVICES = [
-  { name: "Additional engineer/producer", price: "$200/day" },
-  { name: "Instrument rental (guitars, amps, keys)", price: "$50/day" },
-  { name: "Accommodation (nearby partner locations)", price: "$80-120/night" },
-  { name: "Rehearsal/pre-production time", price: "$30/hour" }
-] as const;
+function sortedActivePackages(
+  packages: readonly PricingPackage[] | undefined,
+): PricingPackage[] {
+  if (!packages || packages.length === 0) return [];
+  return [...packages]
+    .filter((p) => p.isActive)
+    .sort((a, b) => {
+      if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+      return a.name.localeCompare(b.name);
+    });
+}
 
-export function ServicesAndPricing() {
+export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
+  const rows = sortedActivePackages(packages);
+
   return (
     <section id="services-pricing" className="py-20 px-4 bg-sage relative">
       <div className="absolute inset-0 opacity-10 bg-texture-stone"></div>
-      
+
       <div className="relative z-10 max-w-6xl mx-auto">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-washed-black mb-6 tracking-wide font-acumin">
-            SERVICES & RATES
+            SERVICES &amp; RATES
           </h2>
           <p className="text-lg text-washed-black/80 font-titillium max-w-3xl mx-auto leading-relaxed">
-            Transparent pricing for professional recording services. Every package includes our full attention to your artistic vision and access to our complete facility.
+            Transparent pricing for professional recording services. Every
+            package includes our full attention to your artistic vision and
+            access to our complete facility.
           </p>
         </div>
 
-        {/* Service Packages */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
-          {SERVICE_PACKAGES.map((service) => (
-            <div 
-              key={service.id} 
-              className={`relative bg-white/90 border-2 rounded-sm p-8 hover:shadow-lg transition-all ${
-                service.popular ? 'border-forest scale-105' : 'border-forest/30'
-              }`}
-            >
-              {service.popular && (
-                <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
-                  <span className="bg-forest text-sand px-4 py-1 rounded-full text-sm font-acumin font-bold tracking-wide">
-                    MOST POPULAR
-                  </span>
-                </div>
-              )}
-              
-              <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold text-washed-black mb-3 font-acumin">{service.name}</h3>
-                <p className="text-washed-black/70 font-titillium text-sm leading-relaxed">{service.description}</p>
-              </div>
-              
-              <ul className="space-y-3 mb-8">
-                {service.features.map((feature, index) => (
-                  <li key={index} className="flex items-start space-x-3">
-                    <svg className="w-5 h-5 text-forest mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                    </svg>
-                    <span className="text-washed-black/80 font-titillium text-sm">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-              
-              <div className="border-t border-forest/20 pt-6 mb-6">
-                {Object.entries(service.pricing).map(([type, price]) => (
-                  <div key={type} className="flex justify-between items-center mb-2">
-                    <span className="text-washed-black/70 font-titillium text-sm capitalize">{type.replace(/([A-Z])/g, ' $1')}</span>
-                    <span className="text-forest font-acumin font-bold text-lg">{price}</span>
+        {rows.length === 0 ? (
+          <p className="text-center text-washed-black/70 font-titillium">
+            Pricing is being updated — please reach out for a custom quote.
+          </p>
+        ) : (
+          <div
+            className={
+              rows.length >= 3
+                ? "grid grid-cols-1 md:grid-cols-3 gap-8 mb-16"
+                : rows.length === 2
+                  ? "grid grid-cols-1 md:grid-cols-2 gap-8 mb-16"
+                  : "grid grid-cols-1 gap-8 mb-16 max-w-xl mx-auto"
+            }
+          >
+            {rows.map((pkg) => {
+              const unit = pkg.unitLabel ?? billingCadenceLabel(pkg.billingCadence);
+              return (
+                <div
+                  key={pkg.id}
+                  className={`relative bg-white/90 border-2 rounded-sm p-8 hover:shadow-lg transition-all ${
+                    pkg.highlight
+                      ? "border-forest scale-105 shadow-xl"
+                      : "border-forest/30"
+                  }`}
+                >
+                  {pkg.highlight && (
+                    <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
+                      <span className="bg-forest text-sand px-4 py-1 rounded-full text-sm font-acumin font-bold tracking-wide">
+                        RECOMMENDED
+                      </span>
+                    </div>
+                  )}
+
+                  <div className="text-center mb-6">
+                    <h3 className="text-2xl font-bold text-washed-black mb-3 font-acumin">
+                      {pkg.name}
+                    </h3>
+                    {pkg.description ? (
+                      <p className="text-washed-black/70 font-titillium text-sm leading-relaxed">
+                        {pkg.description}
+                      </p>
+                    ) : null}
                   </div>
-                ))}
-              </div>
-              
-              <Button 
-                variant={service.popular ? "primary" : "outline"}
-                className="w-full"
-                onClick={() => document.getElementById('artist-inquiries')?.scrollIntoView({ behavior: 'smooth' })}
-              >
-                BOOK NOW
-              </Button>
-            </div>
-          ))}
-        </div>
 
-        {/* Additional Services */}
-        <div className="bg-white/80 border border-forest/30 rounded-sm p-8">
-          <h3 className="text-2xl font-bold text-washed-black mb-6 text-center font-acumin">ADDITIONAL SERVICES</h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {ADDITIONAL_SERVICES.map((service, index) => (
-              <div key={index} className="flex justify-between items-center py-3 border-b border-forest/20 last:border-b-0">
-                <span className="text-washed-black/80 font-titillium">{service.name}</span>
-                <span className="text-forest font-acumin font-bold">{service.price}</span>
-              </div>
-            ))}
+                  {pkg.features && pkg.features.length > 0 ? (
+                    <ul className="space-y-3 mb-8">
+                      {pkg.features.map((feature, index) => (
+                        <li
+                          key={index}
+                          className="flex items-start space-x-3"
+                        >
+                          <svg
+                            className="w-5 h-5 text-forest mt-0.5 flex-shrink-0"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                          <span className="text-washed-black/80 font-titillium text-sm">
+                            {feature}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+
+                  <div className="border-t border-forest/20 pt-6 mb-6">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-washed-black/70 font-titillium text-sm">
+                        {unit}
+                      </span>
+                      <span className="text-forest font-acumin font-bold text-2xl">
+                        {formatPrice(pkg.priceCents, pkg.currency)}
+                      </span>
+                    </div>
+                  </div>
+
+                  <Button
+                    variant={pkg.highlight ? "primary" : "outline"}
+                    className="w-full"
+                    onClick={() =>
+                      document
+                        .getElementById("artist-inquiries")
+                        ?.scrollIntoView({ behavior: "smooth" })
+                    }
+                  >
+                    BOOK NOW
+                  </Button>
+                </div>
+              );
+            })}
           </div>
-        </div>
+        )}
 
-        {/* Contact CTA */}
         <div className="text-center mt-12">
           <p className="text-washed-black/70 font-titillium mb-4">
             Need a custom package or have questions about pricing?
           </p>
-          <Button 
+          <Button
             variant="secondary"
             size="lg"
-            onClick={() => document.getElementById('artist-inquiries')?.scrollIntoView({ behavior: 'smooth' })}
+            onClick={() =>
+              document
+                .getElementById("artist-inquiries")
+                ?.scrollIntoView({ behavior: "smooth" })
+            }
           >
             GET CUSTOM QUOTE
           </Button>
@@ -159,4 +157,4 @@ export function ServicesAndPricing() {
       </div>
     </section>
   );
-} 
+}

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -1,4 +1,71 @@
-/** Shape returned by `api.public.getPublishedPricingFlags` (marketing pricing gate). */
+/**
+ * Published pricing data surfaced to the public marketing site.
+ *
+ * - `flags.priceTabEnabled` gates whether the pricing section renders.
+ * - `packages` is the catalog authored in the CMS. Empty until the owner has
+ *   done a first publish on a brand-new deployment.
+ */
+export type PricingPackage = {
+  id: string;
+  name: string;
+  description?: string;
+  priceCents: number;
+  currency: string;
+  billingCadence:
+    | "hourly"
+    | "six_hour_block"
+    | "daily"
+    | "per_song"
+    | "per_album"
+    | "per_project"
+    | "flat";
+  unitLabel?: string;
+  highlight: boolean;
+  sortOrder: number;
+  isActive: boolean;
+  features?: string[];
+};
+
 export type PricingFlags = {
   flags: { priceTabEnabled: boolean };
+  packages?: PricingPackage[];
 };
+
+/** Default display label for each billing cadence. */
+export function billingCadenceLabel(
+  cadence: PricingPackage["billingCadence"],
+): string {
+  switch (cadence) {
+    case "hourly":
+      return "per hour";
+    case "six_hour_block":
+      return "per 6-hour block";
+    case "daily":
+      return "per day";
+    case "per_song":
+      return "per song";
+    case "per_album":
+      return "per album";
+    case "per_project":
+      return "per project";
+    case "flat":
+      return "flat rate";
+  }
+}
+
+/** Format a package's price as a short display string (`$60`, `$400.00`). */
+export function formatPrice(
+  priceCents: number,
+  currency: string,
+): string {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: priceCents % 100 === 0 ? 0 : 2,
+      minimumFractionDigits: priceCents % 100 === 0 ? 0 : 2,
+    }).format(priceCents / 100);
+  } catch {
+    return `${currency} ${(priceCents / 100).toFixed(2)}`;
+  }
+}

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -31,27 +31,13 @@ export type PricingFlags = {
   packages?: PricingPackage[];
 };
 
-/** Default display label for each billing cadence. */
-export function billingCadenceLabel(
-  cadence: PricingPackage["billingCadence"],
-): string {
-  switch (cadence) {
-    case "hourly":
-      return "per hour";
-    case "six_hour_block":
-      return "per 6-hour block";
-    case "daily":
-      return "per day";
-    case "per_song":
-      return "per song";
-    case "per_album":
-      return "per album";
-    case "per_project":
-      return "per project";
-    case "flat":
-      return "flat rate";
-  }
-}
+/**
+ * Default display label for each billing cadence.
+ *
+ * Re-exported from `convex/cmsShared.ts` so the convex backend tests and the
+ * Next.js frontend share a single source of truth for cadence labels.
+ */
+export { billingCadenceLabel } from "@convex/cmsShared";
 
 /** Format a package's price as a short display string (`$60`, `$400.00`). */
 export function formatPrice(

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -18,7 +18,8 @@ export type PricingPackage = {
     | "per_song"
     | "per_album"
     | "per_project"
-    | "flat";
+    | "flat"
+    | "custom";
   unitLabel?: string;
   highlight: boolean;
   sortOrder: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes INF-83.

## What this ships

A full draft → publish CRUD model for the studio's rate sheet, using the existing CMS `pricing` section so nothing about the publish pipeline changes — the `pricing` snapshot just grows a `packages` array alongside its feature flag.

### Schema

- `pricingContentValidator` now carries an optional `packages: pricingPackageValidator[]`.
- Each package has a stable client-generated `id`, display `name`, optional `description`, integer `priceCents`, `currency`, `billingCadence` (hourly / six_hour_block / daily / per_song / per_album / per_project / flat), optional `unitLabel` override, `highlight`, `sortOrder`, `isActive`, and optional `features` bullet list.
- Default catalog (`DEFAULT_PRICING_PACKAGES`) ships with the legacy hard-coded Recording Hourly / 6-Hour Block / Mixing rates so new deployments and preview sessions always render something sensible.

### Convex API (`convex/admin/pricing.ts`)

- `api.admin.pricing.listDraft` / `listPublished` — owner-gated queries returning `{ flags, packages, hasDraftChanges, publishedAt, publishedBy, updatedAt, updatedBy }`.
- `api.admin.pricing.saveDraftPricing({ flags, packages })` — writes a full `pricing` draft after validating ids (unique, non-empty), non-negative integer cent prices, and required display name / currency.
- `api.admin.pricing.publishPricing()` — thin wrapper around `publishSectionCore` scoped to the pricing section.
- `api.admin.pricing.validatePricing` — read-only preflight (owner-gated) that returns the same `PublishIssue[]` used by `publishSite`.
- `internal.admin.pricing.debugSnapshot` — mirror of `admin.siteSettings.debugSnapshot` for dashboard inspection.

The generic `api.cms.publishSection({ section: "pricing" })` / `api.admin.publish.publishSite` continue to work and pick up the new validator automatically.

### Publish validation

`collectPricingIssues` now enforces package invariants (duplicate ids, missing names, non-integer or negative `priceCents`, missing currency, non-finite `sortOrder`). `publishSite` will refuse to publish ANY section if the pricing draft fails these checks, matching the existing cross-section behavior. Unit-tested in `convex/pricing.test.ts`.

### Public / preview reads

`publishedPricingFromRows` returns `{ flags, packages }` where `packages` is sanitized and sorted by `sortOrder` then `name`. Legacy `settings.flags` fallback for deployments that haven't written the pricing row yet is preserved; packages just come back as `[]` in that case (which causes `ServicesAndPricing` to render a friendly "please reach out for a custom quote" message).

### Frontend

- `src/components/services-pricing.tsx` no longer hard-codes packages; it renders from the CMS snapshot, formats prices with `Intl.NumberFormat`, and emphasizes the `highlight` row with a RECOMMENDED ribbon + scale-up + solid-primary button.
- `src/components/homepage-shell.tsx` forwards `pricingFlags.packages` into the component.
- `src/app/preview/page.tsx` forwards draft packages through the same path, so preview mirrors what publish will push.
- `src/lib/site-settings.ts` exports the shared `PricingPackage` type, `billingCadenceLabel`, and `formatPrice` helpers.

### Admin editor (`src/app/admin/pricing`)

Full CRUD:

- Add / delete / reorder packages (arrow-up / arrow-down buttons renumber `sortOrder` automatically).
- Name, description, price (`Intl`-formatted entry → integer cents), currency (uppercased), cadence, optional unit label override, features (one-per-line textarea that trims empties on blur).
- Exclusive "Recommended" toggle — flipping one row clears highlight on the others.
- "Show on site" toggle (renders a faded + "Hidden" badge on inactive rows).
- Re-uses the shared `CmsPublishToolbar` for Save draft / Publish / Discard / Preview — and saves-then-publishes in a single action when there are unsaved local edits, matching the Settings editor behavior.

Loading skeleton was refreshed to match the new layout.

## Acceptance criteria

- [x] Owner can create/edit/delete rows in draft without affecting live site until publish — the editor mutates local state and only calls `saveDraftPricing` / `publishPricing` on explicit action; public `getPublishedPricingFlags` reads `publishedSnapshot` only.
- [x] Recommended price stands out on the UI — highlighted row gets a RECOMMENDED ribbon, scale-up, primary-border, and primary button in `services-pricing.tsx`.
- [x] Publish promotes the full draft pricing snapshot per schema design — single `ctx.db.patch` inside `publishSectionCore` copies the entire `{ flags, packages }` object.
- [x] Types flow to frontend components — `PricingFlags` + `PricingPackage` exported from `src/lib/site-settings.ts`, and `api.admin.pricing.*` inferred return types drive the editor.

## Verification

- `bun run lint` ✅
- `bun run build` ✅ (includes Next.js typecheck + static page generation)
- `bunx tsc --noEmit` in `convex/` ✅
- `bun test` ✅ — 15/15 tests pass including the new `convex/pricing.test.ts` coverage (publish-validator happy path, duplicate-id detection, missing-name/negative-price, non-integer cents, sanitize + sort + drop-malformed behavior, and `DEFAULT_PRICING_PACKAGES` invariants).
- Manual walkthrough of the rendered CMS pricing section (artifacts below). Because the Convex deployment requires interactive `convex dev` login to push the new `admin/pricing` functions, the admin editor itself couldn't be exercised against a live backend from this agent — but the editor compiles, typechecks, and uses the same publish toolbar wiring as the existing settings editor, which is already in production.

### Screenshot — pricing section with 3 packages (middle highlighted)

[Pricing section rendered from CMS snapshot with middle RECOMMENDED card emphasized](https://cursor.com/agents/bc-01824893-cea5-4a42-9432-8e972e0efd3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_packages_rendered.png)

### Walkthrough video

[pricing_section_render_walkthrough.mp4](https://cursor.com/agents/bc-01824893-cea5-4a42-9432-8e972e0efd3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_section_render_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-83](https://linear.app/only-football-fans/issue/INF-83/lls-convex-pricing-metadata-crud-draft-publish)

<div><a href="https://cursor.com/agents/bc-01824893-cea5-4a42-9432-8e972e0efd3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01824893-cea5-4a42-9432-8e972e0efd3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

