### PR TITLE
Feat/inf 88 marketing equipment

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as cmsShared from "../cmsShared.js";
 import type * as errors from "../errors.js";
 import type * as gearEquipmentSeed from "../gearEquipmentSeed.js";
 import type * as gearLegacySeed from "../gearLegacySeed.js";
+import type * as gearPreviewDraft from "../gearPreviewDraft.js";
 import type * as gearTree from "../gearTree.js";
 import type * as inquiries from "../inquiries.js";
 import type * as lib_auth from "../lib/auth.js";
@@ -48,6 +49,7 @@ declare const fullApi: ApiFromModules<{
   errors: typeof errors;
   gearEquipmentSeed: typeof gearEquipmentSeed;
   gearLegacySeed: typeof gearLegacySeed;
+  gearPreviewDraft: typeof gearPreviewDraft;
   gearTree: typeof gearTree;
   inquiries: typeof inquiries;
   "lib/auth": typeof lib_auth;

--- a/convex/gearPreviewDraft.ts
+++ b/convex/gearPreviewDraft.ts
@@ -1,0 +1,59 @@
+import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import { loadGearDocs, mapSortedGearTree } from "./gearTree";
+import type { Doc } from "./_generated/dataModel";
+
+type GearItemPreview = {
+  stableId: string;
+  name: string;
+  sort: number;
+  specs: Doc<"gearItems">["specs"];
+  url?: string;
+};
+
+/**
+ * Owner-only preview of studio gear (INF-88). Returns the **draft** tree when
+ * `gearMeta.hasDraftChanges` is true, otherwise the published tree. Mirrors
+ * `pricingPreviewDraft.getPreviewPricingFlags` so `/preview` can opt into
+ * draft overlay without ever exposing it to anonymous readers.
+ *
+ * Returns `null` for unauthenticated or non-owner callers.
+ */
+export const getPreviewGear = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) return null;
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const meta = await ctx.db
+      .query("gearMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+
+    const hasDraftChanges = meta?.hasDraftChanges ?? false;
+    const scope = hasDraftChanges ? "draft" : "published";
+
+    const { categories, items } = await loadGearDocs(ctx, scope);
+
+    return {
+      categories: mapSortedGearTree<GearItemPreview>(
+        categories,
+        items,
+        (i) => ({
+          stableId: i.stableId,
+          name: i.name,
+          sort: i.sort,
+          specs: i.specs,
+          ...(i.url !== undefined ? { url: i.url } : {}),
+        }),
+      ),
+      hasDraftChanges,
+    };
+  },
+});

