### PR TITLE
feat(marketing): load pricing from Convex with preload and preview draft

### DIFF
--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -23,9 +23,9 @@ export const SETTINGS_DEFAULTS: SettingsSnapshot = {
 };
 
 /**
- * Default catalog shipped to brand-new deployments. Mirrors the legacy
- * hard-coded rates on `components/services-pricing.tsx` so the public site
- * renders the familiar pricing before the owner customizes anything.
+ * Default catalog shipped to brand-new deployments. Seeds the CMS so the
+ * marketing site can render familiar rates after the first publish; the
+ * public homepage reads published packages via `api.public.getPublishedPricingFlags`.
  */
 export const DEFAULT_PRICING_PACKAGES: PricingPackage[] = [
   {

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { usePreloadedQuery, type Preloaded } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { HomepageShell } from "@/components/homepage-shell";
+
+export function HomeClient({
+  preloadedPricing,
+}: {
+  preloadedPricing: Preloaded<typeof api.public.getPublishedPricingFlags>;
+}) {
+  const pricingFlags = usePreloadedQuery(preloadedPricing);
+  return <HomepageShell pricingFlags={pricingFlags} />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,15 @@
 import { preloadQuery } from "convex/nextjs";
 import { api } from "../../convex/_generated/api";
 import { HomeClient } from "./home-client";
+import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
-  const preloadedPricing = await preloadQuery(api.public.getPublishedPricingFlags);
-  return <HomeClient preloadedPricing={preloadedPricing} />;
+  try {
+    const preloadedPricing = await preloadQuery(
+      api.public.getPublishedPricingFlags,
+    );
+    return <HomeClient preloadedPricing={preloadedPricing} />;
+  } catch {
+    return <HomepageShell pricingFlags={null} />;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,8 @@
-"use client";
-
-import { useQuery } from "convex/react";
+import { preloadQuery } from "convex/nextjs";
 import { api } from "../../convex/_generated/api";
-import { HomepageShell } from "@/components/homepage-shell";
+import { HomeClient } from "./home-client";
 
-export default function Home() {
-  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
-  return <HomepageShell pricingFlags={pricingFlags ?? null} />;
+export default async function Home() {
+  const preloadedPricing = await preloadQuery(api.public.getPublishedPricingFlags);
+  return <HomeClient preloadedPricing={preloadedPricing} />;
 }

--- a/src/components/dynamic-pricing.tsx
+++ b/src/components/dynamic-pricing.tsx
@@ -1,0 +1,40 @@
+import {
+  ServicesAndPricing,
+  ServicesAndPricingSkeleton,
+} from "@/components/services-pricing";
+import type { PricingFlags } from "@/lib/site-settings";
+
+interface MarketingPricingSectionProps {
+  /**
+   * Published or preview pricing payload. `undefined` means still loading (show
+   * skeleton). `null` means unavailable (hide section). Loaded data respects
+   * `flags.priceTabEnabled` for visibility.
+   */
+  readonly pricingFlags: PricingFlags | null | undefined;
+}
+
+/**
+ * Marketing-site pricing block: respects `priceTabEnabled`, loading skeletons,
+ * and empty package state. Uses a single Convex-shaped payload (flags +
+ * packages) from `getPublishedPricingFlags` or `getPreviewPricingFlags`.
+ */
+export function MarketingPricingSection({
+  pricingFlags,
+}: MarketingPricingSectionProps) {
+  const loading = pricingFlags === undefined;
+  const visible =
+    loading ||
+    (pricingFlags !== null && pricingFlags.flags.priceTabEnabled === true);
+
+  if (!visible) {
+    return null;
+  }
+
+  if (loading) {
+    return <ServicesAndPricingSkeleton />;
+  }
+
+  const packages = pricingFlags.packages ?? [];
+
+  return <ServicesAndPricing packages={packages} />;
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,13 +5,14 @@ import { useState } from "react";
 
 interface HeaderProps {
   readonly scrollY: number;
+  readonly showPricing?: boolean;
 }
 
 function lerp(start: number, end: number, progress: number): number {
   return start + (end - start) * progress;
 }
 
-export function Header({ scrollY }: HeaderProps) {
+export function Header({ scrollY, showPricing = false }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const scrollProgress = Math.min(scrollY / 200, 1);
@@ -31,6 +32,7 @@ export function Header({ scrollY }: HeaderProps) {
   const navigationItems = [
     { id: "the-space", label: "The Studio" },
     { id: "equipment-specs", label: "Gear" },
+    ...(showPricing ? [{ id: "services-pricing", label: "Pricing" }] : []),
     { id: "local-favorites", label: "Nearby" },
     { id: "faq", label: "FAQ" },
     { id: "artist-inquiries", label: "Inquire" },

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -8,7 +8,7 @@ import { EquipmentSpecs } from "@/components/equipment-specs";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { FAQ } from "@/components/faq";
 import { ArtistInquiries } from "@/components/artist-inquiries";
-import { ServicesAndPricing } from "@/components/services-pricing";
+import { MarketingPricingSection } from "@/components/dynamic-pricing";
 import type { PricingFlags } from "@/lib/site-settings";
 
 function calculateLogoScale(scrollY: number): number {
@@ -16,7 +16,8 @@ function calculateLogoScale(scrollY: number): number {
 }
 
 interface HomepageShellProps {
-  readonly pricingFlags: PricingFlags | null;
+  /** `undefined` while the client is still subscribing (preview only if not preloaded). */
+  readonly pricingFlags: PricingFlags | null | undefined;
   readonly banner?: React.ReactNode;
 }
 
@@ -58,8 +59,6 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
     };
   }, []);
 
-  const showPricing = pricingFlags?.flags.priceTabEnabled ?? false;
-  const pricingPackages = pricingFlags?.packages ?? [];
   const logoScale = calculateLogoScale(scrollY);
 
   return (
@@ -71,7 +70,7 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
       <div className="relative z-10">
         <TheSpace />
         <EquipmentSpecs />
-        {showPricing && <ServicesAndPricing packages={pricingPackages} />}
+        <MarketingPricingSection pricingFlags={pricingFlags} />
         <AmenitiesNearby />
         <FAQ />
         <ArtistInquiries />

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -61,9 +61,8 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
 
   const logoScale = calculateLogoScale(scrollY);
   const showPricing =
-    pricingFlags !== null &&
-    pricingFlags !== undefined &&
-    pricingFlags.flags.priceTabEnabled === true;
+    pricingFlags === undefined ||
+    (pricingFlags !== null && pricingFlags.flags.priceTabEnabled === true);
 
   return (
     <div ref={containerRef} className="min-h-screen bg-washed-black relative grain-overlay">

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -60,11 +60,15 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
   }, []);
 
   const logoScale = calculateLogoScale(scrollY);
+  const showPricing =
+    pricingFlags !== null &&
+    pricingFlags !== undefined &&
+    pricingFlags.flags.priceTabEnabled === true;
 
   return (
     <div ref={containerRef} className="min-h-screen bg-washed-black relative grain-overlay">
       {banner}
-      <Header scrollY={scrollY} />
+      <Header scrollY={scrollY} showPricing={showPricing} />
       <Hero logoScale={logoScale} />
 
       <div className="relative z-10">

--- a/src/components/services-pricing.tsx
+++ b/src/components/services-pricing.tsx
@@ -21,33 +21,54 @@ function sortedActivePackages(
     });
 }
 
+function SectionHeader() {
+  return (
+    <div className="text-center mb-16 reveal">
+      <p className="label-text text-sand/60 mb-4">Rates</p>
+      <h2 className="headline-primary text-3xl md:text-4xl lg:text-5xl text-warm-white mb-6">
+        Services &amp; Pricing
+      </h2>
+      <div className="section-rule max-w-xs mx-auto mb-8" />
+      <p className="body-text text-lg text-ivory/60 max-w-2xl mx-auto">
+        Transparent pricing for professional recording services. Every package
+        includes our full attention to your artistic vision and access to our
+        complete facility.
+      </p>
+    </div>
+  );
+}
+
 export function ServicesAndPricingSkeleton() {
   return (
-    <section id="services-pricing" className="py-20 px-4 bg-sage relative">
-      <div className="absolute inset-0 opacity-10 bg-texture-stone" />
+    <section
+      id="services-pricing"
+      className="py-24 md:py-32 px-6 bg-washed-black relative"
+    >
+      <div className="absolute inset-0 opacity-20 bg-texture-stone" />
+
       <div className="relative z-10 max-w-6xl mx-auto">
-        <div className="text-center mb-16 space-y-4">
-          <div className="h-10 max-w-md mx-auto rounded bg-washed-black/10 animate-pulse" />
-          <div className="h-5 max-w-2xl mx-auto rounded bg-washed-black/10 animate-pulse" />
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
+        <SectionHeader />
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="relative bg-white/60 border-2 border-forest/20 rounded-sm p-8 animate-pulse"
+              className="relative flex flex-col p-8 border border-sand/8 bg-washed-black/40 animate-pulse"
             >
-              <div className="h-7 bg-washed-black/10 rounded mb-4" />
-              <div className="h-4 bg-washed-black/10 rounded mb-2" />
-              <div className="h-4 bg-washed-black/10 rounded w-4/5 mb-8" />
+              <div className="mb-6">
+                <div className="h-6 w-1/2 bg-sand/10 mb-3" />
+                <div className="h-4 bg-sand/10 mb-2" />
+                <div className="h-4 w-4/5 bg-sand/10" />
+              </div>
               <div className="space-y-3 mb-8">
                 {[0, 1, 2].map((j) => (
-                  <div key={j} className="h-4 bg-washed-black/10 rounded" />
+                  <div key={j} className="h-3 bg-sand/10" />
                 ))}
               </div>
-              <div className="border-t border-forest/20 pt-6 mb-6">
-                <div className="h-8 bg-washed-black/10 rounded" />
+              <div className="mt-auto border-t border-sand/10 pt-6 mb-6">
+                <div className="h-8 bg-sand/10" />
               </div>
-              <div className="h-11 bg-washed-black/10 rounded" />
+              <div className="h-11 bg-sand/10" />
             </div>
           ))}
         </div>
@@ -60,33 +81,28 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
   const rows = sortedActivePackages(packages);
 
   return (
-    <section id="services-pricing" className="py-20 px-4 bg-sage relative">
-      <div className="absolute inset-0 opacity-10 bg-texture-stone" />
+    <section
+      id="services-pricing"
+      className="py-24 md:py-32 px-6 bg-washed-black relative"
+    >
+      <div className="absolute inset-0 opacity-20 bg-texture-stone" />
 
       <div className="relative z-10 max-w-6xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-washed-black mb-6 tracking-wide font-acumin">
-            SERVICES &amp; RATES
-          </h2>
-          <p className="text-lg text-washed-black/80 font-titillium max-w-3xl mx-auto leading-relaxed">
-            Transparent pricing for professional recording services. Every
-            package includes our full attention to your artistic vision and
-            access to our complete facility.
-          </p>
-        </div>
+        <SectionHeader />
 
         {rows.length === 0 ? (
-          <p className="text-center text-washed-black/70 font-titillium">
-            Pricing is being updated — please reach out for a custom quote.
+          <p className="text-center body-text text-ivory/50">
+            Pricing is being updated &mdash; please reach out for a custom
+            quote.
           </p>
         ) : (
           <div
             className={
               rows.length >= 3
-                ? "grid grid-cols-1 md:grid-cols-3 gap-8 mb-16"
+                ? "grid grid-cols-1 md:grid-cols-3 gap-6 reveal reveal-delay-2"
                 : rows.length === 2
-                  ? "grid grid-cols-1 md:grid-cols-2 gap-8 mb-16"
-                  : "grid grid-cols-1 gap-8 mb-16 max-w-xl mx-auto"
+                  ? "grid grid-cols-1 md:grid-cols-2 gap-6 reveal reveal-delay-2"
+                  : "grid grid-cols-1 gap-6 max-w-xl mx-auto reveal reveal-delay-2"
             }
           >
             {rows.map((pkg) => {
@@ -95,26 +111,26 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
               return (
                 <div
                   key={pkg.id}
-                  className={`relative bg-white/90 border-2 rounded-sm p-8 hover:shadow-lg transition-all ${
+                  className={`relative flex flex-col p-8 border transition-all duration-500 ${
                     pkg.highlight
-                      ? "border-forest scale-105 shadow-xl"
-                      : "border-forest/30"
+                      ? "bg-washed-black/60 border-sand/30 hover:border-sand/50"
+                      : "bg-washed-black/40 border-sand/8 hover:border-sand/20"
                   }`}
                 >
                   {pkg.highlight && (
-                    <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
-                      <span className="bg-forest text-sand px-4 py-1 rounded-full text-sm font-acumin font-bold tracking-wide">
-                        RECOMMENDED
+                    <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+                      <span className="label-text bg-sand text-washed-black px-3 py-1 text-[10px]">
+                        Recommended
                       </span>
                     </div>
                   )}
 
-                  <div className="text-center mb-6">
-                    <h3 className="text-2xl font-bold text-washed-black mb-3 font-acumin">
+                  <div className="mb-6">
+                    <h3 className="headline-secondary text-sand text-xl mb-3">
                       {pkg.name}
                     </h3>
                     {pkg.description ? (
-                      <p className="text-washed-black/70 font-titillium text-sm leading-relaxed">
+                      <p className="body-text-small text-ivory/50 leading-relaxed">
                         {pkg.description}
                       </p>
                     ) : null}
@@ -125,20 +141,22 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
                       {pkg.features.map((feature, index) => (
                         <li
                           key={`${pkg.id}-f-${index}`}
-                          className="flex items-start space-x-3"
+                          className="flex items-start gap-3"
                         >
                           <svg
-                            className="w-5 h-5 text-forest mt-0.5 flex-shrink-0"
-                            fill="currentColor"
-                            viewBox="0 0 20 20"
+                            className="w-4 h-4 text-sand/60 mt-0.5 flex-shrink-0"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
                           >
                             <path
-                              fillRule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clipRule="evenodd"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                              d="M5 13l4 4L19 7"
                             />
                           </svg>
-                          <span className="text-washed-black/80 font-titillium text-sm">
+                          <span className="body-text-small text-ivory/70">
                             {feature}
                           </span>
                         </li>
@@ -146,12 +164,10 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
                     </ul>
                   ) : null}
 
-                  <div className="border-t border-forest/20 pt-6 mb-6">
+                  <div className="mt-auto border-t border-sand/10 pt-6 mb-6">
                     <div className="flex items-baseline justify-between gap-2">
-                      <span className="text-washed-black/70 font-titillium text-sm">
-                        {unit}
-                      </span>
-                      <span className="text-forest font-acumin font-bold text-2xl">
+                      <span className="label-text text-ivory/40">{unit}</span>
+                      <span className="headline-secondary text-sand text-2xl">
                         {formatPrice(pkg.priceCents, pkg.currency)}
                       </span>
                     </div>
@@ -166,7 +182,7 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
                         ?.scrollIntoView({ behavior: "smooth" })
                     }
                   >
-                    BOOK NOW
+                    Book Your Session
                   </Button>
                 </div>
               );
@@ -174,12 +190,17 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
           </div>
         )}
 
-        <div className="text-center mt-12">
-          <p className="text-washed-black/70 font-titillium mb-4">
-            Need a custom package or have questions about pricing?
+        <div className="text-center mt-16 reveal reveal-delay-3 pt-12 border-t border-sand/10">
+          <h3 className="headline-secondary text-2xl text-sand mb-4">
+            Need Something Different?
+          </h3>
+          <p className="body-text text-ivory/50 mb-8 max-w-xl mx-auto">
+            Have questions about pricing or need a custom package tailored to
+            your project? We&apos;re happy to design something that fits your
+            vision and timeline.
           </p>
           <Button
-            variant="secondary"
+            variant="outline"
             size="lg"
             onClick={() =>
               document
@@ -187,7 +208,7 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
                 ?.scrollIntoView({ behavior: "smooth" })
             }
           >
-            GET CUSTOM QUOTE
+            Get Custom Quote
           </Button>
         </div>
       </div>

--- a/src/components/services-pricing.tsx
+++ b/src/components/services-pricing.tsx
@@ -6,13 +6,13 @@ import {
 } from "@/lib/site-settings";
 
 interface ServicesAndPricingProps {
-  readonly packages?: PricingPackage[];
+  readonly packages: readonly PricingPackage[];
 }
 
 function sortedActivePackages(
-  packages: readonly PricingPackage[] | undefined,
+  packages: readonly PricingPackage[],
 ): PricingPackage[] {
-  if (!packages || packages.length === 0) return [];
+  if (packages.length === 0) return [];
   return [...packages]
     .filter((p) => p.isActive)
     .sort((a, b) => {
@@ -21,12 +21,47 @@ function sortedActivePackages(
     });
 }
 
+export function ServicesAndPricingSkeleton() {
+  return (
+    <section id="services-pricing" className="py-20 px-4 bg-sage relative">
+      <div className="absolute inset-0 opacity-10 bg-texture-stone" />
+      <div className="relative z-10 max-w-6xl mx-auto">
+        <div className="text-center mb-16 space-y-4">
+          <div className="h-10 max-w-md mx-auto rounded bg-washed-black/10 animate-pulse" />
+          <div className="h-5 max-w-2xl mx-auto rounded bg-washed-black/10 animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="relative bg-white/60 border-2 border-forest/20 rounded-sm p-8 animate-pulse"
+            >
+              <div className="h-7 bg-washed-black/10 rounded mb-4" />
+              <div className="h-4 bg-washed-black/10 rounded mb-2" />
+              <div className="h-4 bg-washed-black/10 rounded w-4/5 mb-8" />
+              <div className="space-y-3 mb-8">
+                {[0, 1, 2].map((j) => (
+                  <div key={j} className="h-4 bg-washed-black/10 rounded" />
+                ))}
+              </div>
+              <div className="border-t border-forest/20 pt-6 mb-6">
+                <div className="h-8 bg-washed-black/10 rounded" />
+              </div>
+              <div className="h-11 bg-washed-black/10 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
   const rows = sortedActivePackages(packages);
 
   return (
     <section id="services-pricing" className="py-20 px-4 bg-sage relative">
-      <div className="absolute inset-0 opacity-10 bg-texture-stone"></div>
+      <div className="absolute inset-0 opacity-10 bg-texture-stone" />
 
       <div className="relative z-10 max-w-6xl mx-auto">
         <div className="text-center mb-16">
@@ -55,7 +90,8 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
             }
           >
             {rows.map((pkg) => {
-              const unit = pkg.unitLabel ?? billingCadenceLabel(pkg.billingCadence);
+              const unit =
+                pkg.unitLabel ?? billingCadenceLabel(pkg.billingCadence);
               return (
                 <div
                   key={pkg.id}
@@ -88,7 +124,7 @@ export function ServicesAndPricing({ packages }: ServicesAndPricingProps) {
                     <ul className="space-y-3 mb-8">
                       {pkg.features.map((feature, index) => (
                         <li
-                          key={index}
+                          key={`${pkg.id}-f-${index}`}
                           className="flex items-start space-x-3"
                         >
                           <svg


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shifts the homepage from client-side querying to server-side preloading with a client wrapper, which can affect rendering/error paths and caching behavior. Also changes how/when the pricing section and nav item appear based on Convex flags and loading state.
> 
> **Overview**
> The homepage pricing data is now loaded via Convex `preloadQuery` on the server (`src/app/page.tsx`) and hydrated through a new client wrapper (`HomeClient`) using `usePreloadedQuery`, with a fallback to rendering the homepage without pricing on preload failure.
> 
> Pricing display is refactored into a new `MarketingPricingSection` that handles **loading skeleton**, **disabled pricing flag**, and **empty packages** states, and `Header` now conditionally shows the “Pricing” nav link based on `priceTabEnabled`. The `ServicesAndPricing` component is restyled and now includes a reusable section header plus a dedicated `ServicesAndPricingSkeleton`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d9aa8736210a16b7cca1ac7226a463a572b357. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->