### PR TITLE
feat(convex): studio gear CMS with draft/publish (INF-86)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as admin_gear from "../admin/gear.js";
 import type * as admin_pricing from "../admin/pricing.js";
 import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
@@ -15,6 +16,8 @@ import type * as cms from "../cms.js";
 import type * as cmsPublishHelpers from "../cmsPublishHelpers.js";
 import type * as cmsShared from "../cmsShared.js";
 import type * as errors from "../errors.js";
+import type * as gearEquipmentSeed from "../gearEquipmentSeed.js";
+import type * as gearTree from "../gearTree.js";
 import type * as inquiries from "../inquiries.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_sentryConvex from "../lib/sentryConvex.js";
@@ -33,6 +36,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "admin/gear": typeof admin_gear;
   "admin/pricing": typeof admin_pricing;
   "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
@@ -40,6 +44,8 @@ declare const fullApi: ApiFromModules<{
   cmsPublishHelpers: typeof cmsPublishHelpers;
   cmsShared: typeof cmsShared;
   errors: typeof errors;
+  gearEquipmentSeed: typeof gearEquipmentSeed;
+  gearTree: typeof gearTree;
   inquiries: typeof inquiries;
   "lib/auth": typeof lib_auth;
   "lib/sentryConvex": typeof lib_sentryConvex;

--- a/convex/admin/gear.ts
+++ b/convex/admin/gear.ts
@@ -1,0 +1,418 @@
+/**
+ * Studio gear CMS (INF-86): CRUD on **draft** only; `publishGear` / `discardDraftGear`
+ * for atomic snapshot swaps. See `convex/gearTree.ts` for tree helpers.
+ *
+ * One-time import from legacy `equipment-specs.tsx` data: run
+ * `bunx convex run internal.seed.seedGearFromEquipmentSpecs` after deploy
+ * (or enter via admin when the UI exists).
+ */
+import { v } from "convex/values";
+import type { Doc } from "../_generated/dataModel";
+import {
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+} from "../_generated/server";
+import { gearSpecsValidator } from "../schema.shared";
+import {
+  copyGearScope,
+  ensureGearMeta,
+  gearDraftMatchesPublished,
+  loadGearDocs,
+} from "../gearTree";
+import { requireCmsOwner } from "../lib/auth";
+import { cmsPublishValidationFailed, cmsValidationError } from "../errors";
+
+type PublishIssue = { path: string; message: string };
+
+function trimName(s: string): string {
+  return s.trim();
+}
+
+function collectGearPublishIssues(draft: {
+  categories: Doc<"gearCategories">[];
+  items: Doc<"gearItems">[];
+}): PublishIssue[] {
+  const issues: PublishIssue[] = [];
+  const catIds = new Set(draft.categories.map((c) => c.stableId));
+
+  for (let i = 0; i < draft.categories.length; i++) {
+    const c = draft.categories[i];
+    if (trimName(c.name).length === 0) {
+      issues.push({
+        path: `categories[${i}].name`,
+        message: "Category name is required.",
+      });
+    }
+  }
+
+  for (let i = 0; i < draft.items.length; i++) {
+    const it = draft.items[i];
+    const base = `items[${i}]`;
+    if (trimName(it.name).length === 0) {
+      issues.push({
+        path: `${base}.name`,
+        message: "Gear item name is required.",
+      });
+    }
+    if (!catIds.has(it.categoryStableId)) {
+      issues.push({
+        path: `${base}.categoryStableId`,
+        message: `Unknown category stable id: ${it.categoryStableId}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+async function getDraftCategoryByStableId(
+  ctx: MutationCtx,
+  stableId: string,
+): Promise<Doc<"gearCategories"> | null> {
+  return await ctx.db
+    .query("gearCategories")
+    .withIndex("by_scope_and_stableId", (q) =>
+      q.eq("scope", "draft").eq("stableId", stableId),
+    )
+    .unique();
+}
+
+async function getDraftItemByStableId(
+  ctx: MutationCtx,
+  stableId: string,
+): Promise<Doc<"gearItems"> | null> {
+  return await ctx.db
+    .query("gearItems")
+    .withIndex("by_scope_and_stableId", (q) =>
+      q.eq("scope", "draft").eq("stableId", stableId),
+    )
+    .unique();
+}
+
+async function patchGearMetaAfterDraftChange(
+  ctx: MutationCtx,
+  updatedBy: string,
+): Promise<void> {
+  const draft = await loadGearDocs(ctx, "draft");
+  const published = await loadGearDocs(ctx, "published");
+  const hasDraftChanges = !gearDraftMatchesPublished(draft, published);
+  const { id } = await ensureGearMeta(ctx);
+  await ctx.db.patch(id, {
+    hasDraftChanges,
+    updatedAt: Date.now(),
+    updatedBy,
+  });
+}
+
+export type GearItemPayload = {
+  stableId: string;
+  categoryStableId: string;
+  name: string;
+  sort: number;
+  specs: Doc<"gearItems">["specs"];
+  url?: string | null;
+};
+
+export type GearCategoryPayload = {
+  stableId: string;
+  name: string;
+  sort: number;
+  items: GearItemPayload[];
+};
+
+function toPayload(
+  categories: Doc<"gearCategories">[],
+  items: Doc<"gearItems">[],
+): GearCategoryPayload[] {
+  const byCat = new Map<string, Doc<"gearItems">[]>();
+  for (const it of items) {
+    const list = byCat.get(it.categoryStableId) ?? [];
+    list.push(it);
+    byCat.set(it.categoryStableId, list);
+  }
+  for (const list of byCat.values()) {
+    list.sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId));
+  }
+  const sortedCats = [...categories].sort(
+    (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
+  );
+  return sortedCats.map((c) => ({
+    stableId: c.stableId,
+    name: c.name,
+    sort: c.sort,
+    items: (byCat.get(c.stableId) ?? []).map((i) => ({
+      stableId: i.stableId,
+      categoryStableId: i.categoryStableId,
+      name: i.name,
+      sort: i.sort,
+      specs: i.specs,
+      url: i.url ?? null,
+    })),
+  }));
+}
+
+export const listDraftGear = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const { categories, items } = await loadGearDocs(ctx, "draft");
+    const meta = await ctx.db
+      .query("gearMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+    return {
+      tree: toPayload(categories, items),
+      hasDraftChanges: meta?.hasDraftChanges ?? false,
+      publishedAt: meta?.publishedAt ?? null,
+      publishedBy: meta?.publishedBy ?? null,
+      updatedAt: meta?.updatedAt ?? null,
+      updatedBy: meta?.updatedBy ?? null,
+    };
+  },
+});
+
+export const listPublishedGearAdmin = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const { categories, items } = await loadGearDocs(ctx, "published");
+    return { tree: toPayload(categories, items) };
+  },
+});
+
+export const validateGearDraft = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const draft = await loadGearDocs(ctx, "draft");
+    const issues = collectGearPublishIssues(draft);
+    return {
+      ok: issues.length === 0,
+      issues,
+    };
+  },
+});
+
+export const putDraftCategory = mutation({
+  args: {
+    stableId: v.string(),
+    name: v.string(),
+    sort: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureGearMeta(ctx);
+    if (trimName(args.name).length === 0) {
+      cmsValidationError("Category name is required.", "name");
+    }
+    if (!Number.isFinite(args.sort)) {
+      cmsValidationError("Sort order must be a finite number.", "sort");
+    }
+
+    const existing = await getDraftCategoryByStableId(ctx, args.stableId);
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        name: args.name.trim(),
+        sort: args.sort,
+      });
+    } else {
+      await ctx.db.insert("gearCategories", {
+        scope: "draft",
+        stableId: args.stableId,
+        name: args.name.trim(),
+        sort: args.sort,
+      });
+    }
+    await patchGearMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const removeDraftCategory = mutation({
+  args: { stableId: v.string() },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const cat = await getDraftCategoryByStableId(ctx, args.stableId);
+    if (!cat) {
+      return { ok: true as const, removed: false };
+    }
+
+    for (;;) {
+      const batch = await ctx.db
+        .query("gearItems")
+        .withIndex("by_scope_and_category_and_sort", (q) =>
+          q.eq("scope", "draft").eq("categoryStableId", args.stableId),
+        )
+        .take(50);
+      if (batch.length === 0) break;
+      for (const row of batch) {
+        await ctx.db.delete(row._id);
+      }
+    }
+
+    await ctx.db.delete(cat._id);
+    await patchGearMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, removed: true };
+  },
+});
+
+export const putDraftItem = mutation({
+  args: {
+    stableId: v.string(),
+    categoryStableId: v.string(),
+    name: v.string(),
+    sort: v.number(),
+    specs: gearSpecsValidator,
+    url: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureGearMeta(ctx);
+    if (trimName(args.name).length === 0) {
+      cmsValidationError("Item name is required.", "name");
+    }
+    if (!Number.isFinite(args.sort)) {
+      cmsValidationError("Sort order must be a finite number.", "sort");
+    }
+
+    const cat = await getDraftCategoryByStableId(ctx, args.categoryStableId);
+    if (!cat) {
+      cmsValidationError(
+        `Draft category not found: ${args.categoryStableId}`,
+        "categoryStableId",
+      );
+    }
+
+    const url =
+      args.url === undefined || args.url === null
+        ? undefined
+        : args.url.trim().length > 0
+          ? args.url.trim()
+          : undefined;
+
+    const existing = await getDraftItemByStableId(ctx, args.stableId);
+    const payload = {
+      categoryStableId: args.categoryStableId,
+      name: args.name.trim(),
+      sort: args.sort,
+      specs: args.specs,
+      url,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, payload);
+    } else {
+      await ctx.db.insert("gearItems", {
+        scope: "draft",
+        stableId: args.stableId,
+        ...payload,
+      });
+    }
+
+    await patchGearMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const removeDraftItem = mutation({
+  args: { stableId: v.string() },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftItemByStableId(ctx, args.stableId);
+    if (!row) {
+      return { ok: true as const, removed: false };
+    }
+    await ctx.db.delete(row._id);
+    await patchGearMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, removed: true };
+  },
+});
+
+export const publishGear = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { userId, updatedBy } = await requireCmsOwner(ctx);
+    const draft = await loadGearDocs(ctx, "draft");
+    const issues = collectGearPublishIssues(draft);
+    if (issues.length > 0) {
+      cmsPublishValidationFailed(
+        "gear",
+        "Publish validation failed.",
+        issues,
+      );
+    }
+
+    await copyGearScope(ctx, "draft", "published");
+
+    const { id: metaId } = await ensureGearMeta(ctx);
+    const now = Date.now();
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      publishedAt: now,
+      publishedBy: userId,
+      updatedAt: now,
+      updatedBy,
+    });
+
+    return {
+      ok: true as const,
+      kind: "published" as const,
+      publishedAt: now,
+      publishedBy: userId,
+    };
+  },
+});
+
+export const discardDraftGear = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureGearMeta(ctx);
+    await copyGearScope(ctx, "published", "draft");
+
+    const { id: metaId } = await ensureGearMeta(ctx);
+    const now = Date.now();
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      updatedAt: now,
+      updatedBy,
+    });
+
+    return { ok: true as const, discarded: true };
+  },
+});
+
+/** Debug: raw row counts per scope (internal). */
+export const debugGearCounts = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return {
+      draftCategories: (
+        await ctx.db
+          .query("gearCategories")
+          .withIndex("by_scope_and_sort", (q) => q.eq("scope", "draft"))
+          .collect()
+      ).length,
+      draftItems: (
+        await ctx.db
+          .query("gearItems")
+          .withIndex("by_scope", (q) => q.eq("scope", "draft"))
+          .collect()
+      ).length,
+      publishedCategories: (
+        await ctx.db
+          .query("gearCategories")
+          .withIndex("by_scope_and_sort", (q) => q.eq("scope", "published"))
+          .collect()
+      ).length,
+      publishedItems: (
+        await ctx.db
+          .query("gearItems")
+          .withIndex("by_scope", (q) => q.eq("scope", "published"))
+          .collect()
+      ).length,
+    };
+  },
+});

--- a/convex/admin/gear.ts
+++ b/convex/admin/gear.ts
@@ -20,6 +20,7 @@ import {
   ensureGearMeta,
   gearDraftMatchesPublished,
   loadGearDocs,
+  mapSortedGearTree,
 } from "../gearTree";
 import { requireCmsOwner } from "../lib/auth";
 import { cmsPublishValidationFailed, cmsValidationError } from "../errors";
@@ -126,30 +127,13 @@ function toPayload(
   categories: Doc<"gearCategories">[],
   items: Doc<"gearItems">[],
 ): GearCategoryPayload[] {
-  const byCat = new Map<string, Doc<"gearItems">[]>();
-  for (const it of items) {
-    const list = byCat.get(it.categoryStableId) ?? [];
-    list.push(it);
-    byCat.set(it.categoryStableId, list);
-  }
-  for (const list of byCat.values()) {
-    list.sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId));
-  }
-  const sortedCats = [...categories].sort(
-    (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
-  );
-  return sortedCats.map((c) => ({
-    stableId: c.stableId,
-    name: c.name,
-    sort: c.sort,
-    items: (byCat.get(c.stableId) ?? []).map((i) => ({
-      stableId: i.stableId,
-      categoryStableId: i.categoryStableId,
-      name: i.name,
-      sort: i.sort,
-      specs: i.specs,
-      url: i.url ?? null,
-    })),
+  return mapSortedGearTree<GearItemPayload>(categories, items, (i) => ({
+    stableId: i.stableId,
+    categoryStableId: i.categoryStableId,
+    name: i.name,
+    sort: i.sort,
+    specs: i.specs,
+    url: i.url ?? null,
   }));
 }
 

--- a/convex/gearEquipmentSeed.ts
+++ b/convex/gearEquipmentSeed.ts
@@ -1,0 +1,166 @@
+/**
+ * Legacy equipment list mirrored from `src/components/equipment-specs.tsx` (INF-86).
+ * Used by `internal.seed.seedGearFromEquipmentSpecs` for one-time Convex import.
+ * When the homepage reads `api.public.getPublishedGear` only, update the TSX
+ * fallback in sync or remove the duplicate.
+ */
+export const LEGACY_EQUIPMENT_SEED: ReadonlyArray<{
+  readonly category: string;
+  readonly items: ReadonlyArray<{ readonly name: string; readonly specs?: string }>;
+}> = [
+  {
+    category: "Interfaces & Console",
+    items: [
+      { name: "API 2448 Console", specs: "With 16x API 560 EQs and 8x API 550B EQs" },
+      { name: "2x Universal Audio Apollo x16 Interfaces" },
+      { name: "Pro Tools Ultimate" },
+    ],
+  },
+  {
+    category: "Preamps & Channel Strips",
+    items: [
+      { name: "Neve 1073OPX" },
+      { name: "AEA RPQ3" },
+      { name: "Tree Audio Branch" },
+      { name: "2x Avalon Channel Strips" },
+      { name: '2x Sunset Sound "Tutti" Mic/Instrument Pre' },
+    ],
+  },
+  {
+    category: "Compressors & Dynamics",
+    items: [
+      { name: "2x Empirical Labs Distressor" },
+      { name: "2x Urei 1176LN" },
+      { name: "2x Purple Audio MC77" },
+      { name: "2x DBX 165" },
+      { name: "Retro STA-Level Compressor" },
+      { name: "Manley Vari-Mu Stereo Compressor/Limiter" },
+      { name: "Unfairchild 670 Stereo Compressor" },
+      { name: "Grandchild 670 Stereo Compressor" },
+      { name: "SSL G-Bus Stereo Compressor" },
+      { name: "Custom SSL Talkback-Style Limiter" },
+      { name: "2x LevelOr Limiter/DI/Distortion Units" },
+    ],
+  },
+  {
+    category: "EQs",
+    items: [
+      { name: "2x Heritage Audio 1073 EQ" },
+      { name: "2x Helios 5011 EQ" },
+      { name: "Chandler Limited Curve Bender" },
+    ],
+  },
+  {
+    category: "Tape & Saturation",
+    items: [
+      { name: "2x Neve Portico 542 Tape Emulators" },
+      { name: "Thermionic Culture Vulture" },
+    ],
+  },
+  {
+    category: "Reverb & Effects",
+    items: [
+      { name: "AMS RMX16 Digital Reverb" },
+      { name: "Bricasti M7 Digital Reverb" },
+    ],
+  },
+  {
+    category: "Plugins",
+    items: [
+      { name: "Universal Audio Suite" },
+      { name: "FabFilter Suite" },
+      { name: "Eventide Suite" },
+      { name: "Waves Suite" },
+      { name: "SSL Suite" },
+      { name: "Soundtoys Suite" },
+      { name: "Valhalla Collection" },
+      { name: "Additional Plugins" },
+    ],
+  },
+  {
+    category: "Dynamic Microphones",
+    items: [
+      { name: "3x Shure SM57" },
+      { name: "4x Shure SM58" },
+      { name: "Shure Beta52A" },
+      { name: "Shure SM7B" },
+      { name: "AKG D112" },
+      { name: "Audix D6" },
+      { name: "4x Sennheiser e906" },
+      { name: "4x Sennheiser MD421" },
+      { name: "Electro-Voice 635A" },
+      { name: "2x Electro-Voice RE16" },
+      { name: "Dr. Alien Smith DirtMic01" },
+      { name: "Dr. Alien Smith Alien8" },
+    ],
+  },
+  {
+    category: "Condenser Microphones",
+    items: [
+      { name: "2x Shure SM81" },
+      { name: "2x Audio-Technica AT4060A" },
+      { name: "4x Audio-Technica AT4021" },
+      { name: "2x Audio-Technica AT4047" },
+      { name: "4x Audio-Technica ATM450" },
+      { name: "2x Neumann U67" },
+      { name: "Neumann M49" },
+      { name: "Neumann U47" },
+      { name: "Neumann KM86" },
+      { name: "Soyuz 017 FET" },
+      { name: "2x Soyuz 013 FET" },
+      { name: "Dachmann Audio 47 FET" },
+    ],
+  },
+  {
+    category: "Ribbon Microphones",
+    items: [
+      { name: "2x Audio-Technica AT4081" },
+      { name: "2x Audio-Technica AT4080" },
+      { name: "2x AEA R84" },
+      { name: "AEA R88" },
+      { name: "AEA R44" },
+      { name: "3x AEA KU5A" },
+      { name: "2x Coles 4038" },
+      { name: "3x Royer R-10" },
+      { name: "Royer R-121" },
+    ],
+  },
+  {
+    category: "Drum Kits & Percussion",
+    items: [
+      { name: "DW Drum Kit" },
+      { name: "Vintage 1960s Rogers Jazz Kit" },
+      { name: "1920s Ludwig Steel Snare" },
+      { name: "2x DW Snares" },
+    ],
+  },
+  {
+    category: "Guitars & Basses",
+    items: [
+      { name: "1990s Fender Stratocaster" },
+      { name: "Custom Hamer Partscaster Tele" },
+      { name: "1978 Gibson 335 with Bigsby" },
+      { name: "2013 '57 Reissue Gibson Les Paul Goldtopp" },
+      { name: "1958 Gibson J-50 Acoustic" },
+      { name: "1971 Martin D-28" },
+      { name: "2005 Martin HD-28" },
+      { name: "1970s Gibson LG-1" },
+      { name: "Ernie Ball Music Man Bass" },
+    ],
+  },
+  {
+    category: "Amplifiers",
+    items: [
+      { name: "Vox AC15" },
+      { name: "Vox AC4" },
+      { name: "Fender Princeton 15w" },
+      { name: "Fender Princeton 10w" },
+      { name: "Fender Blues Jr. Tweed 15w" },
+      { name: "Fender Champ" },
+      { name: "Mesa/Boogie Mark IV Combo" },
+      { name: "Swart 5w Boutique Tube Amp" },
+      { name: "Bitar Boutique Amplifier", specs: "25-watt boutique tube amp" },
+      { name: "Ampeg Micro SVT", specs: "With matching cabinet for bass" },
+    ],
+  },
+];

--- a/convex/gearTree.ts
+++ b/convex/gearTree.ts
@@ -6,6 +6,43 @@ export type GearScope = "draft" | "published";
 type GearCategoryDoc = Doc<"gearCategories">;
 type GearItemDoc = Doc<"gearItems">;
 
+export type SortedGearCategoryRow<T> = {
+  stableId: string;
+  name: string;
+  sort: number;
+  items: T[];
+};
+
+/**
+ * Group items by category, sort categories and items by `sort` then `stableId`,
+ * and map each item through `mapItem`. Used by public site reads and admin payloads
+ * so ordering rules stay in one place.
+ */
+export function mapSortedGearTree<T>(
+  categories: GearCategoryDoc[],
+  items: GearItemDoc[],
+  mapItem: (item: GearItemDoc) => T,
+): SortedGearCategoryRow<T>[] {
+  const byCat = new Map<string, GearItemDoc[]>();
+  for (const it of items) {
+    const list = byCat.get(it.categoryStableId) ?? [];
+    list.push(it);
+    byCat.set(it.categoryStableId, list);
+  }
+  for (const list of byCat.values()) {
+    list.sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId));
+  }
+  const sortedCats = [...categories].sort(
+    (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
+  );
+  return sortedCats.map((c) => ({
+    stableId: c.stableId,
+    name: c.name,
+    sort: c.sort,
+    items: (byCat.get(c.stableId) ?? []).map(mapItem),
+  }));
+}
+
 function normalizeSpecsForCompare(specs: GearItemDoc["specs"]): unknown {
   if (specs.kind === "kv") {
     return {

--- a/convex/gearTree.ts
+++ b/convex/gearTree.ts
@@ -1,0 +1,156 @@
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+
+export type GearScope = "draft" | "published";
+
+type GearCategoryDoc = Doc<"gearCategories">;
+type GearItemDoc = Doc<"gearItems">;
+
+function normalizeSpecsForCompare(specs: GearItemDoc["specs"]): unknown {
+  if (specs.kind === "kv") {
+    return {
+      kind: "kv" as const,
+      pairs: [...specs.pairs].sort((a, b) => a.key.localeCompare(b.key)),
+    };
+  }
+  return specs;
+}
+
+/** Deterministic shape for deep equality between draft and published trees. */
+export function normalizeGearTreeForCompare(
+  categories: GearCategoryDoc[],
+  items: GearItemDoc[],
+): unknown {
+  const catNorm = [...categories]
+    .sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId))
+    .map((c) => ({
+      stableId: c.stableId,
+      name: c.name,
+      sort: c.sort,
+    }));
+  const itemNorm = [...items]
+    .sort(
+      (a, b) =>
+        a.categoryStableId.localeCompare(b.categoryStableId) ||
+        a.sort - b.sort ||
+        a.stableId.localeCompare(b.stableId),
+    )
+    .map((i) => ({
+      stableId: i.stableId,
+      categoryStableId: i.categoryStableId,
+      name: i.name,
+      sort: i.sort,
+      specs: normalizeSpecsForCompare(i.specs),
+      url: i.url ?? null,
+    }));
+  return { categories: catNorm, items: itemNorm };
+}
+
+export async function loadGearDocs(
+  ctx: QueryCtx | MutationCtx,
+  scope: GearScope,
+): Promise<{ categories: GearCategoryDoc[]; items: GearItemDoc[] }> {
+  const categories = await ctx.db
+    .query("gearCategories")
+    .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+    .order("asc")
+    .collect();
+  const items = await ctx.db
+    .query("gearItems")
+    .withIndex("by_scope", (q) => q.eq("scope", scope))
+    .collect();
+  items.sort((a, b) => {
+    if (a.categoryStableId !== b.categoryStableId) {
+      return a.categoryStableId.localeCompare(b.categoryStableId);
+    }
+    return a.sort - b.sort || a.stableId.localeCompare(b.stableId);
+  });
+  return { categories, items };
+}
+
+export function gearDraftMatchesPublished(
+  draft: { categories: GearCategoryDoc[]; items: GearItemDoc[] },
+  published: { categories: GearCategoryDoc[]; items: GearItemDoc[] },
+): boolean {
+  const a = normalizeGearTreeForCompare(draft.categories, draft.items);
+  const b = normalizeGearTreeForCompare(published.categories, published.items);
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Delete all gear docs for a scope (items first). */
+export async function deleteAllGearForScope(
+  ctx: MutationCtx,
+  scope: GearScope,
+): Promise<void> {
+  for (;;) {
+    const batch = await ctx.db
+      .query("gearItems")
+      .withIndex("by_scope", (q) => q.eq("scope", scope))
+      .take(100);
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+  }
+  for (;;) {
+    const batch = await ctx.db
+      .query("gearCategories")
+      .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+      .take(100);
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+  }
+}
+
+/** Copy entire tree from one scope to another; clears destination first. */
+export async function copyGearScope(
+  ctx: MutationCtx,
+  from: GearScope,
+  to: GearScope,
+): Promise<void> {
+  await deleteAllGearForScope(ctx, to);
+  const { categories, items } = await loadGearDocs(ctx, from);
+  for (const c of categories) {
+    await ctx.db.insert("gearCategories", {
+      scope: to,
+      stableId: c.stableId,
+      name: c.name,
+      sort: c.sort,
+    });
+  }
+  for (const i of items) {
+    await ctx.db.insert("gearItems", {
+      scope: to,
+      stableId: i.stableId,
+      categoryStableId: i.categoryStableId,
+      name: i.name,
+      sort: i.sort,
+      specs: i.specs,
+      url: i.url,
+    });
+  }
+}
+
+export async function ensureGearMeta(
+  ctx: MutationCtx,
+): Promise<{ id: Id<"gearMeta">; row: Doc<"gearMeta"> }> {
+  const existing = await ctx.db
+    .query("gearMeta")
+    .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+    .unique();
+  const now = Date.now();
+  if (existing) {
+    return { id: existing._id, row: existing };
+  }
+  const id = await ctx.db.insert("gearMeta", {
+    singletonKey: "default",
+    hasDraftChanges: false,
+    publishedAt: null,
+    updatedAt: now,
+  });
+  const row = await ctx.db.get(id);
+  if (!row) throw new Error("gearMeta insert failed");
+  return { id, row };
+}

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -3,7 +3,7 @@ import {
   publishedPricingFromRows,
   publishedSettingsFromRow,
 } from "./publicSettingsSnapshot";
-import { loadGearDocs } from "./gearTree";
+import { loadGearDocs, mapSortedGearTree } from "./gearTree";
 import type { Doc } from "./_generated/dataModel";
 
 /**
@@ -66,36 +66,6 @@ type GearCategoryPublic = {
   items: GearItemPublic[];
 };
 
-function publishedGearTree(
-  categories: Doc<"gearCategories">[],
-  items: Doc<"gearItems">[],
-): GearCategoryPublic[] {
-  const byCat = new Map<string, Doc<"gearItems">[]>();
-  for (const it of items) {
-    const list = byCat.get(it.categoryStableId) ?? [];
-    list.push(it);
-    byCat.set(it.categoryStableId, list);
-  }
-  for (const list of byCat.values()) {
-    list.sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId));
-  }
-  const sortedCats = [...categories].sort(
-    (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
-  );
-  return sortedCats.map((c) => ({
-    stableId: c.stableId,
-    name: c.name,
-    sort: c.sort,
-    items: (byCat.get(c.stableId) ?? []).map((i) => ({
-      stableId: i.stableId,
-      name: i.name,
-      sort: i.sort,
-      specs: i.specs,
-      ...(i.url !== undefined ? { url: i.url } : {}),
-    })),
-  }));
-}
-
 /**
  * Published studio gear only (INF-86). Anonymous; reads `scope === "published"`.
  */
@@ -103,6 +73,14 @@ export const getPublishedGear = query({
   args: {},
   handler: async (ctx) => {
     const { categories, items } = await loadGearDocs(ctx, "published");
-    return { categories: publishedGearTree(categories, items) };
+    return {
+      categories: mapSortedGearTree<GearItemPublic>(categories, items, (i) => ({
+        stableId: i.stableId,
+        name: i.name,
+        sort: i.sort,
+        specs: i.specs,
+        ...(i.url !== undefined ? { url: i.url } : {}),
+      })),
+    };
   },
 });

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -3,6 +3,8 @@ import {
   publishedPricingFromRows,
   publishedSettingsFromRow,
 } from "./publicSettingsSnapshot";
+import { loadGearDocs } from "./gearTree";
+import type { Doc } from "./_generated/dataModel";
 
 /**
  * **Public (anonymous) site reads** — published snapshot only.
@@ -46,5 +48,61 @@ export const getPublishedPricingFlags = query({
     ]);
 
     return publishedPricingFromRows(pricingRow, settingsRow);
+  },
+});
+
+type GearItemPublic = {
+  stableId: string;
+  name: string;
+  sort: number;
+  specs: Doc<"gearItems">["specs"];
+  url?: string;
+};
+
+type GearCategoryPublic = {
+  stableId: string;
+  name: string;
+  sort: number;
+  items: GearItemPublic[];
+};
+
+function publishedGearTree(
+  categories: Doc<"gearCategories">[],
+  items: Doc<"gearItems">[],
+): GearCategoryPublic[] {
+  const byCat = new Map<string, Doc<"gearItems">[]>();
+  for (const it of items) {
+    const list = byCat.get(it.categoryStableId) ?? [];
+    list.push(it);
+    byCat.set(it.categoryStableId, list);
+  }
+  for (const list of byCat.values()) {
+    list.sort((a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId));
+  }
+  const sortedCats = [...categories].sort(
+    (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
+  );
+  return sortedCats.map((c) => ({
+    stableId: c.stableId,
+    name: c.name,
+    sort: c.sort,
+    items: (byCat.get(c.stableId) ?? []).map((i) => ({
+      stableId: i.stableId,
+      name: i.name,
+      sort: i.sort,
+      specs: i.specs,
+      ...(i.url !== undefined ? { url: i.url } : {}),
+    })),
+  }));
+}
+
+/**
+ * Published studio gear only (INF-86). Anonymous; reads `scope === "published"`.
+ */
+export const getPublishedGear = query({
+  args: {},
+  handler: async (ctx) => {
+    const { categories, items } = await loadGearDocs(ctx, "published");
+    return { categories: publishedGearTree(categories, items) };
   },
 });

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -104,3 +104,20 @@ export const cmsSectionValidator = v.union(
   v.literal("settings"),
   v.literal("pricing"),
 );
+
+/** Draft vs published rows in `gearCategories` / `gearItems` (INF-86). */
+export const gearScopeValidator = v.union(
+  v.literal("draft"),
+  v.literal("published"),
+);
+
+/**
+ * Item specs: markdown string or structured key/value pairs.
+ */
+export const gearSpecsValidator = v.union(
+  v.object({ kind: v.literal("markdown"), text: v.string() }),
+  v.object({
+    kind: v.literal("kv"),
+    pairs: v.array(v.object({ key: v.string(), value: v.string() })),
+  }),
+);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import {
   cmsSectionValidator,
   cmsSnapshotValidator,
+  gearSpecsValidator,
 } from "./schema.shared";
 
 // Draft/publish model: see docs/cms-publish.md (INF-70).
@@ -42,4 +43,46 @@ export default defineSchema({
     draftSnapshot: v.optional(cmsSnapshotValidator),
     hasDraftChanges: v.boolean(),
   }).index("by_section", ["section"]),
+
+  /**
+   * Studio gear CMS (INF-86): separate rows per scope so we can index by category
+   * and sort. Publish replaces all `published` rows in one transaction; discard
+   * copies `published` → `draft` after clearing draft.
+   */
+  gearMeta: defineTable({
+    singletonKey: v.literal("default"),
+    hasDraftChanges: v.boolean(),
+    publishedAt: v.union(v.number(), v.null()),
+    publishedBy: v.optional(v.string()),
+    updatedAt: v.number(),
+    updatedBy: v.optional(v.string()),
+  }).index("by_singleton", ["singletonKey"]),
+
+  gearCategories: defineTable({
+    scope: v.union(v.literal("draft"), v.literal("published")),
+    /** Client-generated stable id (not Convex `_id`). */
+    stableId: v.string(),
+    name: v.string(),
+    sort: v.number(),
+  })
+    .index("by_scope_and_sort", ["scope", "sort"])
+    .index("by_scope_and_stableId", ["scope", "stableId"]),
+
+  gearItems: defineTable({
+    scope: v.union(v.literal("draft"), v.literal("published")),
+    stableId: v.string(),
+    /** References `gearCategories.stableId` for the same scope. */
+    categoryStableId: v.string(),
+    name: v.string(),
+    sort: v.number(),
+    specs: gearSpecsValidator,
+    url: v.optional(v.string()),
+  })
+    .index("by_scope", ["scope"])
+    .index("by_scope_and_category_and_sort", [
+      "scope",
+      "categoryStableId",
+      "sort",
+    ])
+    .index("by_scope_and_stableId", ["scope", "stableId"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import {
   cmsSectionValidator,
   cmsSnapshotValidator,
+  gearScopeValidator,
   gearSpecsValidator,
 } from "./schema.shared";
 
@@ -59,7 +60,7 @@ export default defineSchema({
   }).index("by_singleton", ["singletonKey"]),
 
   gearCategories: defineTable({
-    scope: v.union(v.literal("draft"), v.literal("published")),
+    scope: gearScopeValidator,
     /** Client-generated stable id (not Convex `_id`). */
     stableId: v.string(),
     name: v.string(),
@@ -69,7 +70,7 @@ export default defineSchema({
     .index("by_scope_and_stableId", ["scope", "stableId"]),
 
   gearItems: defineTable({
-    scope: v.union(v.literal("draft"), v.literal("published")),
+    scope: gearScopeValidator,
     stableId: v.string(),
     /** References `gearCategories.stableId` for the same scope. */
     categoryStableId: v.string(),

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -5,6 +5,8 @@ import {
   type CmsSection,
   type CmsSnapshot,
 } from "./cmsShared";
+import { LEGACY_EQUIPMENT_SEED } from "./gearEquipmentSeed";
+import { ensureGearMeta, gearDraftMatchesPublished, loadGearDocs } from "./gearTree";
 
 /**
  * Idempotent seed for local dev: creates both CMS rows (`settings`, `pricing`)
@@ -46,6 +48,66 @@ export const seedSiteSettingsDefaults = internalMutation({
 
     return {
       results,
+    };
+  },
+});
+
+/**
+ * One-time import of legacy `equipment-specs.tsx` gear into **draft** only (INF-86).
+ * No-op when any gear rows already exist. After running, call `api.admin.gear.publishGear`
+ * from the dashboard (owner auth) to go live, or edit draft first.
+ *
+ * `bunx convex run internal.seed.seedGearFromEquipmentSpecs`
+ */
+export const seedGearFromEquipmentSpecs = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const draft = await loadGearDocs(ctx, "draft");
+    const published = await loadGearDocs(ctx, "published");
+    if (
+      draft.categories.length +
+        draft.items.length +
+        published.categories.length +
+        published.items.length >
+      0
+    ) {
+      return { ok: false as const, reason: "already_has_data" as const };
+    }
+
+    for (let ci = 0; ci < LEGACY_EQUIPMENT_SEED.length; ci++) {
+      const cat = LEGACY_EQUIPMENT_SEED[ci];
+      const catStableId = `legacy_cat_${ci}`;
+      await ctx.db.insert("gearCategories", {
+        scope: "draft",
+        stableId: catStableId,
+        name: cat.category,
+        sort: ci,
+      });
+      for (let ii = 0; ii < cat.items.length; ii++) {
+        const item = cat.items[ii];
+        await ctx.db.insert("gearItems", {
+          scope: "draft",
+          stableId: `legacy_cat_${ci}_item_${ii}`,
+          categoryStableId: catStableId,
+          name: item.name,
+          sort: ii,
+          specs: { kind: "markdown", text: item.specs ?? "" },
+        });
+      }
+    }
+
+    const { id: metaId } = await ensureGearMeta(ctx);
+    const draftAfter = await loadGearDocs(ctx, "draft");
+    const publishedAfter = await loadGearDocs(ctx, "published");
+    const hasDraftChanges = !gearDraftMatchesPublished(draftAfter, publishedAfter);
+    await ctx.db.patch(metaId, {
+      hasDraftChanges,
+      updatedAt: Date.now(),
+    });
+
+    return {
+      ok: true as const,
+      categoriesSeeded: LEGACY_EQUIPMENT_SEED.length,
     };
   },
 });


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Convex tables and publish/discard mutations that bulk-delete and copy gear data between draft and published scopes; mistakes could overwrite published content. Public API now serves gear from the new published dataset, so data/shape issues would impact the marketing site.
> 
> **Overview**
> Adds a new **studio gear** domain with draft/publish semantics: schema introduces `gearMeta`, `gearCategories`, and `gearItems` (scoped as `draft` vs `published`) plus shared helpers in `gearTree.ts` to load, compare, and copy scopes.
> 
> Introduces owner-gated admin endpoints in `admin/gear.ts` to CRUD draft categories/items, validate draft before publish, and atomically `publishGear`/`discardDraftGear` by copying entire scopes while tracking `hasDraftChanges` and publish metadata.
> 
> Adds a new anonymous public query `public.getPublishedGear` that returns the published gear tree, plus an internal seed (`seedGearFromEquipmentSpecs`) and the legacy data source (`gearEquipmentSeed.ts`) for one-time import; generated `api` types are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1527a91673fea3456b0cde460a376347b43cc439. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->