--- a/src/app/admin/gear/gear-editor.tsx
+++ b/src/app/admin/gear/gear-editor.tsx
@@ -736,7 +736,7 @@ function GearEditorForm() {
         publishedByLabel={publishedByLabel}
         busy={busy}
         inlineError={inlineError}
-        previewHref="/#equipment-specs"
+        previewHref="/preview#equipment-specs"
         onPublish={() => {
           void (async () => {
             const ok = await runAction("Publishing…", publishProgram);

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -29,8 +29,12 @@ export default async function AdminLayout({
 
   return (
     <TooltipProvider>
-      <Toaster richColors closeButton />
-      <SidebarProvider defaultOpen={defaultOpen}>
+      <Toaster richColors closeButton position="top-right" />
+      <SidebarProvider
+        defaultOpen={defaultOpen}
+        resizableWidth
+        sidebarWidthStorageKey="admin_sidebar_width_px"
+      >
         <AdminSidebar />
         <SidebarInset className="text-foreground">
           {children}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -1,17 +1,70 @@
 "use client";
 
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+
+type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
+type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
+
+function BothPreloaded({
+  preloadedPricing,
+  preloadedGear,
+}: {
+  preloadedPricing: NonNullable<PreloadedPricing>;
+  preloadedGear: NonNullable<PreloadedGear>;
+}) {
+  const pricingFlags = usePreloadedQuery(preloadedPricing);
+  const gear = usePreloadedQuery(preloadedGear);
+  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
+}
+
+function PricingPreloadedGearLive({
+  preloadedPricing,
+}: {
+  preloadedPricing: NonNullable<PreloadedPricing>;
+}) {
+  const pricingFlags = usePreloadedQuery(preloadedPricing);
+  const gear = useQuery(api.public.getPublishedGear);
+  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
+}
+
+function PricingLiveGearPreloaded({
+  preloadedGear,
+}: {
+  preloadedGear: NonNullable<PreloadedGear>;
+}) {
+  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
+  const gear = usePreloadedQuery(preloadedGear);
+  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
+}
+
+function BothLive() {
+  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
+  const gear = useQuery(api.public.getPublishedGear);
+  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
+}
 
 export function HomeClient({
   preloadedPricing,
   preloadedGear,
 }: {
-  preloadedPricing: Preloaded<typeof api.public.getPublishedPricingFlags>;
-  preloadedGear: Preloaded<typeof api.public.getPublishedGear>;
+  preloadedPricing: PreloadedPricing;
+  preloadedGear: PreloadedGear;
 }) {
-  const pricingFlags = usePreloadedQuery(preloadedPricing);
-  const gear = usePreloadedQuery(preloadedGear);
-  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
+  if (preloadedPricing && preloadedGear) {
+    return (
+      <BothPreloaded
+        preloadedPricing={preloadedPricing}
+        preloadedGear={preloadedGear}
+      />
+    );
+  }
+  if (preloadedPricing) {
+    return <PricingPreloadedGearLive preloadedPricing={preloadedPricing} />;
+  }
+  if (preloadedGear) {
+    return <PricingLiveGearPreloaded preloadedGear={preloadedGear} />;
+  }
+  return <BothLive />;
 }

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -6,9 +6,12 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export function HomeClient({
   preloadedPricing,
+  preloadedGear,
 }: {
   preloadedPricing: Preloaded<typeof api.public.getPublishedPricingFlags>;
+  preloadedGear: Preloaded<typeof api.public.getPublishedGear>;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
-  return <HomepageShell pricingFlags={pricingFlags} />;
+  const gear = usePreloadedQuery(preloadedGear);
+  return <HomepageShell pricingFlags={pricingFlags} gear={gear} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,17 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
   try {
-    const [preloadedPricing, preloadedGear] = await Promise.all([
+    const [pricingSettled, gearSettled] = await Promise.allSettled([
       preloadQuery(api.public.getPublishedPricingFlags),
       preloadQuery(api.public.getPublishedGear),
     ]);
+    const preloadedPricing =
+      pricingSettled.status === "fulfilled" ? pricingSettled.value : null;
+    const preloadedGear =
+      gearSettled.status === "fulfilled" ? gearSettled.value : null;
+    if (preloadedPricing === null && preloadedGear === null) {
+      return <HomepageShell pricingFlags={null} gear={null} />;
+    }
     return (
       <HomeClient
         preloadedPricing={preloadedPricing}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,11 +5,17 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
   try {
-    const preloadedPricing = await preloadQuery(
-      api.public.getPublishedPricingFlags,
+    const [preloadedPricing, preloadedGear] = await Promise.all([
+      preloadQuery(api.public.getPublishedPricingFlags),
+      preloadQuery(api.public.getPublishedGear),
+    ]);
+    return (
+      <HomeClient
+        preloadedPricing={preloadedPricing}
+        preloadedGear={preloadedGear}
+      />
     );
-    return <HomeClient preloadedPricing={preloadedPricing} />;
   } catch {
-    return <HomepageShell pricingFlags={null} />;
+    return <HomepageShell pricingFlags={null} gear={null} />;
   }
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -10,8 +10,9 @@ function PreviewContent() {
   const pricingFlags = useQuery(
     api.pricingPreviewDraft.getPreviewPricingFlags,
   );
+  const gearPreview = useQuery(api.gearPreviewDraft.getPreviewGear);
 
-  if (pricingFlags === undefined) {
+  if (pricingFlags === undefined || gearPreview === undefined) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">Loading preview…</p>
@@ -19,7 +20,7 @@ function PreviewContent() {
     );
   }
 
-  if (pricingFlags === null) {
+  if (pricingFlags === null || gearPreview === null) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">
@@ -29,15 +30,17 @@ function PreviewContent() {
     );
   }
 
+  const hasDraftChanges =
+    pricingFlags.hasDraftChanges || gearPreview.hasDraftChanges;
+
   return (
     <HomepageShell
       pricingFlags={{
         flags: pricingFlags.flags,
         packages: pricingFlags.packages,
       }}
-      banner={
-        <PreviewBanner hasDraftChanges={pricingFlags.hasDraftChanges} />
-      }
+      gear={{ categories: gearPreview.categories }}
+      banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />
   );
 }

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -63,7 +63,11 @@ export function AdminSidebar() {
   const pathname = usePathname();
 
   return (
-    <Sidebar collapsible="icon" className="group-data-[side=left]:border-r-0">
+    <Sidebar
+      collapsible="icon"
+      showResizeHandle
+      className="group-data-[side=left]:border-r-0"
+    >
       <SidebarHeader className="p-4 group-data-[collapsible=icon]:p-2">
         <Link
           href="/admin"

--- a/src/components/equipment-specs.tsx
+++ b/src/components/equipment-specs.tsx
@@ -1,174 +1,34 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
-type EquipmentItem = {
+/**
+ * Published (or preview) gear payload surfaced to the marketing site.
+ * Matches the return shape of `api.public.getPublishedGear` and the
+ * `categories` portion of `api.gearPreviewDraft.getPreviewGear`.
+ */
+export type GearSpecs =
+  | { kind: "markdown"; text: string }
+  | { kind: "kv"; pairs: { key: string; value: string }[] };
+
+export type GearItem = {
+  stableId: string;
   name: string;
-  specs?: string;
+  sort: number;
+  specs: GearSpecs;
+  url?: string;
 };
 
-type EquipmentCategory = {
-  category: string;
-  items: EquipmentItem[];
+export type GearCategory = {
+  stableId: string;
+  name: string;
+  sort: number;
+  items: GearItem[];
 };
 
-const EQUIPMENT_CATEGORIES: EquipmentCategory[] = [
-  {
-    category: "Interfaces & Console",
-    items: [
-      { name: "API 2448 Console", specs: "With 16x API 560 EQs and 8x API 550B EQs" },
-      { name: "2x Universal Audio Apollo x16 Interfaces" },
-      { name: "Pro Tools Ultimate" },
-    ],
-  },
-  {
-    category: "Preamps & Channel Strips",
-    items: [
-      { name: "Neve 1073OPX" },
-      { name: "AEA RPQ3" },
-      { name: "Tree Audio Branch" },
-      { name: "2x Avalon Channel Strips" },
-      { name: '2x Sunset Sound "Tutti" Mic/Instrument Pre' },
-    ],
-  },
-  {
-    category: "Compressors & Dynamics",
-    items: [
-      { name: "2x Empirical Labs Distressor" },
-      { name: "2x Urei 1176LN" },
-      { name: "2x Purple Audio MC77" },
-      { name: "2x DBX 165" },
-      { name: "Retro STA-Level Compressor" },
-      { name: "Manley Vari-Mu Stereo Compressor/Limiter" },
-      { name: "Unfairchild 670 Stereo Compressor" },
-      { name: "Grandchild 670 Stereo Compressor" },
-      { name: "SSL G-Bus Stereo Compressor" },
-      { name: "Custom SSL Talkback-Style Limiter" },
-      { name: "2x LevelOr Limiter/DI/Distortion Units" },
-    ],
-  },
-  {
-    category: "EQs",
-    items: [
-      { name: "2x Heritage Audio 1073 EQ" },
-      { name: "2x Helios 5011 EQ" },
-      { name: "Chandler Limited Curve Bender" },
-    ],
-  },
-  {
-    category: "Tape & Saturation",
-    items: [
-      { name: "2x Neve Portico 542 Tape Emulators" },
-      { name: "Thermionic Culture Vulture" },
-    ],
-  },
-  {
-    category: "Reverb & Effects",
-    items: [
-      { name: "AMS RMX16 Digital Reverb" },
-      { name: "Bricasti M7 Digital Reverb" },
-    ],
-  },
-  {
-    category: "Plugins",
-    items: [
-      { name: "Universal Audio Suite" },
-      { name: "FabFilter Suite" },
-      { name: "Eventide Suite" },
-      { name: "Waves Suite" },
-      { name: "SSL Suite" },
-      { name: "Soundtoys Suite" },
-      { name: "Valhalla Collection" },
-      { name: "Additional Plugins" },
-    ],
-  },
-  {
-    category: "Dynamic Microphones",
-    items: [
-      { name: "3x Shure SM57" },
-      { name: "4x Shure SM58" },
-      { name: "Shure Beta52A" },
-      { name: "Shure SM7B" },
-      { name: "AKG D112" },
-      { name: "Audix D6" },
-      { name: "4x Sennheiser e906" },
-      { name: "4x Sennheiser MD421" },
-      { name: "Electro-Voice 635A" },
-      { name: "2x Electro-Voice RE16" },
-      { name: "Dr. Alien Smith DirtMic01" },
-      { name: "Dr. Alien Smith Alien8" },
-    ],
-  },
-  {
-    category: "Condenser Microphones",
-    items: [
-      { name: "2x Shure SM81" },
-      { name: "2x Audio-Technica AT4060A" },
-      { name: "4x Audio-Technica AT4021" },
-      { name: "2x Audio-Technica AT4047" },
-      { name: "4x Audio-Technica ATM450" },
-      { name: "2x Neumann U67" },
-      { name: "Neumann M49" },
-      { name: "Neumann U47" },
-      { name: "Neumann KM86" },
-      { name: "Soyuz 017 FET" },
-      { name: "2x Soyuz 013 FET" },
-      { name: "Dachmann Audio 47 FET" },
-    ],
-  },
-  {
-    category: "Ribbon Microphones",
-    items: [
-      { name: "2x Audio-Technica AT4081" },
-      { name: "2x Audio-Technica AT4080" },
-      { name: "2x AEA R84" },
-      { name: "AEA R88" },
-      { name: "AEA R44" },
-      { name: "3x AEA KU5A" },
-      { name: "2x Coles 4038" },
-      { name: "3x Royer R-10" },
-      { name: "Royer R-121" },
-    ],
-  },
-  {
-    category: "Drum Kits & Percussion",
-    items: [
-      { name: "DW Drum Kit" },
-      { name: "Vintage 1960s Rogers Jazz Kit" },
-      { name: "1920s Ludwig Steel Snare" },
-      { name: "2x DW Snares" },
-    ],
-  },
-  {
-    category: "Guitars & Basses",
-    items: [
-      { name: "1990s Fender Stratocaster" },
-      { name: "Custom Hamer Partscaster Tele" },
-      { name: "1978 Gibson 335 with Bigsby" },
-      { name: "2013 '57 Reissue Gibson Les Paul Goldtopp" },
-      { name: "1958 Gibson J-50 Acoustic" },
-      { name: "1971 Martin D-28" },
-      { name: "2005 Martin HD-28" },
-      { name: "1970s Gibson LG-1" },
-      { name: "Ernie Ball Music Man Bass" },
-    ],
-  },
-  {
-    category: "Amplifiers",
-    items: [
-      { name: "Vox AC15" },
-      { name: "Vox AC4" },
-      { name: "Fender Princeton 15w" },
-      { name: "Fender Princeton 10w" },
-      { name: "Fender Blues Jr. Tweed 15w" },
-      { name: "Fender Champ" },
-      { name: "Mesa/Boogie Mark IV Combo" },
-      { name: "Swart 5w Boutique Tube Amp" },
-      { name: "Bitar Boutique Amplifier", specs: "25-watt boutique tube amp" },
-      { name: "Ampeg Micro SVT", specs: "With matching cabinet for bass" },
-    ],
-  },
-] as const;
+export type GearPayload = {
+  categories: GearCategory[];
+};
 
 const STUDIO_SPECS = [
   {
@@ -179,102 +39,226 @@ const STUDIO_SPECS = [
   { label: "Cue System", value: "16-channel Hear Technology Cue System" },
 ] as const;
 
-export function EquipmentSpecs() {
-  const [expandedCategories, setExpandedCategories] = useState<number[]>([0, 1, 2]);
+const DEFAULT_EXPANDED_COUNT = 3;
 
-  const toggleCategory = (index: number) => {
-    setExpandedCategories((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
-  };
+function formatSpecs(specs: GearSpecs): string {
+  if (specs.kind === "markdown") {
+    return specs.text.trim();
+  }
+  return specs.pairs
+    .map(({ key, value }) => `${key.trim()}: ${value.trim()}`)
+    .filter((line) => line.length > 2)
+    .join(", ");
+}
 
+function SectionHeader() {
+  return (
+    <div className="text-center mb-16 reveal">
+      <p className="label-text text-sand/60 mb-4">Equipment</p>
+      <h2 className="headline-primary text-3xl md:text-4xl lg:text-5xl text-warm-white mb-6">
+        Studio Specifications
+      </h2>
+      <div className="section-rule max-w-xs mx-auto mb-8" />
+      <p className="body-text text-lg text-ivory/60 max-w-2xl mx-auto">
+        World-class equipment and acoustically designed spaces ensure your recordings
+        capture every nuance with pristine clarity and character.
+      </p>
+    </div>
+  );
+}
+
+function StudioSpecsGrid() {
+  return (
+    <div className="reveal reveal-delay-1 mb-16">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-sand/10 border border-sand/10">
+        {STUDIO_SPECS.map((spec) => (
+          <div key={spec.label} className="bg-washed-black p-6 md:p-8 text-center">
+            <div className="label-text text-sand mb-3">{spec.label}</div>
+            <div className="body-text-small text-ivory/60">{spec.value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SectionShell({ children }: { children: React.ReactNode }) {
   return (
     <section id="equipment-specs" className="py-24 md:py-32 px-6 bg-charcoal relative">
       <div className="absolute inset-0 opacity-20 bg-texture-stone" />
 
       <div className="relative z-10 max-w-6xl mx-auto">
-        {/* Section header */}
-        <div className="text-center mb-16 reveal">
-          <p className="label-text text-sand/60 mb-4">Equipment</p>
-          <h2 className="headline-primary text-3xl md:text-4xl lg:text-5xl text-warm-white mb-6">
-            Studio Specifications
-          </h2>
-          <div className="section-rule max-w-xs mx-auto mb-8" />
-          <p className="body-text text-lg text-ivory/60 max-w-2xl mx-auto">
-            World-class equipment and acoustically designed spaces ensure your recordings
-            capture every nuance with pristine clarity and character.
-          </p>
-        </div>
-
-        {/* Studio Room Specs */}
-        <div className="reveal reveal-delay-1 mb-16">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-sand/10 border border-sand/10">
-            {STUDIO_SPECS.map((spec, index) => (
-              <div key={index} className="bg-washed-black p-6 md:p-8 text-center">
-                <div className="label-text text-sand mb-3">{spec.label}</div>
-                <div className="body-text-small text-ivory/60">{spec.value}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Equipment Categories — accordion style */}
-        <div className="reveal reveal-delay-2 space-y-px">
-          {EQUIPMENT_CATEGORIES.map((category, categoryIndex) => {
-            const isExpanded = expandedCategories.includes(categoryIndex);
-            return (
-              <div key={categoryIndex} className="border border-sand/8 bg-washed-black/60">
-                <button
-                  onClick={() => toggleCategory(categoryIndex)}
-                  className="w-full px-6 py-5 flex items-center justify-between hover:bg-sand/5 transition-colors"
-                >
-                  <span className="headline-secondary text-lg text-sand">
-                    {category.category}
-                  </span>
-                  <div className="flex items-center gap-3">
-                    <span className="label-text text-ivory/30 text-[10px]">
-                      {category.items.length}
-                    </span>
-                    <svg
-                      className={`w-4 h-4 text-ivory/30 transition-transform duration-300 ${
-                        isExpanded ? "rotate-180" : ""
-                      }`}
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={1.5}
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </div>
-                </button>
-
-                {isExpanded && (
-                  <div className="px-6 pb-6 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-1">
-                    {category.items.map((item, itemIndex) => (
-                      <div
-                        key={itemIndex}
-                        className="py-2 border-b border-sand/5 last:border-0 flex items-baseline justify-between gap-4"
-                      >
-                        <span className="body-text text-ivory/70 text-sm">{item.name}</span>
-                        {item.specs && (
-                          <span className="body-text-small text-ivory/35 text-xs whitespace-nowrap">
-                            {item.specs}
-                          </span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <SectionHeader />
+        <StudioSpecsGrid />
+        {children}
       </div>
     </section>
+  );
+}
+
+export function EquipmentSpecsSkeleton() {
+  return (
+    <SectionShell>
+      <div className="reveal reveal-delay-2 space-y-px" aria-hidden>
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="border border-sand/8 bg-washed-black/60 px-6 py-5 flex items-center justify-between animate-pulse"
+          >
+            <div className="h-4 w-48 bg-sand/10" />
+            <div className="h-3 w-8 bg-sand/10" />
+          </div>
+        ))}
+      </div>
+    </SectionShell>
+  );
+}
+
+function EquipmentSpecsEmpty() {
+  return (
+    <div className="reveal reveal-delay-2 border border-sand/8 bg-washed-black/60 p-10 text-center">
+      <p className="body-text text-ivory/60">
+        Equipment list coming soon. Check back shortly — our gear inventory is being
+        updated.
+      </p>
+    </div>
+  );
+}
+
+interface EquipmentSpecsProps {
+  /**
+   * `undefined` → still loading (render skeleton).
+   * `null` → query unavailable or caller not permitted (render empty state).
+   * Payload → render accordion.
+   */
+  readonly gear: GearPayload | null | undefined;
+}
+
+export function EquipmentSpecs({ gear }: EquipmentSpecsProps) {
+  if (gear === undefined) {
+    return <EquipmentSpecsSkeleton />;
+  }
+
+  const categories = gear?.categories ?? [];
+
+  if (categories.length === 0) {
+    return (
+      <SectionShell>
+        <EquipmentSpecsEmpty />
+      </SectionShell>
+    );
+  }
+
+  return (
+    <SectionShell>
+      <EquipmentCategoriesAccordion categories={categories} />
+    </SectionShell>
+  );
+}
+
+function EquipmentCategoriesAccordion({
+  categories,
+}: {
+  readonly categories: readonly GearCategory[];
+}) {
+  const initialExpanded = useMemo(
+    () =>
+      categories
+        .slice(0, DEFAULT_EXPANDED_COUNT)
+        .map((c) => c.stableId),
+    [categories],
+  );
+  const [expanded, setExpanded] = useState<readonly string[]>(initialExpanded);
+
+  const toggle = (stableId: string) => {
+    setExpanded((prev) =>
+      prev.includes(stableId)
+        ? prev.filter((id) => id !== stableId)
+        : [...prev, stableId],
+    );
+  };
+
+  return (
+    <div className="reveal reveal-delay-2 space-y-px">
+      {categories.map((category) => {
+        const isExpanded = expanded.includes(category.stableId);
+        return (
+          <div
+            key={category.stableId}
+            className="border border-sand/8 bg-washed-black/60"
+          >
+            <button
+              type="button"
+              onClick={() => toggle(category.stableId)}
+              aria-expanded={isExpanded}
+              aria-controls={`equipment-panel-${category.stableId}`}
+              className="w-full px-6 py-5 flex items-center justify-between hover:bg-sand/5 transition-colors"
+            >
+              <span className="headline-secondary text-lg text-sand">
+                {category.name}
+              </span>
+              <div className="flex items-center gap-3">
+                <span className="label-text text-ivory/30 text-[10px]">
+                  {category.items.length}
+                </span>
+                <svg
+                  className={`w-4 h-4 text-ivory/30 transition-transform duration-300 ${
+                    isExpanded ? "rotate-180" : ""
+                  }`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            </button>
+
+            {isExpanded && (
+              <div
+                id={`equipment-panel-${category.stableId}`}
+                className="px-6 pb-6 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-1"
+              >
+                {category.items.map((item) => {
+                  const specsLabel = formatSpecs(item.specs);
+                  return (
+                    <div
+                      key={item.stableId}
+                      className="py-2 border-b border-sand/5 last:border-0 flex items-baseline justify-between gap-4"
+                    >
+                      <span className="body-text text-ivory/70 text-sm">
+                        {item.url ? (
+                          <a
+                            href={item.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-sand underline-offset-4 hover:underline"
+                          >
+                            {item.name}
+                          </a>
+                        ) : (
+                          item.name
+                        )}
+                      </span>
+                      {specsLabel.length > 0 && (
+                        <span className="body-text-small text-ivory/35 text-xs whitespace-nowrap">
+                          {specsLabel}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { Header } from "@/components/header";
 import { Hero } from "@/components/hero";
 import { TheSpace } from "@/components/the-space";
-import { EquipmentSpecs } from "@/components/equipment-specs";
+import { EquipmentSpecs, type GearPayload } from "@/components/equipment-specs";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { FAQ } from "@/components/faq";
 import { ArtistInquiries } from "@/components/artist-inquiries";
@@ -18,10 +18,15 @@ function calculateLogoScale(scrollY: number): number {
 interface HomepageShellProps {
   /** `undefined` while the client is still subscribing (preview only if not preloaded). */
   readonly pricingFlags: PricingFlags | null | undefined;
+  /**
+   * Published (or preview) gear payload. `undefined` renders the skeleton;
+   * `null` renders the graceful empty state.
+   */
+  readonly gear: GearPayload | null | undefined;
   readonly banner?: React.ReactNode;
 }
 
-export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
+export function HomepageShell({ pricingFlags, gear, banner }: HomepageShellProps) {
   const [scrollY, setScrollY] = useState(0);
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
@@ -72,7 +77,7 @@ export function HomepageShell({ pricingFlags, banner }: HomepageShellProps) {
 
       <div className="relative z-10">
         <TheSpace />
-        <EquipmentSpecs />
+        <EquipmentSpecs gear={gear} />
         <MarketingPricingSection pricingFlags={pricingFlags} />
         <AmenitiesNearby />
         <FAQ />

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -35,6 +35,11 @@ const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
+/** Default matches `SIDEBAR_WIDTH` at 16px root. */
+const SIDEBAR_WIDTH_DEFAULT_PX = 256
+const SIDEBAR_WIDTH_MIN_PX = 200
+const SIDEBAR_WIDTH_MAX_PX = 480
+
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
   open: boolean
@@ -43,6 +48,9 @@ type SidebarContextProps = {
   setOpenMobile: (open: boolean) => void
   isMobile: boolean
   toggleSidebar: () => void
+  resizableWidth: boolean
+  sidebarWidthPx: number
+  setSidebarWidthPx: (px: number) => void
 }
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
@@ -60,6 +68,8 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  resizableWidth = false,
+  sidebarWidthStorageKey = "sidebar_width_px",
   className,
   style,
   children,
@@ -68,9 +78,52 @@ function SidebarProvider({
   defaultOpen?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  /** When true, sidebar width is draggable and persisted to localStorage. */
+  resizableWidth?: boolean
+  sidebarWidthStorageKey?: string
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
+  const [sidebarWidthPx, setSidebarWidthPxState] = React.useState(
+    SIDEBAR_WIDTH_DEFAULT_PX
+  )
+
+  React.useEffect(() => {
+    if (!resizableWidth || typeof window === "undefined") return
+    try {
+      const raw = window.localStorage.getItem(sidebarWidthStorageKey)
+      if (raw == null) return
+      const n = Number.parseInt(raw, 10)
+      if (Number.isFinite(n)) {
+        setSidebarWidthPxState(
+          Math.min(SIDEBAR_WIDTH_MAX_PX, Math.max(SIDEBAR_WIDTH_MIN_PX, n))
+        )
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [resizableWidth, sidebarWidthStorageKey])
+
+  const setSidebarWidthPx = React.useCallback(
+    (px: number) => {
+      const clamped = Math.min(
+        SIDEBAR_WIDTH_MAX_PX,
+        Math.max(SIDEBAR_WIDTH_MIN_PX, Math.round(px))
+      )
+      setSidebarWidthPxState(clamped)
+      if (resizableWidth && typeof window !== "undefined") {
+        try {
+          window.localStorage.setItem(
+            sidebarWidthStorageKey,
+            String(clamped)
+          )
+        } catch {
+          /* ignore */
+        }
+      }
+    },
+    [resizableWidth, sidebarWidthStorageKey]
+  )
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
@@ -125,9 +178,25 @@ function SidebarProvider({
       openMobile,
       setOpenMobile,
       toggleSidebar,
+      resizableWidth,
+      sidebarWidthPx,
+      setSidebarWidthPx,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      resizableWidth,
+      sidebarWidthPx,
+      setSidebarWidthPx,
+    ]
   )
+
+  const widthCss = resizableWidth ? `${sidebarWidthPx}px` : SIDEBAR_WIDTH
 
   return (
     <SidebarContext.Provider value={contextValue}>
@@ -135,7 +204,7 @@ function SidebarProvider({
         data-slot="sidebar-wrapper"
         style={
           {
-            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width": widthCss,
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
             ...style,
           } as React.CSSProperties
@@ -152,10 +221,89 @@ function SidebarProvider({
   )
 }
 
+function SidebarResizeHandle({
+  side = "left",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { side?: "left" | "right" }) {
+  const { isMobile, state, resizableWidth, sidebarWidthPx, setSidebarWidthPx } =
+    useSidebar()
+  const draggingRef = React.useRef(false)
+
+  if (!resizableWidth || isMobile || state === "collapsed") {
+    return null
+  }
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={sidebarWidthPx}
+      aria-valuemin={SIDEBAR_WIDTH_MIN_PX}
+      aria-valuemax={SIDEBAR_WIDTH_MAX_PX}
+      tabIndex={0}
+      data-slot="sidebar-resize-handle"
+      className={cn(
+        "absolute inset-y-0 z-30 w-1 cursor-col-resize touch-none select-none",
+        "border-r border-transparent",
+        "hover:border-sidebar-border/80 hover:bg-sidebar-border/15",
+        "focus-visible:border-sidebar-border focus-visible:bg-sidebar-border/20 focus-visible:outline-none",
+        side === "left" ? "right-0" : "left-0",
+        className
+      )}
+      onPointerDown={(e) => {
+        if (e.button !== 0) return
+        e.preventDefault()
+        const el = e.currentTarget
+        el.setPointerCapture(e.pointerId)
+        draggingRef.current = true
+        const startX = e.clientX
+        const startWidth = sidebarWidthPx
+        const onMove = (ev: PointerEvent) => {
+          if (!draggingRef.current) return
+          const delta =
+            side === "left" ? ev.clientX - startX : startX - ev.clientX
+          setSidebarWidthPx(startWidth + delta)
+        }
+        const onUp = (ev: PointerEvent) => {
+          draggingRef.current = false
+          try {
+            el.releasePointerCapture(ev.pointerId)
+          } catch {
+            /* already released */
+          }
+          window.removeEventListener("pointermove", onMove)
+          window.removeEventListener("pointerup", onUp)
+          window.removeEventListener("pointercancel", onUp)
+        }
+        window.addEventListener("pointermove", onMove)
+        window.addEventListener("pointerup", onUp)
+        window.addEventListener("pointercancel", onUp)
+      }}
+      onKeyDown={(e) => {
+        const step = e.shiftKey ? 16 : 4
+        if (e.key === "ArrowLeft") {
+          e.preventDefault()
+          setSidebarWidthPx(
+            sidebarWidthPx + (side === "left" ? -step : step)
+          )
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault()
+          setSidebarWidthPx(
+            sidebarWidthPx + (side === "left" ? step : -step)
+          )
+        }
+      }}
+      {...props}
+    />
+  )
+}
+
 function Sidebar({
   side = "left",
   variant = "sidebar",
   collapsible = "offcanvas",
+  showResizeHandle = false,
   className,
   children,
   dir,
@@ -164,6 +312,7 @@ function Sidebar({
   side?: "left" | "right"
   variant?: "sidebar" | "floating" | "inset"
   collapsible?: "offcanvas" | "icon" | "none"
+  showResizeHandle?: boolean
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
 
@@ -249,6 +398,7 @@ function Sidebar({
         >
           {children}
         </div>
+        {showResizeHandle ? <SidebarResizeHandle side={side} /> : null}
       </div>
     </div>
   )
@@ -720,6 +870,7 @@ export {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
+  SidebarResizeHandle,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Convex query paths and changes homepage/preview data-fetching to include gear, which could affect marketing page rendering and preview access control if misconfigured. Also introduces resizable admin sidebar state persisted in localStorage, with moderate UI regression risk.
> 
> **Overview**
> Marketing pages now render the **studio equipment list from CMS data** instead of a hardcoded array: `HomepageShell` accepts a `gear` payload and `EquipmentSpecs` handles loading (`undefined`), empty (`null`/no categories), and populated states with a dynamic accordion and optional item links.
> 
> The homepage (`/`) now preloads both published pricing and published gear with `Promise.allSettled` and falls back to live queries when preloading fails, while `/preview` gains an owner-only `api.gearPreviewDraft.getPreviewGear` endpoint and combines gear+pricing draft status to drive the preview banner. Admin UX tweaks include routing the gear editor preview button to `/preview#equipment-specs` and adding a **draggable, persisted sidebar width** plus top-right toast positioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ce05b07ca71c4ed42d94f36e9cfe0b7b01ce3e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->