### PR TITLE
fix(admin): reset CMS autosave debounce on each edit; pricing field contrast

### DIFF
--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -25,7 +25,7 @@ Each section has its own `cmsSections` row and therefore its own independent dra
 
 ## Admin UI (Settings, Pricing, Gear)
 
-The shared `CmsPublishToolbar` exposes three actions: **Publish**, **Discard**, and **Preview site**. There is **no explicit "Save draft" button** — editors auto-save local edits via a debounced `useAutosaveDraft` hook (`src/lib/use-autosave-draft.ts`, default 1000ms) that calls the same `api.cms.saveDraft` mutation under the hood. The toolbar renders sticky at the bottom of the admin viewport and shows a subtle `Saving… / Saved / Save failed — retrying` indicator alongside the "Unpublished changes" badge.
+The shared `CmsPublishToolbar` exposes three actions: **Publish**, **Discard**, and **Preview site**. There is **no explicit "Save draft" button** — editors auto-save local edits via a debounced `useAutosaveDraft` hook (`src/lib/use-autosave-draft.ts`, default 1000ms) that calls the same `api.cms.saveDraft` mutation under the hood. The debounce resets on each edit (idle window from the last keystroke), not only when the editor first becomes dirty. The toolbar renders sticky at the bottom of the admin viewport and shows a subtle `Saving… / Saved / Save failed — retrying` indicator alongside the "Unpublished changes" badge.
 
 Publish flushes any pending autosave first, so fast-clicking Publish after an edit is safe and never loses work.
 

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -81,6 +81,10 @@ const CADENCE_LABELS: Record<BillingCadence, string> = {
   custom: "Custom…",
 };
 
+/** Shared `Input` / textarea styling so admin fields stay readable on light surfaces. */
+const PRICING_FIELD_INPUT_CLASS =
+  "text-foreground placeholder:text-muted-foreground";
+
 function isCadence(value: string): value is BillingCadence {
   return (VALID_CADENCES as readonly string[]).includes(value);
 }
@@ -289,6 +293,7 @@ function PricingForm() {
 
   const { status: autosaveStatus, flush: flushAutosave } = useAutosaveDraft({
     dirty: hasLocalEdits && source !== undefined,
+    debounceResetKey: localDraft,
     pauseWhen: busy !== null,
     saveEffect: () =>
       convexMutationEffect(() =>
@@ -453,6 +458,7 @@ function PricingForm() {
                         updatePackage(pkg.id, { name: e.target.value })
                       }
                       placeholder="Recording — Hourly"
+                      className={PRICING_FIELD_INPUT_CLASS}
                     />
                   </label>
 
@@ -524,7 +530,7 @@ function PricingForm() {
                           }
                           updatePackage(pkg.id, { priceCents: next });
                         }}
-                        className="flex-1"
+                        className={cn(PRICING_FIELD_INPUT_CLASS, "flex-1")}
                       />
                       <Input
                         type="text"
@@ -536,7 +542,7 @@ function PricingForm() {
                             currency: e.target.value.toUpperCase(),
                           })
                         }
-                        className="w-20"
+                        className={cn(PRICING_FIELD_INPUT_CLASS, "w-20")}
                       />
                     </div>
                   </label>
@@ -575,6 +581,7 @@ function PricingForm() {
                         pkg.billingCadence === "custom" &&
                         (pkg.unitLabel ?? "").trim() === ""
                       }
+                      className={PRICING_FIELD_INPUT_CLASS}
                     />
                     {pkg.billingCadence === "custom" &&
                     (pkg.unitLabel ?? "").trim() === "" ? (
@@ -599,7 +606,10 @@ function PricingForm() {
                               : e.target.value,
                         })
                       }
-                      className="block w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+                      className={cn(
+                        PRICING_FIELD_INPUT_CLASS,
+                        "block w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm",
+                      )}
                     />
                   </label>
 
