### PR TITLE
Add About page CMS model, preview, and public rendering

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as aboutPreviewDraft from "../aboutPreviewDraft.js";
 import type * as admin_gear from "../admin/gear.js";
 import type * as admin_photos from "../admin/photos.js";
 import type * as admin_pricing from "../admin/pricing.js";
@@ -42,6 +43,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  aboutPreviewDraft: typeof aboutPreviewDraft;
   "admin/gear": typeof admin_gear;
   "admin/photos": typeof admin_photos;
   "admin/pricing": typeof admin_pricing;

--- a/convex/aboutPreviewDraft.ts
+++ b/convex/aboutPreviewDraft.ts
@@ -1,0 +1,45 @@
+import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import { publishedAboutFromRow } from "./publicSettingsSnapshot";
+
+/**
+ * Preview About copy for owner-only access. Resolves **draft** when present,
+ * else published (same effective snapshot as the editor).
+ *
+ * Returns `null` for unauthenticated or non-owner callers — never leaks drafts.
+ */
+export const getPreviewAbout = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "about"))
+      .unique();
+
+    if (!row) {
+      return {
+        ...publishedAboutFromRow(null),
+        hasDraftChanges: false,
+      };
+    }
+
+    const effectiveRow = {
+      ...row,
+      publishedSnapshot: row.draftSnapshot ?? row.publishedSnapshot,
+    };
+
+    return {
+      ...publishedAboutFromRow(effectiveRow),
+      hasDraftChanges: row.hasDraftChanges,
+    };
+  },
+});

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -103,6 +103,12 @@ export const saveDraft = mutation({
         );
       }
     } else if (args.section === "pricing") {
+      if ("metadata" in args.content) {
+        cmsValidationError(
+          "Pricing content cannot include metadata.",
+          "content",
+        );
+      }
       if (!isPricingPayload) {
         cmsValidationError(
           "Pricing content must include flags.priceTabEnabled.",

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import {
+  aboutContentValidator,
   cmsSectionValidator,
   pricingContentValidator,
   settingsContentValidator,
@@ -70,37 +71,48 @@ export const getSection = query({
 export const saveDraft = mutation({
   args: {
     section: cmsSectionValidator,
-    content: v.union(settingsContentValidator, pricingContentValidator),
+    content: v.union(
+      settingsContentValidator,
+      pricingContentValidator,
+      aboutContentValidator,
+    ),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
 
-    // Runtime guard: the `content` union lets either shape through, but we
-    // enforce that the payload matches the target section so a settings row
-    // can never end up with a pricing payload (or vice versa).
+    // Runtime guard: the `content` union lets any of the three shapes through,
+    // but we enforce that the payload matches the target section so e.g. a
+    // settings row can never end up with a pricing or about payload.
+    const isSettingsPayload =
+      "metadata" in args.content &&
+      !("heroTitle" in args.content) &&
+      !("packages" in args.content);
+    const isPricingPayload =
+      "flags" in args.content &&
+      typeof (args.content as { flags?: unknown }).flags === "object" &&
+      (args.content as { flags?: { priceTabEnabled?: unknown } }).flags
+        ?.priceTabEnabled !== undefined;
+    const isAboutPayload =
+      "heroTitle" in args.content && "body" in args.content;
+
     if (args.section === "settings") {
-      if (!("metadata" in args.content) && !("flags" in args.content)) {
+      if (!isSettingsPayload) {
         cmsValidationError(
           "Settings content must include metadata.",
           "content",
         );
       }
-      if ("flags" in args.content && !("metadata" in args.content)) {
-        cmsValidationError(
-          "Settings content cannot be a pricing payload.",
-          "content",
-        );
-      }
-    } else {
-      if (!("flags" in args.content)) {
+    } else if (args.section === "pricing") {
+      if (!isPricingPayload) {
         cmsValidationError(
           "Pricing content must include flags.priceTabEnabled.",
           "content",
         );
       }
-      if ("metadata" in args.content) {
+    } else {
+      if (!isAboutPayload) {
         cmsValidationError(
-          "Pricing content cannot include metadata.",
+          "About content must include heroTitle and body blocks.",
           "content",
         );
       }

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -1,10 +1,12 @@
 import type { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
+  ABOUT_DEFAULTS,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
   cmsSnapshotsEqual,
   defaultSnapshotForSection,
+  type AboutSnapshot,
   type CmsSection,
   type CmsSnapshot,
   type PricingSnapshot,
@@ -46,6 +48,9 @@ async function initialSnapshotForSection(
       flags: legacyFlags ?? PRICING_DEFAULTS.flags,
       packages: [],
     } satisfies PricingSnapshot;
+  }
+  if (section === "about") {
+    return ABOUT_DEFAULTS;
   }
   return SETTINGS_DEFAULTS;
 }
@@ -177,6 +182,58 @@ function collectPricingIssues(draft: PricingSnapshot): PublishIssue[] {
   return issues;
 }
 
+function collectAboutIssues(draft: AboutSnapshot): PublishIssue[] {
+  const issues: PublishIssue[] = [];
+
+  const heroTitle = trimOrEmpty(draft.heroTitle);
+  if (heroTitle.length === 0) {
+    issues.push({
+      path: "heroTitle",
+      message: "Hero title is required to publish.",
+    });
+  }
+
+  if (!Array.isArray(draft.body) || draft.body.length === 0) {
+    issues.push({
+      path: "body",
+      message: "At least one body block is required.",
+    });
+  } else {
+    for (let i = 0; i < draft.body.length; i++) {
+      const block = draft.body[i];
+      const base = `body[${i}]`;
+      if (block.type !== "paragraph" && block.type !== "heading") {
+        issues.push({
+          path: `${base}.type`,
+          message: "Block type must be \"paragraph\" or \"heading\".",
+        });
+      }
+      if (typeof block.text !== "string" || block.text.trim().length === 0) {
+        issues.push({
+          path: `${base}.text`,
+          message: "Block text cannot be empty.",
+        });
+      }
+    }
+  }
+
+  if (draft.highlights !== undefined) {
+    for (let i = 0; i < draft.highlights.length; i++) {
+      if (
+        typeof draft.highlights[i] !== "string" ||
+        draft.highlights[i].trim().length === 0
+      ) {
+        issues.push({
+          path: `highlights[${i}]`,
+          message: "Highlight text cannot be empty.",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
 /** Best-effort checks before promoting `draft` to published (INF-75). */
 export function collectPublishIssues(
   section: CmsSection,
@@ -184,6 +241,9 @@ export function collectPublishIssues(
 ): PublishIssue[] {
   if (section === "settings") {
     return collectSettingsIssues(draft as SettingsSnapshot);
+  }
+  if (section === "about") {
+    return collectAboutIssues(draft as AboutSnapshot);
   }
   return collectPricingIssues(draft as PricingSnapshot);
 }

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -1,6 +1,8 @@
 import type { Infer } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import type {
+  aboutBlockValidator,
+  aboutContentValidator,
   pricingBillingCadenceValidator,
   pricingContentValidator,
   pricingPackageValidator,
@@ -13,6 +15,8 @@ export type SettingsSnapshot = Infer<typeof settingsContentValidator>;
 export type PricingSnapshot = Infer<typeof pricingContentValidator>;
 export type PricingPackage = Infer<typeof pricingPackageValidator>;
 export type PricingBillingCadence = Infer<typeof pricingBillingCadenceValidator>;
+export type AboutSnapshot = Infer<typeof aboutContentValidator>;
+export type AboutBlock = Infer<typeof aboutBlockValidator>;
 
 /** Per-section default snapshots used for seeding and new-row inserts. */
 export const SETTINGS_DEFAULTS: SettingsSnapshot = {
@@ -84,8 +88,34 @@ export const PRICING_DEFAULTS: PricingSnapshot = {
   packages: DEFAULT_PRICING_PACKAGES,
 };
 
+/**
+ * Default About page copy shipped with a brand-new deployment. Seeded so the
+ * public route renders before the owner has made their first publish. Kept
+ * intentionally short — real copy goes in via the admin editor.
+ */
+export const ABOUT_DEFAULTS: AboutSnapshot = {
+  heroTitle: "About Lula Lake Sound",
+  heroSubtitle: "A creative space for music production and recording.",
+  body: [
+    {
+      type: "paragraph",
+      text: "Lula Lake Sound is a studio focused on helping artists capture the sound they hear in their heads.",
+    },
+  ],
+  highlights: [],
+  seoTitle: "",
+  seoDescription: "",
+};
+
 export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
-  return section === "settings" ? SETTINGS_DEFAULTS : PRICING_DEFAULTS;
+  switch (section) {
+    case "settings":
+      return SETTINGS_DEFAULTS;
+    case "pricing":
+      return PRICING_DEFAULTS;
+    case "about":
+      return ABOUT_DEFAULTS;
+  }
 }
 
 /**

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -1,5 +1,6 @@
 import { query } from "./_generated/server";
 import {
+  publishedAboutFromRow,
   publishedPricingFromRows,
   publishedSettingsFromRow,
 } from "./publicSettingsSnapshot";
@@ -83,6 +84,22 @@ export const getPublishedGear = query({
         ...(i.url !== undefined ? { url: i.url } : {}),
       })),
     };
+  },
+});
+
+/**
+ * Published About page copy only. Anonymous; reads `publishedSnapshot` for
+ * the `about` section. Falls back to seeded defaults when the row doesn't
+ * exist yet, so the public route always renders.
+ */
+export const getPublishedAbout = query({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "about"))
+      .unique();
+    return publishedAboutFromRow(row);
   },
 });
 

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -1,7 +1,10 @@
 import type { Doc } from "./_generated/dataModel";
 import {
+  ABOUT_DEFAULTS,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
+  type AboutBlock,
+  type AboutSnapshot,
   type PricingPackage,
   type PricingSnapshot,
   type SettingsSnapshot,
@@ -140,6 +143,67 @@ export function publishedPricingFromRows(
   return {
     flags: flags ?? PRICING_DEFAULTS.flags,
     packages,
+  };
+}
+
+function isValidAboutBlock(value: unknown): value is AboutBlock {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (v.type !== "paragraph" && v.type !== "heading") return false;
+  if (typeof v.text !== "string") return false;
+  return true;
+}
+
+/**
+ * Returns safe published About page copy. Tolerant of partially-invalid
+ * stored data (e.g. a stray non-string highlight won't blow up the public
+ * route) and falls back to `ABOUT_DEFAULTS` when there's nothing usable.
+ *
+ * Strings are passed through **as text** — consumers must not feed them to
+ * `dangerouslySetInnerHTML`. If a future field stores markdown that allows
+ * raw HTML, sanitize here (e.g. rehype-sanitize) before returning.
+ */
+export function publishedAboutFromRow(
+  row: Doc<"cmsSections"> | null,
+): AboutSnapshot {
+  const snap = row?.publishedSnapshot as unknown;
+  if (!snap || typeof snap !== "object") {
+    return ABOUT_DEFAULTS;
+  }
+
+  const s = snap as {
+    heroTitle?: unknown;
+    heroSubtitle?: unknown;
+    body?: unknown;
+    highlights?: unknown;
+    seoTitle?: unknown;
+    seoDescription?: unknown;
+  };
+
+  const heroTitle =
+    typeof s.heroTitle === "string" ? s.heroTitle : ABOUT_DEFAULTS.heroTitle;
+  const heroSubtitle =
+    typeof s.heroSubtitle === "string" ? s.heroSubtitle : undefined;
+
+  const body: AboutBlock[] = Array.isArray(s.body)
+    ? s.body.filter(isValidAboutBlock)
+    : [];
+
+  const highlights: string[] | undefined = Array.isArray(s.highlights)
+    ? s.highlights.filter((h): h is string => typeof h === "string")
+    : undefined;
+
+  const seoTitle = typeof s.seoTitle === "string" ? s.seoTitle : undefined;
+  const seoDescription =
+    typeof s.seoDescription === "string" ? s.seoDescription : undefined;
+
+  return {
+    heroTitle,
+    ...(heroSubtitle !== undefined ? { heroSubtitle } : {}),
+    body: body.length > 0 ? body : ABOUT_DEFAULTS.body,
+    ...(highlights !== undefined ? { highlights } : {}),
+    ...(seoTitle !== undefined ? { seoTitle } : {}),
+    ...(seoDescription !== undefined ? { seoDescription } : {}),
   };
 }
 

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -7,6 +7,7 @@ import { v } from "convex/values";
  * Sections today:
  * - `settings`  — site metadata (title, description; extend as CMS grows).
  * - `pricing`   — feature flags and package/rate catalog that govern pricing surfaces.
+ * - `about`     — About page hero copy, body block array, optional highlights, SEO meta.
  */
 export const siteFlagsValidator = v.object({
   priceTabEnabled: v.boolean(),
@@ -94,15 +95,53 @@ export const pricingContentValidator = v.object({
   packages: v.optional(v.array(pricingPackageValidator)),
 });
 
+/**
+ * Ordered block that makes up the About page body.
+ *
+ * We intentionally pick a **block array of plain text** over a raw markdown
+ * string so public renderers never have to parse or sanitize HTML — each
+ * block's `text` goes into a React text node (which auto-escapes) inside a
+ * fixed element chosen by `type`. This satisfies the "no script injection"
+ * acceptance criteria without a sanitization pipeline.
+ *
+ * If richer formatting is needed later, switch to a markdown string field
+ * and run it through `rehype-sanitize` in the public loader.
+ */
+export const aboutBlockValidator = v.object({
+  type: v.union(v.literal("paragraph"), v.literal("heading")),
+  text: v.string(),
+});
+
+/**
+ * "about" section snapshot — About page copy (INF-xx follow-up to INF-70).
+ *
+ * - `heroTitle` — required display heading above the fold.
+ * - `heroSubtitle` — optional supporting line.
+ * - `body` — ordered paragraph / heading blocks (see `aboutBlockValidator`).
+ * - `highlights` — optional short bulleted callouts (e.g. key studio facts).
+ * - `seoTitle` / `seoDescription` — optional overrides for page metadata;
+ *   when blank the route should fall back to the `settings` section.
+ */
+export const aboutContentValidator = v.object({
+  heroTitle: v.string(),
+  heroSubtitle: v.optional(v.string()),
+  body: v.array(aboutBlockValidator),
+  highlights: v.optional(v.array(v.string())),
+  seoTitle: v.optional(v.string()),
+  seoDescription: v.optional(v.string()),
+});
+
 /** Any section's snapshot payload — discriminated at runtime by the row's `section`. */
 export const cmsSnapshotValidator = v.union(
   settingsContentValidator,
   pricingContentValidator,
+  aboutContentValidator,
 );
 
 export const cmsSectionValidator = v.union(
   v.literal("settings"),
   v.literal("pricing"),
+  v.literal("about"),
 );
 
 /** Draft vs published rows in `gearCategories` / `gearItems` (INF-86). */

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import {
+  ABOUT_DEFAULTS,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
   type CmsSection,
@@ -46,6 +47,7 @@ export const seedSiteSettingsDefaults = internalMutation({
     const results = await Promise.all([
       ensureSeeded("settings", SETTINGS_DEFAULTS),
       ensureSeeded("pricing", PRICING_DEFAULTS),
+      ensureSeeded("about", ABOUT_DEFAULTS),
     ]);
 
     return {

--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -18,10 +18,13 @@
 |---------|-------|--------------|
 | `settings` | `{ metadata?: { title, description } }` | `/admin/settings` |
 | `pricing`  | `{ flags: { priceTabEnabled } }`         | `/admin/pricing` |
+| `about`    | `{ heroTitle, heroSubtitle?, body: Block[], highlights?, seoTitle?, seoDescription? }` (block = `{ type: 'paragraph' \| 'heading', text: string }`) | `/admin/about` |
 
 Each section has its own `cmsSections` row and therefore its own independent draft / publish lifecycle. Publishing one section never publishes another (except via `api.admin.publish.publishSite`, which explicitly iterates all `cmsSections` rows with pending drafts **and** the studio gallery when `galleryPhotoMeta.hasDraftChanges` is true).
 
 > Legacy rows whose `settings.publishedSnapshot` still contains `flags` remain schema-valid thanks to an optional `flags` field on `settingsContentValidator`. Public / preview pricing queries fall back to that legacy location when the `pricing` row hasn’t been written yet, so no migration is required before deploy.
+
+> The `about` body uses a **block array of plain text** (`{type, text}`) rather than a raw markdown string so public renderers never have to parse or sanitize HTML — each block's `text` is rendered as a React text node inside a fixed element chosen by `type`. If raw markdown (with HTML) is introduced later, run it through `rehype-sanitize` in `publishedAboutFromRow` (or the public route loader) before handing off to a renderer.
 
 ## Admin UI (Settings, Pricing, Gear)
 


### PR DESCRIPTION
## Summary
- Added a new `about` CMS section with schema, defaults, seeding, and publish validation support.
- Implemented public and owner-only preview queries for the About page, with safe fallback rendering when data is missing or partially invalid.
- Extended CMS save/publish helpers and docs to cover About content blocks, highlights, and optional SEO fields.

## Testing
- Not run
- Checked the diff for schema, query, and publish-path consistency across `convex/cms.ts`, `convex/public.ts`, and `convex/publicSettingsSnapshot.ts`
- Reviewed the new About content validation rules for required hero title and body blocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to extending the CMS schema/section unions and publish-validation logic, which could affect draft saving/publishing behavior across sections if mis-typed or mis-routed. Adds new anonymous/public read paths, so regressions could surface on the marketing site if defaults/sanitization are incorrect.
> 
> **Overview**
> Introduces a new CMS `about` section (schema validators, defaults, and seeding) so About page copy can follow the same draft/publish lifecycle as `settings` and `pricing`.
> 
> Adds an owner-gated preview query (`getPreviewAbout`) that resolves draft-over-published without leaking drafts, and a new anonymous public query (`getPublishedAbout`) that returns sanitized published About content with fallbacks to `ABOUT_DEFAULTS` when missing/partially invalid.
> 
> Extends shared CMS plumbing to support `about` end-to-end: `saveDraft` accepts/guards the new snapshot shape, `defaultSnapshotForSection` and row initialization handle `about`, and publish preflight validation now includes About-specific required-field checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf6ce657586ef586e9bba0a8b773c161c2c05c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->