### PR TITLE
feat(inf-91): surface CMS gallery on home, allow 50MB images

### DIFF
--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -7,7 +7,7 @@ export const ALLOWED_GALLERY_IMAGE_TYPES = [
   "image/webp",
 ] as const;
 
-export const MAX_GALLERY_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_GALLERY_IMAGE_BYTES = 50 * 1024 * 1024;
 export const MAX_GALLERY_PHOTOS = 40;
 const GALLERY_QUERY_LIMIT = 128;
 

--- a/docs/gallery-photos.md
+++ b/docs/gallery-photos.md
@@ -30,7 +30,7 @@ That keeps uploads cheap while still allowing the draft order and metadata to di
 2. client `POST`s the file to Convex storage
 3. `api.admin.photos.saveUploadedPhoto`
    - validates content type: JPEG / PNG / WebP only
-   - validates max size: 10 MB
+   - validates max size: 50 MB
    - stores metadata on the draft row
    - updates draft/published change tracking
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -50,6 +50,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/f/**",
       },
+      /** Convex file storage (`ctx.storage.getUrl`) — required for `next/image` optimization. */
+      {
+        protocol: "https",
+        hostname: "*.convex.cloud",
+        pathname: "/api/storage/**",
+      },
     ],
     // Cache optimized images for 31 days to reduce transformations and cache writes
     minimumCacheTTL: 2678400, // 31 days in seconds

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -3,72 +3,120 @@
 import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import type { GalleryPhoto } from "@/components/the-space";
 
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
 type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
