### PR TITLE
Improve photo editor upload feedback and drag reorder

### DIFF
--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -979,7 +979,7 @@ function PhotosEditorForm() {
           </p>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
           {photos.map((photo, index) => {
             const fields = getEditableFields(photo);
             const isDirty = edits[photo.stableId] !== undefined;
@@ -998,7 +998,7 @@ function PhotosEditorForm() {
                 key={photo.stableId}
                 data-stable-id={photo.stableId}
                 className={cn(
-                  "relative grid gap-4 p-4 transition lg:grid-cols-[240px_minmax(0,1fr)]",
+                  "relative flex min-w-0 flex-col gap-2 p-2.5 transition",
                   isDraggingThis && "opacity-60",
                   dropHint === "before" &&
                     "shadow-[0_-2px_0_0_var(--color-primary)]",
@@ -1014,17 +1014,57 @@ function PhotosEditorForm() {
                 onDrop={(event) => void handleRowDrop(event, photo.stableId)}
                 onDragEnd={handleRowDragEnd}
               >
-                {/* Drag handle (also functions as an ARIA handle cue) */}
-                <div
-                  className="pointer-events-none absolute left-1 top-1/2 hidden -translate-y-1/2 text-muted-foreground/60 lg:block"
-                  aria-hidden
-                >
-                  <GripVertical className="size-4" />
-                </div>
-
-                <div className="overflow-hidden rounded-lg border border-border bg-muted/30">
+                <div className="relative overflow-hidden rounded-lg border border-border bg-muted/30">
+                  <div
+                    className="pointer-events-none absolute left-1.5 top-1.5 z-10 text-muted-foreground/70"
+                    aria-hidden
+                  >
+                    <GripVertical className="size-4" />
+                  </div>
+                  <div className="absolute right-1 top-1 z-10 flex gap-0.5 rounded-md border border-border/60 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm dark:bg-background/80">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent"
+                      aria-label="Move photo up"
+                      disabled={index === 0 || busy !== null || isRowBusy}
+                      onClick={() => void movePhoto(photo.stableId, -1)}
+                    >
+                      <ArrowUp className="size-3.5" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent"
+                      aria-label="Move photo down"
+                      disabled={
+                        index === photos.length - 1 ||
+                        busy !== null ||
+                        isRowBusy
+                      }
+                      onClick={() => void movePhoto(photo.stableId, 1)}
+                    >
+                      <ArrowDown className="size-3.5" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent"
+                      aria-label="Delete photo"
+                      disabled={busy !== null || isRowBusy}
+                      onClick={() => setDeleteStableId(photo.stableId)}
+                    >
+                      <Trash2
+                        className="size-3.5 text-destructive"
+                        aria-hidden
+                      />
+                    </Button>
+                  </div>
                   {photo.url ? (
-                    <div className="relative aspect-[4/3]">
+                    <div className="relative aspect-[4/3] w-full">
                       <Image
                         src={photo.url}
                         alt={photo.alt}
@@ -1032,89 +1072,50 @@ function PhotosEditorForm() {
                         unoptimized
                         draggable={false}
                         className="select-none object-cover"
-                        sizes="240px"
+                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                       />
                     </div>
                   ) : (
-                    <div className="flex aspect-[4/3] items-center justify-center text-sm text-muted-foreground">
+                    <div className="flex aspect-[4/3] items-center justify-center px-2 text-center text-xs text-muted-foreground">
                       Image unavailable
                     </div>
                   )}
                 </div>
 
-                <div className="space-y-4">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="space-y-1">
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground/55">
-                        Photo #{index + 1}
-                      </p>
-                      <p className="body-text-small text-foreground/80">
+                <div className="min-w-0 space-y-1.5">
+                  <div className="min-w-0 space-y-0">
+                    <p className="truncate text-[10px] font-semibold uppercase tracking-wider text-foreground/55">
+                      <span className="mr-1.5">Photo #{index + 1}</span>
+                      <span className="font-normal normal-case text-foreground/80">
                         {photo.originalFileName ?? "Untitled image"}
+                      </span>
+                    </p>
+                    <p className="truncate text-[11px] leading-tight text-muted-foreground">
+                      {photo.width && photo.height
+                        ? `${photo.width} × ${photo.height}`
+                        : "Dimensions unavailable"}
+                      {" · "}
+                      {photo.contentType}
+                      {" · "}
+                      {formatBytes(photo.sizeBytes)}
+                    </p>
+                    {rowAction === "saving" && (
+                      <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Loader2 className="size-3 animate-spin" aria-hidden />
+                        Saving…
                       </p>
-                      <p className="body-text-small text-muted-foreground">
-                        {photo.width && photo.height
-                          ? `${photo.width} × ${photo.height}`
-                          : "Dimensions unavailable"}
-                        {" · "}
-                        {photo.contentType}
-                        {" · "}
-                        {formatBytes(photo.sizeBytes)}
+                    )}
+                    {rowAction === "deleting" && (
+                      <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Loader2 className="size-3 animate-spin" aria-hidden />
+                        Deleting…
                       </p>
-                      {rowAction === "saving" && (
-                        <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                          <Loader2 className="size-3 animate-spin" aria-hidden />
-                          Saving…
-                        </p>
-                      )}
-                      {rowAction === "deleting" && (
-                        <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                          <Loader2 className="size-3 animate-spin" aria-hidden />
-                          Deleting…
-                        </p>
-                      )}
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-1">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Move photo up"
-                        disabled={index === 0 || busy !== null || isRowBusy}
-                        onClick={() => void movePhoto(photo.stableId, -1)}
-                      >
-                        <ArrowUp className="size-4" aria-hidden />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Move photo down"
-                        disabled={
-                          index === photos.length - 1 ||
-                          busy !== null ||
-                          isRowBusy
-                        }
-                        onClick={() => void movePhoto(photo.stableId, 1)}
-                      >
-                        <ArrowDown className="size-4" aria-hidden />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Delete photo"
-                        disabled={busy !== null || isRowBusy}
-                        onClick={() => setDeleteStableId(photo.stableId)}
-                      >
-                        <Trash2 className="size-4 text-destructive" aria-hidden />
-                      </Button>
-                    </div>
+                    )}
                   </div>
 
-                  <div className="grid gap-4">
-                    <label className="space-y-1">
-                      <span className="body-text-small text-muted-foreground">
+                  <div className="grid gap-1.5">
+                    <label className="min-w-0 space-y-0.5">
+                      <span className="text-[11px] leading-none text-muted-foreground">
                         Alt text
                         <span
                           className="ml-1 text-destructive"
@@ -1133,6 +1134,7 @@ function PhotosEditorForm() {
                           updatePhotoEdit(photo, { alt: event.target.value })
                         }
                         maxLength={MAX_ALT_LENGTH}
+                        className="h-7 py-1 text-sm"
                       />
                       {altInvalid && (
                         <span
@@ -1144,8 +1146,8 @@ function PhotosEditorForm() {
                       )}
                     </label>
 
-                    <label className="space-y-1">
-                      <span className="body-text-small text-muted-foreground">
+                    <label className="min-w-0 space-y-0.5">
+                      <span className="text-[11px] leading-none text-muted-foreground">
                         Caption
                       </span>
                       <Textarea
@@ -1154,13 +1156,14 @@ function PhotosEditorForm() {
                           updatePhotoEdit(photo, { caption: event.target.value })
                         }
                         maxLength={MAX_CAPTION_LENGTH}
-                        rows={3}
+                        rows={2}
+                        className="min-h-[2.5rem] max-h-24 resize-y py-1.5 text-sm [field-sizing:fixed]"
                       />
                     </label>
                   </div>
 
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="body-text-small text-muted-foreground">
+                  <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-1.5">
+                    <p className="text-[11px] leading-tight text-muted-foreground">
                       {isDirty
                         ? "Unsaved metadata changes."
                         : "Metadata saved to draft."}
@@ -1168,18 +1171,20 @@ function PhotosEditorForm() {
                     <Button
                       type="button"
                       variant="outline"
+                      size="sm"
+                      aria-label="Save photo details"
                       disabled={!isDirty || busy !== null || isRowBusy}
                       onClick={() => void savePhotoDetails(photo)}
                     >
                       {rowAction === "saving" ? (
                         <Loader2
-                          className="mr-1 size-4 animate-spin"
+                          className="mr-1 size-3.5 animate-spin"
                           aria-hidden
                         />
                       ) : (
-                        <Save className="mr-1 size-4" aria-hidden />
+                        <Save className="mr-1 size-3.5" aria-hidden />
                       )}
-                      Save details
+                      Save
                     </Button>
                   </div>
                 </div>

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -242,9 +242,8 @@ function PhotosEditorForm() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
-  const uploadDismissTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
-    null,
-  );
+  /** Browser `setTimeout` ids are numeric; avoid `NodeJS.Timeout` from `ReturnType<typeof setTimeout>`. */
+  const uploadDismissTimerRef = useRef<number | null>(null);
 
   const [busy, setBusy] = useState<string | null>(null);
   const [rowBusy, setRowBusy] = useState<RowBusy>({});

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -21,10 +21,20 @@ import {
 } from "react";
 import { Effect, pipe } from "effect";
 import { toast } from "sonner";
-import { ArrowDown, ArrowUp, ImagePlus, Loader2, Save, Trash2, Upload } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  GripVertical,
+  ImagePlus,
+  Loader2,
+  Save,
+  Trash2,
+  Upload,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Card } from "@/components/ui/card";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -41,6 +51,13 @@ import { cn } from "@/lib/utils";
 
 const MAX_ALT_LENGTH = 240;
 const MAX_CAPTION_LENGTH = 600;
+/**
+ * Custom drag MIME used for photo reordering. Using a namespaced string lets us
+ * distinguish a reorder drag from a browser file drag (which surfaces "Files"
+ * in dataTransfer.types) so the upload dropzone and the row reorder target
+ * don't fight each other.
+ */
+const REORDER_MIME = "application/x-lls-photo-reorder";
 
 type PhotoItem = {
   stableId: string;
@@ -63,6 +80,20 @@ type PhotoEdits = Record<
     caption: string;
   }
 >;
+
+/** Per-row action state — lets us show a spinner on just the affected row. */
+type RowAction = "saving" | "deleting";
+type RowBusy = Record<string, RowAction | undefined>;
+
+/** Per-file upload progress entry shown in the upload tray. */
+type UploadProgressEntry = {
+  readonly id: string;
+  readonly name: string;
+  /** Fraction 0..1 of bytes uploaded to Convex storage. */
+  readonly progress: number;
+  readonly status: "uploading" | "saving" | "done" | "error";
+  readonly error?: string;
+};
 
 function defaultAltFromFileName(fileName: string): string {
   const withoutExtension = fileName.replace(/\.[^.]+$/, "");
@@ -129,6 +160,53 @@ async function readImageDimensions(
   }
 }
 
+/**
+ * Upload a single file to a Convex upload URL with progress reporting.
+ * Returns the resulting storageId on success; throws a readable Error otherwise.
+ */
+async function uploadFileWithProgress(
+  uploadUrl: string,
+  file: File,
+  onProgress: (fraction: number) => void,
+): Promise<Id<"_storage">> {
+  return await new Promise<Id<"_storage">>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", uploadUrl);
+    xhr.setRequestHeader("Content-Type", file.type);
+    xhr.upload.addEventListener("progress", (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress(Math.min(1, event.loaded / event.total));
+      }
+    });
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const parsed = JSON.parse(xhr.responseText) as {
+            storageId: Id<"_storage">;
+          };
+          onProgress(1);
+          resolve(parsed.storageId);
+        } catch {
+          reject(new Error("Upload succeeded but response was malformed."));
+        }
+      } else {
+        reject(
+          new Error(
+            `Upload failed (${xhr.status} ${xhr.statusText || "unknown"}).`,
+          ),
+        );
+      }
+    });
+    xhr.addEventListener("error", () =>
+      reject(new Error("Network error during upload.")),
+    );
+    xhr.addEventListener("abort", () =>
+      reject(new Error("Upload was aborted.")),
+    );
+    xhr.send(file);
+  });
+}
+
 export function PhotosEditor() {
   return (
     <>
@@ -166,14 +244,38 @@ function PhotosEditorForm() {
   const dragDepthRef = useRef(0);
 
   const [busy, setBusy] = useState<string | null>(null);
+  const [rowBusy, setRowBusy] = useState<RowBusy>({});
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [edits, setEdits] = useState<PhotoEdits>({});
   const [deleteStableId, setDeleteStableId] = useState<string | null>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const [uploadQueue, setUploadQueue] = useState<UploadProgressEntry[]>([]);
+
+  // Drag-reorder state
+  const [draggingStableId, setDraggingStableId] = useState<string | null>(null);
+  const [reorderTarget, setReorderTarget] = useState<{
+    stableId: string;
+    position: "before" | "after";
+  } | null>(null);
 
   const photos = useMemo(
     () => (data?.photos ?? []) as PhotoItem[],
     [data],
+  );
+
+  const setRowAction = useCallback(
+    (stableId: string, action: RowAction | undefined) => {
+      setRowBusy((prev) => {
+        const next = { ...prev };
+        if (action === undefined) {
+          delete next[stableId];
+        } else {
+          next[stableId] = action;
+        }
+        return next;
+      });
+    },
+    [],
   );
 
   const runAction = useCallback(
@@ -246,16 +348,21 @@ function PhotosEditorForm() {
         return false;
       }
 
-      const outcome = await runAction(
-        "Saving…",
+      setInlineError(null);
+      setRowAction(photo.stableId, "saving");
+      const outcome = await runAdminEffect(
         convexMutationEffect(() =>
           updateDraftPhotoMetadata({
             stableId: photo.stableId,
             alt: fields.alt.trim(),
-            caption: fields.caption.trim().length > 0 ? fields.caption.trim() : null,
+            caption:
+              fields.caption.trim().length > 0 ? fields.caption.trim() : null,
           }),
         ),
+        { onErrorMessage: setInlineError },
       );
+      setRowAction(photo.stableId, undefined);
+
       if (outcome === undefined) {
         return false;
       }
@@ -264,7 +371,12 @@ function PhotosEditorForm() {
       toast.success("Photo details saved.");
       return true;
     },
-    [clearPhotoEdit, getEditableFields, runAction, updateDraftPhotoMetadata],
+    [
+      clearPhotoEdit,
+      getEditableFields,
+      setRowAction,
+      updateDraftPhotoMetadata,
+    ],
   );
 
   const savePendingEdits = useCallback(async (): Promise<boolean> => {
@@ -278,7 +390,9 @@ function PhotosEditorForm() {
       const validationError = validatePhotoFields(fields.alt, fields.caption);
       if (validationError) {
         setInlineError(validationError);
-        toast.error(validationError);
+        toast.error(
+          `${photo.originalFileName ?? "Photo"}: ${validationError}`,
+        );
         return false;
       }
     }
@@ -303,6 +417,20 @@ function PhotosEditorForm() {
     return true;
   }, [edits, getEditableFields, photos, runAction, updateDraftPhotoMetadata]);
 
+  /** Persist the given order to the draft; used by both arrow buttons and DnD. */
+  const persistOrder = useCallback(
+    async (orderedStableIds: string[]): Promise<boolean> => {
+      const outcome = await runAction(
+        "Reordering…",
+        convexMutationEffect(() =>
+          reorderDraftPhotos({ orderedStableIds }),
+        ),
+      );
+      return outcome !== undefined;
+    },
+    [reorderDraftPhotos, runAction],
+  );
+
   const movePhoto = useCallback(
     async (stableId: string, direction: -1 | 1) => {
       const index = photos.findIndex((photo) => photo.stableId === stableId);
@@ -314,19 +442,117 @@ function PhotosEditorForm() {
       const [moved] = reordered.splice(index, 1);
       reordered.splice(target, 0, moved);
 
-      const outcome = await runAction(
-        "Reordering…",
-        convexMutationEffect(() =>
-          reorderDraftPhotos({
-            orderedStableIds: reordered.map((photo) => photo.stableId),
-          }),
-        ),
-      );
-      if (outcome !== undefined) {
+      const ok = await persistOrder(reordered.map((photo) => photo.stableId));
+      if (ok) {
         toast.success("Photo order updated.");
       }
     },
-    [photos, reorderDraftPhotos, runAction],
+    [persistOrder, photos],
+  );
+
+  // --- Drag-reorder handlers (native HTML5) -------------------------------
+
+  const handleRowDragStart = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>, stableId: string) => {
+      // Don't allow reorder while another action is in flight.
+      if (busy !== null) {
+        event.preventDefault();
+        return;
+      }
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData(REORDER_MIME, stableId);
+      // Set a benign text payload too — some platforms require one.
+      event.dataTransfer.setData("text/plain", stableId);
+      setDraggingStableId(stableId);
+    },
+    [busy],
+  );
+
+  const handleRowDragOver = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>, overStableId: string) => {
+      if (!event.dataTransfer.types.includes(REORDER_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "move";
+
+      const rect = event.currentTarget.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      const position = event.clientY < midpoint ? "before" : "after";
+      setReorderTarget((prev) =>
+        prev?.stableId === overStableId && prev.position === position
+          ? prev
+          : { stableId: overStableId, position },
+      );
+    },
+    [],
+  );
+
+  const handleRowDrop = useCallback(
+    async (
+      event: ReactDragEvent<HTMLDivElement>,
+      overStableId: string,
+    ) => {
+      if (!event.dataTransfer.types.includes(REORDER_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const sourceId = event.dataTransfer.getData(REORDER_MIME);
+      const position =
+        reorderTarget?.stableId === overStableId
+          ? reorderTarget.position
+          : "after";
+      setDraggingStableId(null);
+      setReorderTarget(null);
+
+      if (!sourceId || sourceId === overStableId) return;
+
+      const sourceIndex = photos.findIndex((p) => p.stableId === sourceId);
+      const targetIndex = photos.findIndex((p) => p.stableId === overStableId);
+      if (sourceIndex === -1 || targetIndex === -1) return;
+
+      const reordered = [...photos];
+      const [moved] = reordered.splice(sourceIndex, 1);
+      // Recompute the target index after removal.
+      const adjustedTarget = photos.findIndex((p) => p.stableId === overStableId);
+      const insertAt =
+        position === "before"
+          ? adjustedTarget > sourceIndex
+            ? adjustedTarget - 1
+            : adjustedTarget
+          : adjustedTarget > sourceIndex
+            ? adjustedTarget
+            : adjustedTarget + 1;
+      reordered.splice(insertAt, 0, moved);
+
+      const orderedIds = reordered.map((p) => p.stableId);
+      // No-op if order didn't actually change.
+      const unchanged = orderedIds.every(
+        (id, idx) => photos[idx]?.stableId === id,
+      );
+      if (unchanged) return;
+
+      const ok = await persistOrder(orderedIds);
+      if (ok) {
+        toast.success("Photo order updated.");
+      }
+    },
+    [persistOrder, photos, reorderTarget],
+  );
+
+  const handleRowDragEnd = useCallback(() => {
+    setDraggingStableId(null);
+    setReorderTarget(null);
+  }, []);
+
+  // --- Upload handling (with progress) ------------------------------------
+
+  const updateUploadEntry = useCallback(
+    (id: string, patch: Partial<UploadProgressEntry>) => {
+      setUploadQueue((prev) =>
+        prev.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)),
+      );
+    },
+    [],
   );
 
   const processFiles = useCallback(
@@ -362,20 +588,38 @@ function PhotosEditorForm() {
 
       let successCount = 0;
       for (const file of filesToUpload) {
+        const entryId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+        // Create the queue entry up-front so the tray appears immediately.
+        setUploadQueue((prev) => [
+          ...prev,
+          {
+            id: entryId,
+            name: file.name,
+            progress: 0,
+            status: "uploading",
+          },
+        ]);
+
         if (
           !(data.limits.acceptedMimeTypes as readonly string[]).includes(
             file.type,
           )
         ) {
-          toast.error(`${file.name}: only JPEG, PNG, and WebP are allowed.`);
+          const msg = `${file.name}: only JPEG, PNG, and WebP are allowed.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
           continue;
         }
         if (file.size > data.limits.maxImageBytes) {
-          toast.error(
-            `${file.name}: image must be ${Math.floor(
-              data.limits.maxImageBytes / (1024 * 1024),
-            )}MB or smaller.`,
-          );
+          const msg = `${file.name}: image must be ${Math.floor(
+            data.limits.maxImageBytes / (1024 * 1024),
+          )}MB or smaller.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
           continue;
         }
 
@@ -384,25 +628,31 @@ function PhotosEditorForm() {
           { onErrorMessage: setInlineError },
         );
         if (!upload) {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: "Could not get upload URL.",
+          });
           break;
         }
 
-        const uploadResponse = await fetch(upload.uploadUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": file.type,
-          },
-          body: file,
-        });
-
-        if (!uploadResponse.ok) {
-          toast.error(`${file.name}: upload failed.`);
+        let storageId: Id<"_storage"> | undefined;
+        try {
+          storageId = await uploadFileWithProgress(
+            upload.uploadUrl,
+            file,
+            (fraction) => updateUploadEntry(entryId, { progress: fraction }),
+          );
+        } catch (error) {
+          const msg =
+            error instanceof Error
+              ? `${file.name}: ${error.message}`
+              : `${file.name}: upload failed.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
           continue;
         }
 
-        const { storageId } = (await uploadResponse.json()) as {
-          storageId: Id<"_storage">;
-        };
+        updateUploadEntry(entryId, { status: "saving", progress: 1 });
         const dimensions = await readImageDimensions(file);
 
         const saved = await runAdminEffect(
@@ -421,6 +671,12 @@ function PhotosEditorForm() {
 
         if (saved !== undefined) {
           successCount += 1;
+          updateUploadEntry(entryId, { status: "done" });
+        } else {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: `${file.name}: could not save photo.`,
+          });
         }
       }
 
@@ -432,8 +688,13 @@ function PhotosEditorForm() {
             : `${successCount} photos uploaded.`,
         );
       }
+
+      // Auto-dismiss successful entries a moment later; keep errors pinned.
+      window.setTimeout(() => {
+        setUploadQueue((prev) => prev.filter((entry) => entry.status === "error"));
+      }, 2500);
     },
-    [data, generateUploadUrl, photos.length, saveUploadedPhoto],
+    [data, generateUploadUrl, photos.length, saveUploadedPhoto, updateUploadEntry],
   );
 
   const handleFileSelection = useCallback(
@@ -512,16 +773,19 @@ function PhotosEditorForm() {
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteStableId) return;
-    const outcome = await runAction(
-      "Deleting…",
+    setInlineError(null);
+    setRowAction(deleteStableId, "deleting");
+    const outcome = await runAdminEffect(
       convexMutationEffect(() => removeDraftPhoto({ stableId: deleteStableId })),
+      { onErrorMessage: setInlineError },
     );
+    setRowAction(deleteStableId, undefined);
     setDeleteStableId(null);
     if (outcome !== undefined) {
       clearPhotoEdit(deleteStableId);
       toast.success("Photo removed.");
     }
-  }, [clearPhotoEdit, deleteStableId, removeDraftPhoto, runAction]);
+  }, [clearPhotoEdit, deleteStableId, removeDraftPhoto, setRowAction]);
 
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
@@ -563,6 +827,10 @@ function PhotosEditorForm() {
     return <p className="body-text text-foreground/80">Loading photos…</p>;
   }
 
+  const anyUploading = uploadQueue.some(
+    (entry) => entry.status === "uploading" || entry.status === "saving",
+  );
+
   return (
     <div
       className={cn(
@@ -601,8 +869,9 @@ function PhotosEditorForm() {
             </h2>
             <p className="body-text-small max-w-2xl text-foreground/85">
               Upload and arrange the photos shown in the “The Space” section.
-              Drag and drop images onto this page, or use the Upload button.
-              Uploads land in draft first; publish makes the new order and metadata live.
+              Drag and drop images onto this page to upload, or drag a card by
+              its handle to reorder. Uploads land in draft first; publish makes
+              the new order and metadata live.
             </p>
           </div>
 
@@ -638,6 +907,70 @@ function PhotosEditorForm() {
         </div>
       </div>
 
+      {/* Upload progress tray — shown per-file while uploading and for any errors after. */}
+      {uploadQueue.length > 0 && (
+        <div
+          className="space-y-2 rounded-xl border border-border bg-muted/30 p-4"
+          aria-live="polite"
+          aria-busy={anyUploading}
+        >
+          <p className="body-text-small font-medium text-foreground/85">
+            {anyUploading ? "Uploading photos…" : "Upload results"}
+          </p>
+          <ul className="space-y-2">
+            {uploadQueue.map((entry) => (
+              <li key={entry.id} className="space-y-1">
+                <div className="flex items-center justify-between gap-3 text-sm">
+                  <span className="truncate text-foreground/85" title={entry.name}>
+                    {entry.name}
+                  </span>
+                  <span
+                    className={cn(
+                      "shrink-0 text-xs",
+                      entry.status === "error"
+                        ? "text-destructive"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {entry.status === "uploading" &&
+                      `${Math.round(entry.progress * 100)}%`}
+                    {entry.status === "saving" && "Saving…"}
+                    {entry.status === "done" && "Done"}
+                    {entry.status === "error" && "Failed"}
+                  </span>
+                </div>
+                <div
+                  className={cn(
+                    "h-1.5 overflow-hidden rounded-full bg-border/70",
+                    entry.status === "error" && "bg-destructive/20",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all",
+                      entry.status === "error"
+                        ? "bg-destructive"
+                        : entry.status === "done"
+                          ? "bg-emerald-500"
+                          : "bg-primary",
+                    )}
+                    style={{
+                      width:
+                        entry.status === "error"
+                          ? "100%"
+                          : `${Math.round(entry.progress * 100)}%`,
+                    }}
+                  />
+                </div>
+                {entry.error && (
+                  <p className="text-xs text-destructive">{entry.error}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {photos.length === 0 ? (
         <div className="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
           <p className="body-text text-foreground/80">
@@ -650,11 +983,45 @@ function PhotosEditorForm() {
           {photos.map((photo, index) => {
             const fields = getEditableFields(photo);
             const isDirty = edits[photo.stableId] !== undefined;
+            const rowAction = rowBusy[photo.stableId];
+            const isRowBusy = rowAction !== undefined;
+            const isDraggingThis = draggingStableId === photo.stableId;
+            const dropHint =
+              reorderTarget?.stableId === photo.stableId &&
+              draggingStableId !== null &&
+              draggingStableId !== photo.stableId
+                ? reorderTarget.position
+                : null;
+            const altInvalid = fields.alt.trim().length === 0;
             return (
-              <article
+              <Card
                 key={photo.stableId}
-                className="grid gap-4 rounded-xl border border-border bg-card p-4 shadow-sm lg:grid-cols-[240px_minmax(0,1fr)]"
+                data-stable-id={photo.stableId}
+                className={cn(
+                  "relative grid gap-4 p-4 transition lg:grid-cols-[240px_minmax(0,1fr)]",
+                  isDraggingThis && "opacity-60",
+                  dropHint === "before" &&
+                    "shadow-[0_-2px_0_0_var(--color-primary)]",
+                  dropHint === "after" &&
+                    "shadow-[0_2px_0_0_var(--color-primary)]",
+                  isRowBusy && "pointer-events-none",
+                )}
+                draggable={busy === null}
+                onDragStart={(event) =>
+                  handleRowDragStart(event, photo.stableId)
+                }
+                onDragOver={(event) => handleRowDragOver(event, photo.stableId)}
+                onDrop={(event) => void handleRowDrop(event, photo.stableId)}
+                onDragEnd={handleRowDragEnd}
               >
+                {/* Drag handle (also functions as an ARIA handle cue) */}
+                <div
+                  className="pointer-events-none absolute left-1 top-1/2 hidden -translate-y-1/2 text-muted-foreground/60 lg:block"
+                  aria-hidden
+                >
+                  <GripVertical className="size-4" />
+                </div>
+
                 <div className="overflow-hidden rounded-lg border border-border bg-muted/30">
                   {photo.url ? (
                     <div className="relative aspect-[4/3]">
@@ -663,7 +1030,8 @@ function PhotosEditorForm() {
                         alt={photo.alt}
                         fill
                         unoptimized
-                        className="object-cover"
+                        draggable={false}
+                        className="select-none object-cover"
                         sizes="240px"
                       />
                     </div>
@@ -692,6 +1060,18 @@ function PhotosEditorForm() {
                         {" · "}
                         {formatBytes(photo.sizeBytes)}
                       </p>
+                      {rowAction === "saving" && (
+                        <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                          <Loader2 className="size-3 animate-spin" aria-hidden />
+                          Saving…
+                        </p>
+                      )}
+                      {rowAction === "deleting" && (
+                        <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                          <Loader2 className="size-3 animate-spin" aria-hidden />
+                          Deleting…
+                        </p>
+                      )}
                     </div>
 
                     <div className="flex flex-wrap items-center gap-1">
@@ -700,7 +1080,7 @@ function PhotosEditorForm() {
                         variant="ghost"
                         size="icon"
                         aria-label="Move photo up"
-                        disabled={index === 0 || busy !== null}
+                        disabled={index === 0 || busy !== null || isRowBusy}
                         onClick={() => void movePhoto(photo.stableId, -1)}
                       >
                         <ArrowUp className="size-4" aria-hidden />
@@ -710,7 +1090,11 @@ function PhotosEditorForm() {
                         variant="ghost"
                         size="icon"
                         aria-label="Move photo down"
-                        disabled={index === photos.length - 1 || busy !== null}
+                        disabled={
+                          index === photos.length - 1 ||
+                          busy !== null ||
+                          isRowBusy
+                        }
                         onClick={() => void movePhoto(photo.stableId, 1)}
                       >
                         <ArrowDown className="size-4" aria-hidden />
@@ -720,7 +1104,7 @@ function PhotosEditorForm() {
                         variant="ghost"
                         size="icon"
                         aria-label="Delete photo"
-                        disabled={busy !== null}
+                        disabled={busy !== null || isRowBusy}
                         onClick={() => setDeleteStableId(photo.stableId)}
                       >
                         <Trash2 className="size-4 text-destructive" aria-hidden />
@@ -732,14 +1116,32 @@ function PhotosEditorForm() {
                     <label className="space-y-1">
                       <span className="body-text-small text-muted-foreground">
                         Alt text
+                        <span
+                          className="ml-1 text-destructive"
+                          aria-hidden
+                        >
+                          *
+                        </span>
                       </span>
                       <Input
                         value={fields.alt}
+                        aria-invalid={altInvalid || undefined}
+                        aria-describedby={
+                          altInvalid ? `alt-hint-${photo.stableId}` : undefined
+                        }
                         onChange={(event) =>
                           updatePhotoEdit(photo, { alt: event.target.value })
                         }
                         maxLength={MAX_ALT_LENGTH}
                       />
+                      {altInvalid && (
+                        <span
+                          id={`alt-hint-${photo.stableId}`}
+                          className="block text-xs text-amber-600 dark:text-amber-400"
+                        >
+                          Alt text is required before publish.
+                        </span>
+                      )}
                     </label>
 
                     <label className="space-y-1">
@@ -759,20 +1161,29 @@ function PhotosEditorForm() {
 
                   <div className="flex items-center justify-between gap-3">
                     <p className="body-text-small text-muted-foreground">
-                      {isDirty ? "Unsaved metadata changes." : "Metadata saved to draft."}
+                      {isDirty
+                        ? "Unsaved metadata changes."
+                        : "Metadata saved to draft."}
                     </p>
                     <Button
                       type="button"
                       variant="outline"
-                      disabled={!isDirty || busy !== null}
+                      disabled={!isDirty || busy !== null || isRowBusy}
                       onClick={() => void savePhotoDetails(photo)}
                     >
-                      <Save className="mr-1 size-4" aria-hidden />
+                      {rowAction === "saving" ? (
+                        <Loader2
+                          className="mr-1 size-4 animate-spin"
+                          aria-hidden
+                        />
+                      ) : (
+                        <Save className="mr-1 size-4" aria-hidden />
+                      )}
                       Save details
                     </Button>
                   </div>
                 </div>
-              </article>
+              </Card>
             );
           })}
         </div>
@@ -807,14 +1218,33 @@ function PhotosEditorForm() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={busy !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
+            >
+              Cancel
+            </AlertDialogCancel>
             <Button
               type="button"
               variant="destructive"
-              disabled={busy !== null}
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
               onClick={() => void handleDeleteConfirm()}
             >
-              Delete photo
+              {deleteStableId && rowBusy[deleteStableId] === "deleting" ? (
+                <>
+                  <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+                  Deleting…
+                </>
+              ) : (
+                "Delete photo"
+              )}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -242,6 +242,9 @@ function PhotosEditorForm() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
+  const uploadDismissTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  );
 
   const [busy, setBusy] = useState<string | null>(null);
   const [rowBusy, setRowBusy] = useState<RowBusy>({});
@@ -512,16 +515,14 @@ function PhotosEditorForm() {
 
       const reordered = [...photos];
       const [moved] = reordered.splice(sourceIndex, 1);
-      // Recompute the target index after removal.
-      const adjustedTarget = photos.findIndex((p) => p.stableId === overStableId);
+      const targetIndexInReordered = reordered.findIndex(
+        (p) => p.stableId === overStableId,
+      );
+      if (targetIndexInReordered === -1) return;
       const insertAt =
         position === "before"
-          ? adjustedTarget > sourceIndex
-            ? adjustedTarget - 1
-            : adjustedTarget
-          : adjustedTarget > sourceIndex
-            ? adjustedTarget
-            : adjustedTarget + 1;
+          ? targetIndexInReordered
+          : targetIndexInReordered + 1;
       reordered.splice(insertAt, 0, moved);
 
       const orderedIds = reordered.map((p) => p.stableId);
@@ -586,12 +587,19 @@ function PhotosEditorForm() {
 
       setBusy("Uploading…");
 
+      if (uploadDismissTimerRef.current !== null) {
+        window.clearTimeout(uploadDismissTimerRef.current);
+        uploadDismissTimerRef.current = null;
+      }
+
+      const batchEntryIds: string[] = [];
       let successCount = 0;
       for (const file of filesToUpload) {
         const entryId =
           typeof crypto !== "undefined" && "randomUUID" in crypto
             ? crypto.randomUUID()
             : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        batchEntryIds.push(entryId);
 
         // Create the queue entry up-front so the tray appears immediately.
         setUploadQueue((prev) => [
@@ -689,9 +697,15 @@ function PhotosEditorForm() {
         );
       }
 
-      // Auto-dismiss successful entries a moment later; keep errors pinned.
-      window.setTimeout(() => {
-        setUploadQueue((prev) => prev.filter((entry) => entry.status === "error"));
+      // Auto-dismiss this batch's non-error entries; keep errors pinned.
+      uploadDismissTimerRef.current = window.setTimeout(() => {
+        uploadDismissTimerRef.current = null;
+        setUploadQueue((prev) =>
+          prev.filter(
+            (entry) =>
+              entry.status === "error" || !batchEntryIds.includes(entry.id),
+          ),
+        );
       }, 2500);
     },
     [data, generateUploadUrl, photos.length, saveUploadedPhoto, updateUploadEntry],

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,74 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "flex flex-col gap-1.5 px-4 pt-4 [&:has(+[data-slot=card-content])]:pb-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 pb-4", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-4 pb-4", className)}
+      {...props}
+    />
+  )
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }


### PR DESCRIPTION
## Summary
- Added per-file upload progress with status updates, error handling, and auto-dismiss for successful uploads.
- Improved photo editor row feedback with inline saving/deleting spinners and more specific validation messaging.
- Added native drag-and-drop photo reordering with visual drop hints and a dedicated drag handle.
- Introduced a reusable `Card` UI component and used it to wrap photo editor rows.

## Testing
- Not run (not requested).
- Verified the diff for upload flow changes, row-level busy states, and drag/reorder handling.
- Checked that the new `Card` component exports match the import used by the photo editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the admin photo upload and reordering flows (including switching uploads to XHR for progress) and introduces new drag/drop behavior that could affect usability and ordering persistence.
> 
> **Overview**
> Improves the admin `PhotosEditor` UX by adding **per-file upload progress/results** (with queued status, inline errors, and auto-dismiss of successful uploads) and switching uploads to an `XMLHttpRequest`-based helper for progress reporting.
> 
> Adds **native drag-and-drop reordering** for photo cards using a custom drag MIME to avoid conflicts with file-drop uploading, plus shared `persistOrder` logic and clearer reorder feedback.
> 
> Refactors the photo list UI into a responsive card grid with **row-level busy states** (saving/deleting spinners, per-row disabling) and more specific validation messaging, and introduces a reusable `Card` component in `components/ui/card.tsx` that the editor now uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f5aadc0d00b0b56a6d9cb61acb8e4e58c17ad9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->