@@ -719,7 +729,7 @@ function FeaturesEditor({ features, onChange }: FeaturesEditorProps) {
                 onChange={(e) => update(idx, e.target.value)}
                 onBlur={commit}
                 placeholder={`Feature ${idx + 1}`}
-                className="flex-1"
+                className={cn(PRICING_FIELD_INPUT_CLASS, "flex-1")}
               />
               <Button
                 type="button"

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -117,6 +117,7 @@ function SettingsForm() {
 
   const { status: autosaveStatus, flush: flushAutosave } = useAutosaveDraft({
     dirty: hasLocalEdits && source !== undefined,
+    debounceResetKey: localDraft,
     pauseWhen: busy !== null,
     saveEffect: () =>
       convexMutationEffect(() =>

--- a/src/lib/use-autosave-draft.ts
+++ b/src/lib/use-autosave-draft.ts
@@ -14,6 +14,14 @@ export interface UseAutosaveDraftOptions {
    * transitions to `true`, the debounce timer is (re)started.
    */
   readonly dirty: boolean;
+  /**
+   * When `dirty` is true, include a value that changes on every local edit
+   * (e.g. the draft object from React state, or a serialized snapshot) so the
+   * debounce timer clears and restarts after each keystroke — idle debounce
+   * from the last edit, not from the first time `dirty` became true.
+   * Ignored when `dirty` is false (the effect still clears any pending timer).
+   */
+  readonly debounceResetKey?: unknown;
   /** Debounce delay before persisting to the server. Defaults to 1000ms. */
   readonly delayMs?: number;
   /**
@@ -48,12 +56,16 @@ export interface UseAutosaveDraftResult {
 }
 
 /**
- * Debounced autosave hook. Whenever `dirty` becomes (or stays) `true`, a
- * timer is scheduled that runs `saveEffect` after `delayMs` of inactivity.
- * In-flight timers are cancelled on unmount or when `pauseWhen` is `true`.
+ * Debounced autosave hook. While `dirty` is true, a timer runs `saveEffect`
+ * after `delayMs` with no further edits. The timer is cleared and restarted
+ * whenever `debounceResetKey` changes (pass draft state or a revision counter
+ * from the editor so each keystroke resets the idle window). When `dirty` is
+ * false, pending timers are cleared and no save is scheduled. Timers are also
+ * cancelled on unmount or when `pauseWhen` is `true`.
  */
 export function useAutosaveDraft({
   dirty,
+  debounceResetKey,
   delayMs = 1000,
   saveEffect,
   pauseWhen = false,
@@ -121,7 +133,7 @@ export function useAutosaveDraft({
       void runSave();
     }, delayMs);
     return clearTimer;
-  }, [dirty, delayMs, pauseWhen, runSave]);
+  }, [dirty, debounceResetKey, delayMs, pauseWhen, runSave]);
 
   useEffect(() => {
     mountedRef.current = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Autosave:** `useAutosaveDraft` now accepts optional `debounceResetKey`. While `dirty` is true, the debounce effect depends on this key so the timer clears and restarts on every local edit (idle debounce from the last keystroke), preventing saves at a fixed offset from the first keystroke and the brief “revert to stale query” flash when `onSaved` clears `localDraft`.
- **Call sites:** `pricing-editor` and `settings-editor` pass `localDraft` as `debounceResetKey`.
- **Contrast:** Pricing admin `Input` components and the package description `textarea` use `text-foreground` and `placeholder:text-muted-foreground` so typed text is readable on the light admin surface without changing the shared `Input` defaults for the marketing site.
- **Docs:** One sentence in `docs/cms-publish.md` describing reset-on-edit debounce.

## Testing

- `bun run lint` — clean
- `bun run build` — success

Manual verification in the admin UI (continuous typing in Features >1s before pause, publish after edit, field readability) was not run in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87f3f141-a36e-4ff3-b767-9667e5e5a768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87f3f141-a36e-4ff3-b767-9667e5e5a768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