+type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos> | null;
+
+function PhotosData({
+  preloaded,
+  children,
+}: {
+  preloaded: PreloadedPhotos;
+  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+}) {
+  if (preloaded) {
+    return <PhotosFromPreload preloaded={preloaded}>{children}</PhotosFromPreload>;
+  }
+  return <PhotosLive>{children}</PhotosLive>;
+}
+
+function PhotosFromPreload({
+  preloaded,
+  children,
+}: {
+  preloaded: NonNullable<PreloadedPhotos>;
+  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+}) {
+  const photos = usePreloadedQuery(preloaded);
+  return <>{children(photos)}</>;
+}
+
+function PhotosLive({
+  children,
+}: {
+  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+}) {
+  const photos = useQuery(api.public.getPublishedGalleryPhotos);
+  return <>{children(photos)}</>;
+}
 
 function BothPreloaded({
   preloadedPricing,
   preloadedGear,
+  photos,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
+  photos: GalleryPhoto[] | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = usePreloadedQuery(preloadedGear);
-  const photos = useQuery(api.public.getPublishedGalleryPhotos);
   return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
 }
 
 function PricingPreloadedGearLive({
   preloadedPricing,
+  photos,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
+  photos: GalleryPhoto[] | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = useQuery(api.public.getPublishedGear);
-  const photos = useQuery(api.public.getPublishedGalleryPhotos);
   return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
 }
 
 function PricingLiveGearPreloaded({
   preloadedGear,
+  photos,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
+  photos: GalleryPhoto[] | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = usePreloadedQuery(preloadedGear);
-  const photos = useQuery(api.public.getPublishedGalleryPhotos);
   return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
 }
 
-function BothLive() {
+function BothLive({ photos }: { photos: GalleryPhoto[] | undefined }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = useQuery(api.public.getPublishedGear);
-  const photos = useQuery(api.public.getPublishedGalleryPhotos);
   return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
 }
 
 export function HomeClient({
   preloadedPricing,
   preloadedGear,
+  preloadedPhotos,
 }: {
   preloadedPricing: PreloadedPricing;
   preloadedGear: PreloadedGear;
+  preloadedPhotos: PreloadedPhotos;
 }) {
-  if (preloadedPricing && preloadedGear) {
-    return (
-      <BothPreloaded
-        preloadedPricing={preloadedPricing}
-        preloadedGear={preloadedGear}
-      />
-    );
-  }
-  if (preloadedPricing) {
-    return <PricingPreloadedGearLive preloadedPricing={preloadedPricing} />;
-  }
-  if (preloadedGear) {
-    return <PricingLiveGearPreloaded preloadedGear={preloadedGear} />;
-  }
-  return <BothLive />;
+  return (
+    <PhotosData preloaded={preloadedPhotos}>
+      {(photos) => {
+        if (preloadedPricing && preloadedGear) {
+          return (
+            <BothPreloaded
+              preloadedPricing={preloadedPricing}
+              preloadedGear={preloadedGear}
+              photos={photos}
+            />
+          );
+        }
+        if (preloadedPricing) {
+          return (
+            <PricingPreloadedGearLive preloadedPricing={preloadedPricing} photos={photos} />
+          );
+        }
+        if (preloadedGear) {
+          return <PricingLiveGearPreloaded preloadedGear={preloadedGear} photos={photos} />;
+        }
+        return <BothLive photos={photos} />;
+      }}
+    </PhotosData>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,11 @@ export default async function Home() {
       gearSettled.status === "fulfilled" ? gearSettled.value : null;
     const preloadedPhotos =
       photosSettled.status === "fulfilled" ? photosSettled.value : null;
-    if (preloadedPricing === null && preloadedGear === null) {
+    if (
+      preloadedPricing === null &&
+      preloadedGear === null &&
+      preloadedPhotos === null
+    ) {
       return <HomepageShell pricingFlags={null} gear={null} photos={null} />;
     }
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,14 +5,17 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
   try {
-    const [pricingSettled, gearSettled] = await Promise.allSettled([
+    const [pricingSettled, gearSettled, photosSettled] = await Promise.allSettled([
       preloadQuery(api.public.getPublishedPricingFlags),
       preloadQuery(api.public.getPublishedGear),
+      preloadQuery(api.public.getPublishedGalleryPhotos),
     ]);
     const preloadedPricing =
       pricingSettled.status === "fulfilled" ? pricingSettled.value : null;
     const preloadedGear =
       gearSettled.status === "fulfilled" ? gearSettled.value : null;
+    const preloadedPhotos =
+      photosSettled.status === "fulfilled" ? photosSettled.value : null;
     if (preloadedPricing === null && preloadedGear === null) {
       return <HomepageShell pricingFlags={null} gear={null} photos={null} />;
     }
@@ -20,6 +23,7 @@ export default async function Home() {
       <HomeClient
         preloadedPricing={preloadedPricing}
         preloadedGear={preloadedGear}
+        preloadedPhotos={preloadedPhotos}
       />
     );
   } catch {

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -17,6 +17,49 @@ export type GalleryPhoto = {
   originalFileName: string | null;
 };
 
+function galleryImageAlt(alt: string): string {
+  const t = alt.trim();
+  return t.length > 0 ? t : "Lula Lake Sound studio gallery photo";
+}
+
+function GallerySkeleton() {
+  return (
+    <div className="reveal reveal-delay-2">
+      <div className="group relative">
+        <div className="relative mx-auto w-full max-w-5xl">
+          <div className="relative overflow-hidden border border-sand/10 bg-washed-black">
+            <div className="relative flex h-[55vh] w-full items-center justify-center md:h-[65vh]">
+              <div className="absolute inset-0 bg-gradient-to-br from-ivory/[0.04] via-transparent to-ivory/[0.02]" />
+              <div className="relative grid w-[min(100%,24rem)] grid-cols-3 gap-2 px-4 sm:w-[min(100%,28rem)] sm:gap-2.5 md:gap-3">
+                {Array.from({ length: 6 }, (_, i) => (
+                  <div
+                    key={i}
+                    className="aspect-[4/3] animate-pulse rounded-sm bg-ivory/[0.07]"
+                    style={{ animationDelay: `${i * 70}ms` }}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-6 flex justify-center gap-1.5" aria-hidden>
+        {Array.from({ length: 6 }, (_, i) => (
+          <div
+            key={i}
+            className="h-1 w-1 animate-pulse rounded-full bg-ivory/12"
+            style={{ animationDelay: `${i * 50}ms` }}
+          />
+        ))}
+      </div>
+      <div className="mt-8 flex w-full flex-col items-center gap-2 text-center" aria-hidden>
+        <div className="h-3.5 w-full max-w-lg animate-pulse rounded bg-ivory/[0.06]" />
+        <div className="h-3.5 w-full max-w-md animate-pulse rounded bg-ivory/[0.05]" />
+      </div>
+    </div>
+  );
+}
+
 function StudioGallery({
   photos,
 }: {
@@ -25,13 +68,7 @@ function StudioGallery({
   const [currentIndex, setCurrentIndex] = useState(0);
 
   if (photos === undefined) {
-    return (
-      <div className="relative overflow-hidden border border-sand/10 bg-washed-black">
-        <div className="flex h-[55vh] items-center justify-center md:h-[65vh]">
-          <div className="body-text-small text-ivory/40">Loading gallery...</div>
-        </div>
-      </div>
-    );
+    return <GallerySkeleton />;
   }
 
   const availablePhotos = photos ?? [];
@@ -64,11 +101,13 @@ function StudioGallery({
               {currentPhoto.url ? (
                 <Image
                   src={currentPhoto.url}
-                  alt={currentPhoto.alt}
+                  alt={galleryImageAlt(currentPhoto.alt)}
                   fill
-                  unoptimized
                   className="object-contain"
-                  sizes="(max-width: 768px) 100vw, 1200px"
+                  sizes="(max-width: 768px) 100vw, min(1200px, 100vw)"
+                  quality={75}
+                  loading="lazy"
+                  fetchPriority="low"
                 />
               ) : (
                 <div className="body-text-small text-ivory/40">


### PR DESCRIPTION
Preload published gallery photos on the homepage, render in The Space, allow Convex storage URLs in next/image, and document the new size cap.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to increased allowed upload size (potential storage/bandwidth cost and performance impact) and changes to homepage data fetching and image optimization behavior.
> 
> **Overview**
> Homepage now **preloads published gallery photos** server-side and threads them through `HomeClient` so the gallery can render from preloaded data (falling back to a live query when preload fails).
> 
> Gallery rendering in `TheSpace` is updated for a richer loading state (skeleton), safer default alt text, and `next/image` optimization settings (sizes/quality/lazy priority), enabled by allowing Convex storage URLs (`*.convex.cloud/api/storage/**`) in `next.config.ts`.
> 
> The maximum allowed gallery image upload size is increased from **10MB to 50MB**, with matching documentation updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50c826c8cb327010b9e887d5e70da5c3e88e770. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->