### PR TITLE
INF-46: CMS-backed About page, preview, and CMS button contrast

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,2 @@
+1. always use bun over npm
+2. never use useEffect()

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as aboutPreviewDraft from "../aboutPreviewDraft.js";
 import type * as aboutTeamStorage from "../aboutTeamStorage.js";
+import type * as admin_about from "../admin/about.js";
 import type * as admin_aboutTeam from "../admin/aboutTeam.js";
 import type * as admin_gear from "../admin/gear.js";
 import type * as admin_photos from "../admin/photos.js";
@@ -47,6 +48,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   aboutPreviewDraft: typeof aboutPreviewDraft;
   aboutTeamStorage: typeof aboutTeamStorage;
+  "admin/about": typeof admin_about;
   "admin/aboutTeam": typeof admin_aboutTeam;
   "admin/gear": typeof admin_gear;
   "admin/photos": typeof admin_photos;

--- a/convex/admin/about.ts
+++ b/convex/admin/about.ts
@@ -1,0 +1,25 @@
+/**
+ * Owner-only helpers for the About admin editor that aren't tied to
+ * team headshots or the studio gallery.
+ */
+import { v } from "convex/values";
+import { query } from "../_generated/server";
+import { requireCmsOwner } from "../lib/auth";
+
+/**
+ * Resolve a signed URL for the About hero image storage id.
+ *
+ * The hero image can point to either a gallery photo's storageId or a
+ * bespoke upload made directly from the About editor (not added to the
+ * public studio gallery). Both cases live in Convex `_storage`, so a
+ * simple URL lookup is enough — we just need an owner-gated query so
+ * the admin surface can render a preview for uploads that don't appear
+ * in the gallery picker. Returns `null` if the blob was deleted.
+ */
+export const getHeroImageUrl = query({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, args) => {
+    await requireCmsOwner(ctx);
+    return await ctx.storage.getUrl(args.storageId);
+  },
+});

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -28,9 +28,20 @@ export type PublicAboutTeamMember = {
   imageUrl: string | null;
 };
 
-/** Published About payload for marketing routes (sanitized + image URLs). */
-export type PublicAboutSnapshot = Omit<AboutSnapshot, "teamMembers"> & {
+/**
+ * Published About payload for marketing routes (sanitized + image URLs).
+ *
+ * `heroImageStorageId` is stripped (we never leak storage ids to anonymous
+ * callers); the resolved signed URL lives on `heroImageUrl` instead. When
+ * the storage blob has been deleted or was never set, `heroImageUrl` is
+ * `null` — the public renderer should fall back to a baked-in default.
+ */
+export type PublicAboutSnapshot = Omit<
+  AboutSnapshot,
+  "teamMembers" | "heroImageStorageId"
+> & {
   teamMembers?: PublicAboutTeamMember[];
+  heroImageUrl?: string | null;
 };
 
 /** Per-section default snapshots used for seeding and new-row inserts. */
@@ -107,8 +118,12 @@ export const PRICING_DEFAULTS: PricingSnapshot = {
  * Default About page copy shipped with a brand-new deployment. Seeded so the
  * public route renders before the owner has made their first publish. Kept
  * intentionally short — real copy goes in via the admin editor.
+ *
+ * `published` defaults to `false` (INF-46): the About page is hidden behind
+ * a feature flag until the owner explicitly enables it from the CMS.
  */
 export const ABOUT_DEFAULTS: AboutSnapshot = {
+  published: false,
   heroTitle: "About Lula Lake Sound",
   heroSubtitle: "A creative space for music production and recording.",
   body: [
@@ -117,6 +132,7 @@ export const ABOUT_DEFAULTS: AboutSnapshot = {
       text: "Lula Lake Sound is a studio focused on helping artists capture the sound they hear in their heads.",
     },
   ],
+  pullQuote: "The mountain doesn't rush. Neither should the music.",
   highlights: [],
   seoTitle: "",
   seoDescription: "",

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -106,6 +106,24 @@ export const getPublishedAbout = query({
 });
 
 /**
+ * Lightweight visibility check for the INF-46 About-page feature flag. Used
+ * by the header nav and other high-traffic surfaces so we don't have to load
+ * the full About snapshot (and generate signed team-headshot URLs) every
+ * time they need to decide whether to render the "About" link.
+ */
+export const getPublishedAboutVisibility = query({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_section", (q) => q.eq("section", "about"))
+      .unique();
+    const snapshot = publishedAboutFromRow(row);
+    return { published: snapshot.published === true };
+  },
+});
+
+/**
  * Published studio gallery photos only. Anonymous; reads `scope === "published"`.
  */
 export const getPublishedGalleryPhotos = query({

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -191,16 +191,27 @@ export function publishedAboutFromRow(
   }
 
   const s = snap as {
+    published?: unknown;
+    heroImageStorageId?: unknown;
     heroTitle?: unknown;
     heroSubtitle?: unknown;
     bodyHtml?: unknown;
     body?: unknown;
+    pullQuote?: unknown;
     highlights?: unknown;
     seoTitle?: unknown;
     seoDescription?: unknown;
     teamMembers?: unknown;
   };
 
+  // INF-46: hidden by default. Missing flag on legacy rows is treated as
+  // `false` so shipping the feature doesn't unexpectedly expose the page;
+  // the owner must toggle it on explicitly from the CMS.
+  const published = typeof s.published === "boolean" ? s.published : false;
+  const heroImageStorageId =
+    typeof s.heroImageStorageId === "string" && s.heroImageStorageId.length > 0
+      ? (s.heroImageStorageId as Id<"_storage">)
+      : undefined;
   const heroTitle =
     typeof s.heroTitle === "string" ? s.heroTitle : ABOUT_DEFAULTS.heroTitle;
   const heroSubtitle =
@@ -214,6 +225,11 @@ export function publishedAboutFromRow(
   const body: AboutBlock[] = Array.isArray(s.body)
     ? s.body.filter(isValidAboutBlock)
     : [];
+
+  const pullQuote =
+    typeof s.pullQuote === "string" && s.pullQuote.trim().length > 0
+      ? s.pullQuote
+      : undefined;
 
   const highlights: string[] | undefined = Array.isArray(s.highlights)
     ? s.highlights.filter((h): h is string => typeof h === "string")
@@ -235,6 +251,8 @@ export function publishedAboutFromRow(
     : undefined;
 
   return {
+    published,
+    ...(heroImageStorageId !== undefined ? { heroImageStorageId } : {}),
     heroTitle,
     ...(heroSubtitle !== undefined ? { heroSubtitle } : {}),
     ...(bodyHtml !== undefined ? { bodyHtml } : {}),
@@ -242,6 +260,7 @@ export function publishedAboutFromRow(
     // `bodyHtml` is absent. Once all rows have `bodyHtml`, this can be
     // dropped alongside the schema field.
     body: body.length > 0 ? body : ABOUT_DEFAULTS.body,
+    ...(pullQuote !== undefined ? { pullQuote } : {}),
     ...(highlights !== undefined ? { highlights } : {}),
     ...(seoTitle !== undefined ? { seoTitle } : {}),
     ...(seoDescription !== undefined ? { seoDescription } : {}),
@@ -252,28 +271,42 @@ export function publishedAboutFromRow(
 }
 
 /**
- * Resolve team headshots to signed URLs for anonymous public callers (no storage ids).
+ * Resolve team headshots + the CMS-picked hero image to signed URLs for
+ * anonymous public callers (never leaks raw storage ids). `null` signals the
+ * blob is missing / deleted — the public renderer should fall back to a
+ * baked-in default image.
  */
 export async function materializePublicAbout(
   ctx: QueryCtx,
   snapshot: AboutSnapshot,
 ): Promise<PublicAboutSnapshot> {
-  const { teamMembers, ...rest } = snapshot;
-  if (!teamMembers || teamMembers.length === 0) {
-    return rest as PublicAboutSnapshot;
-  }
-  const publicTeam: PublicAboutTeamMember[] = await Promise.all(
-    teamMembers.map(async (m) => ({
-      id: m.id,
-      name: m.name,
-      title: m.title,
-      imageUrl:
-        m.storageId !== undefined
-          ? await ctx.storage.getUrl(m.storageId)
-          : null,
-    })),
-  );
-  return { ...rest, teamMembers: publicTeam };
+  const { teamMembers, heroImageStorageId, ...rest } = snapshot;
+
+  const heroImageUrl =
+    heroImageStorageId !== undefined
+      ? await ctx.storage.getUrl(heroImageStorageId)
+      : null;
+
+  const publicTeam: PublicAboutTeamMember[] | undefined =
+    teamMembers && teamMembers.length > 0
+      ? await Promise.all(
+          teamMembers.map(async (m) => ({
+            id: m.id,
+            name: m.name,
+            title: m.title,
+            imageUrl:
+              m.storageId !== undefined
+                ? await ctx.storage.getUrl(m.storageId)
+                : null,
+          })),
+        )
+      : undefined;
+
+  return {
+    ...rest,
+    ...(publicTeam !== undefined ? { teamMembers: publicTeam } : {}),
+    heroImageUrl,
+  };
 }
 
 /**

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -122,8 +122,17 @@ export const aboutTeamMemberValidator = v.object({
 });
 
 /**
- * "about" section snapshot — About page copy (INF-70 / INF-98).
+ * "about" section snapshot — About page copy (INF-70 / INF-98 / INF-46).
  *
+ * - `published` — INF-46 visibility flag. Feature-flag that gates the public
+ *   `/about` route and the header's "About" nav link. Treated as `false`
+ *   (hidden) when absent so net-new deployments stay off until the owner
+ *   explicitly enables the page from the CMS.
+ * - `heroImageStorageId` — optional Convex storage id of the cinematic hero
+ *   image shown at the top of the public About page. The owner picks an
+ *   already-uploaded photo from the studio gallery (INF-46 follow-up); the
+ *   public renderer falls back to a baked-in image when this is absent or
+ *   when the storage blob has been deleted (`storage.getUrl` → `null`).
  * - `heroTitle` — required display heading above the fold.
  * - `heroSubtitle` — optional supporting line.
  * - `bodyHtml` — rich-text body authored in the admin editor (Tiptap HTML
@@ -136,16 +145,23 @@ export const aboutTeamMemberValidator = v.object({
  * - `body` — legacy ordered paragraph / heading blocks (see
  *   `aboutBlockValidator`). Kept for back-compat so pre-INF-98 rows keep
  *   validating; new writes populate `bodyHtml` instead.
+ * - `pullQuote` — INF-46 editorial pull quote rendered **below** the
+ *   owner / studio-designer headshots on the Variant A layout.
  * - `highlights` — optional short bulleted callouts (e.g. key studio facts).
  * - `seoTitle` / `seoDescription` — optional overrides for page metadata;
  *   when blank the route should fall back to the `settings` section.
  * - `teamMembers` — optional ordered list of people (image, name, title).
+ *   The public page renders the first two entries as owner / studio
+ *   designer headshots in the Variant A layout.
  */
 export const aboutContentValidator = v.object({
+  published: v.optional(v.boolean()),
+  heroImageStorageId: v.optional(v.id("_storage")),
   heroTitle: v.string(),
   heroSubtitle: v.optional(v.string()),
   bodyHtml: v.optional(v.string()),
   body: v.array(aboutBlockValidator),
+  pullQuote: v.optional(v.string()),
   highlights: v.optional(v.array(v.string())),
   seoTitle: v.optional(v.string()),
   seoDescription: v.optional(v.string()),

--- a/src/app/about/about-client.tsx
+++ b/src/app/about/about-client.tsx
@@ -1,38 +1,17 @@
 "use client";
 
 import { usePreloadedQuery, type Preloaded } from "convex/react";
-import Image from "next/image";
-import Link from "next/link";
-import { useEffect, useState } from "react";
 import { api } from "../../../convex/_generated/api";
-import type { PublicAboutSnapshot } from "../../../convex/cmsShared";
-import { Header } from "@/components/header";
-import { AboutBodyContent } from "./about-body-content";
+import { AboutLayout } from "./about-layout";
 
 type PreloadedAbout = Preloaded<typeof api.public.getPublishedAbout>;
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags>;
 
-function AboutBody({ data }: { readonly data: PublicAboutSnapshot }) {
-  const html = data.bodyHtml?.trim();
-  if (html && html.length > 0) {
-    return <AboutBodyContent key={html} html={html} />;
-  }
-
-  return (
-    <div className="prose-editor max-w-none space-y-4">
-      {data.body.map((block, i) =>
-        block.type === "heading" ? (
-          <h2 key={i} className="text-sand">
-            {block.text}
-          </h2>
-        ) : (
-          <p key={i}>{block.text}</p>
-        ),
-      )}
-    </div>
-  );
-}
-
+/**
+ * Public `/about` client. Resolves the two preloaded queries from the server
+ * component and hands plain data to the shared {@link AboutLayout}, which is
+ * also reused by the owner-only `/preview/about` route.
+ */
 export function AboutClient({
   aboutPreloaded,
   pricingPreloaded,
@@ -42,81 +21,7 @@ export function AboutClient({
 }) {
   const data = usePreloadedQuery(aboutPreloaded);
   const pricingData = usePreloadedQuery(pricingPreloaded);
-  const [scrollY, setScrollY] = useState(0);
+  const showPricing = pricingData.flags.priceTabEnabled === true;
 
-  useEffect(() => {
-    const onScroll = () => setScrollY(window.scrollY);
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  const showPricing = pricingData.flags.priceTabEnabled;
-
-  return (
-    <div className="dark min-h-screen bg-washed-black relative grain-overlay">
-      <Header scrollY={scrollY} showPricing={showPricing} />
-
-      <main className="mx-auto max-w-3xl px-4 pb-24 pt-28 md:pt-32">
-        <p className="label-text text-sand/70 mb-2">
-          <Link href="/" className="hover:text-sand transition-colors">
-            Home
-          </Link>
-          <span className="mx-2 text-sand/40">/</span>
-          About
-        </p>
-
-        <h1 className="headline-primary text-ivory mb-3 text-balance">
-          {data.heroTitle}
-        </h1>
-        {data.heroSubtitle ? (
-          <p className="body-text text-ivory/75 mb-10 max-w-2xl">
-            {data.heroSubtitle}
-          </p>
-        ) : (
-          <div className="mb-10" />
-        )}
-
-        <AboutBody data={data} />
-
-        {data.teamMembers && data.teamMembers.length > 0 ? (
-          <section className="mt-24 border-t border-sand/10 pt-16">
-            <h2 className="headline-secondary text-sand mb-10 text-center">
-              Team
-            </h2>
-            <ul className="grid gap-10 sm:grid-cols-2">
-              {data.teamMembers.map((m) => (
-                <li
-                  key={m.id}
-                  className="flex flex-col items-center text-center space-y-3"
-                >
-                  {m.imageUrl ? (
-                    <div className="relative size-40 overflow-hidden rounded-full border border-sand/15 bg-charcoal/50">
-                      <Image
-                        src={m.imageUrl}
-                        alt={m.name}
-                        fill
-                        sizes="160px"
-                        className="object-cover"
-                      />
-                    </div>
-                  ) : (
-                    <div
-                      className="flex size-40 items-center justify-center rounded-full border border-dashed border-sand/20 bg-charcoal/30 text-xs text-ivory/40"
-                      aria-hidden
-                    >
-                      No photo
-                    </div>
-                  )}
-                  <div>
-                    <p className="headline-secondary text-ivory">{m.name}</p>
-                    <p className="body-text-small text-ivory/65">{m.title}</p>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ) : null}
-      </main>
-    </div>
-  );
+  return <AboutLayout data={data} showPricing={showPricing} />;
 }

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useCallback, useState } from "react";
 import type {
   PublicAboutSnapshot,
@@ -137,6 +138,11 @@ interface AboutLayoutProps {
 
 export function AboutLayout({ data, showPricing, banner }: AboutLayoutProps) {
   const [scrollY, setScrollY] = useState(0);
+  const pathname = usePathname();
+  const aboutHref =
+    pathname === "/preview" || pathname.startsWith("/preview/")
+      ? "/preview/about"
+      : "/about";
 
   // Ref callback owns the scroll listener + reveal observer lifecycle so we
   // can follow the project's "no useEffect" convention (see AGENTS.md). React
@@ -200,7 +206,12 @@ export function AboutLayout({ data, showPricing, banner }: AboutLayoutProps) {
           route, and owners viewing draft see their latest toggle value
           anyway — always showing the About link here keeps the header
           self-consistent with the current page. */}
-      <Header scrollY={scrollY} showPricing={showPricing} showAbout />
+      <Header
+        scrollY={scrollY}
+        showPricing={showPricing}
+        showAbout
+        aboutHref={aboutHref}
+      />
 
       <main>
         <section className="relative" aria-labelledby="about-hero-title">

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useCallback, useState } from "react";
+import type {
+  PublicAboutSnapshot,
+  PublicAboutTeamMember,
+} from "../../../convex/cmsShared";
+import { Header } from "@/components/header";
+import { SiteFooter } from "@/components/site-footer";
+import { AboutBodyContent } from "./about-body-content";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared presentational layer for the public About page and the owner-only
+ * preview. Takes plain data (already materialized by whichever query the
+ * caller used) so we can mount the same markup behind either
+ * `api.public.getPublishedAbout` or `api.aboutPreviewDraft.getPreviewAbout`.
+ *
+ * Per the client direction (2026-04-21, INF-46):
+ *  - Variant A "Cinematic Editorial" hero + two-column narrative.
+ *  - Owner / studio-designer circular headshots.
+ *  - **Pull quote placement: below the About body copy** (left column), not under headshots.
+ *  - **No milestones / timeline section** is rendered.
+ */
+
+/**
+ * Fallback cinematic hero image when the CMS has no `heroImageStorageId`
+ * set (or the blob has been deleted → `storage.getUrl` → `null`). This URL
+ * is already listed under `images.remotePatterns` in `next.config.ts`, so
+ * `next/image` can optimize it without changes.
+ *
+ * The owner-facing flow is: pick from existing gallery photos in the
+ * About admin — `data.heroImageUrl` is the resolved signed URL when set.
+ */
+const HERO_IMAGE_FALLBACK_SRC =
+  "https://g3ik3pexma.ufs.sh/f/Ans4G8qtRkcnAhUWTJqtRkcnhBTMlYH2mZ96dp7NjQyvSeA8";
+
+/**
+ * Reuses the site-wide `.reveal` + `.reveal-delay-N` CSS (see
+ * `src/app/globals.css`). A container-level IntersectionObserver toggles
+ * `.in-view` on each observed element when it scrolls into view.
+ */
+const MAX_REVEAL_DELAY = 6;
+function aboutRevealDelay(step: number): string {
+  if (step <= 0) return "reveal";
+  const clamped = Math.min(step, MAX_REVEAL_DELAY);
+  return `reveal reveal-delay-${clamped}`;
+}
+
+function BodyCopy({ data }: { readonly data: PublicAboutSnapshot }) {
+  const html = data.bodyHtml?.trim();
+  if (html && html.length > 0) {
+    return (
+      <div className="max-w-2xl">
+        <AboutBodyContent key={html} html={html} />
+      </div>
+    );
+  }
+  return (
+    <div className="max-w-2xl space-y-6">
+      {data.body.map((block, i) =>
+        block.type === "heading" ? (
+          <h2
+            key={i}
+            className="headline-secondary text-sand text-2xl md:text-3xl"
+          >
+            {block.text}
+          </h2>
+        ) : (
+          <p
+            key={i}
+            className="body-text text-ivory/70 text-lg leading-[1.8]"
+          >
+            {block.text}
+          </p>
+        ),
+      )}
+    </div>
+  );
+}
+
+interface HeadshotProps {
+  readonly member?: PublicAboutTeamMember;
+  readonly fallbackRole: string;
+}
+
+function Headshot({ member, fallbackRole }: HeadshotProps) {
+  const role = member?.title ?? fallbackRole;
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative aspect-square w-full max-w-[220px] overflow-hidden rounded-full border border-sand/10 bg-charcoal/40">
+        {member?.imageUrl ? (
+          <Image
+            src={member.imageUrl}
+            alt={member.name ? `Portrait of ${member.name}` : ""}
+            fill
+            sizes="(min-width: 1024px) 220px, (min-width: 640px) 40vw, 70vw"
+            className="object-cover"
+          />
+        ) : (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 px-4 text-center"
+            aria-hidden
+          >
+            <span className="label-text text-ivory/30 text-[10px] tracking-[0.2em] leading-snug">
+              Portrait
+            </span>
+            <span className="body-text-small text-ivory/35 text-[11px] leading-snug">
+              Coming soon
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="mt-5 text-center">
+        {member?.name ? (
+          <p className="headline-secondary text-ivory text-lg">{member.name}</p>
+        ) : null}
+        <p className="label-text text-sand/60 text-[10px] tracking-[0.2em] mt-1">
+          {role}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface AboutLayoutProps {
+  readonly data: PublicAboutSnapshot;
+  readonly showPricing: boolean;
+  /**
+   * Optional banner slot above the header (used by the preview route to show
+   * "Draft" / "No unpublished changes" state).
+   */
+  readonly banner?: React.ReactNode;
+}
+
+export function AboutLayout({ data, showPricing, banner }: AboutLayoutProps) {
+  const [scrollY, setScrollY] = useState(0);
+
+  // Ref callback owns the scroll listener + reveal observer lifecycle so we
+  // can follow the project's "no useEffect" convention (see AGENTS.md). React
+  // 19 runs the cleanup returned here when the node detaches, matching the
+  // pattern in `src/components/homepage-shell.tsx`.
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+
+    let ticking = false;
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        setScrollY(window.scrollY);
+        ticking = false;
+      });
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    setScrollY(window.scrollY);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("in-view");
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -60px 0px" },
+    );
+    const reveals = node.querySelectorAll(".reveal");
+    reveals.forEach((el) => observer.observe(el));
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      observer.disconnect();
+    };
+  }, []);
+
+  const team = data.teamMembers ?? [];
+  // Variant A composition features exactly two circular headshots — owner +
+  // studio designer. Additional team members on the same CMS snapshot are
+  // reserved for a future grid section.
+  const [owner, designer] = [team[0], team[1]];
+  const pullQuote = data.pullQuote?.trim();
+  // `heroImageUrl` may be `null` if the stored blob was deleted from the
+  // gallery; fall back to the baked-in image so the page always has a hero.
+  const heroImageSrc =
+    data.heroImageUrl && data.heroImageUrl.length > 0
+      ? data.heroImageUrl
+      : HERO_IMAGE_FALLBACK_SRC;
+
+  return (
+    <div
+      ref={containerRef}
+      className="dark min-h-screen bg-deep-forest text-ivory relative grain-overlay"
+    >
+      {banner}
+      {/* About page only mounts when `published === true` for the public
+          route, and owners viewing draft see their latest toggle value
+          anyway — always showing the About link here keeps the header
+          self-consistent with the current page. */}
+      <Header scrollY={scrollY} showPricing={showPricing} showAbout />
+
+      <main>
+        <section className="relative" aria-labelledby="about-hero-title">
+          <div className="relative h-[70vh] md:h-[85vh] overflow-hidden">
+            <Image
+              src={heroImageSrc}
+              alt=""
+              role="presentation"
+              fill
+              className="object-cover"
+              quality={85}
+              priority
+              sizes="100vw"
+            />
+            <div
+              aria-hidden
+              className="absolute inset-0 bg-gradient-to-b from-deep-forest/60 via-deep-forest/30 to-deep-forest"
+            />
+            <div className="absolute inset-0 flex items-end">
+              <div className="mx-auto w-full max-w-7xl px-6 pb-16 md:px-16 md:pb-24">
+                <nav aria-label="Breadcrumb" className={aboutRevealDelay(0)}>
+                  <Link
+                    href="/"
+                    className="label-text text-sand/60 hover:text-sand transition-colors text-[11px] tracking-[0.2em]"
+                  >
+                    ← Lula Lake Sound
+                  </Link>
+                </nav>
+                <h1
+                  id="about-hero-title"
+                  className={cn(
+                    aboutRevealDelay(2),
+                    "headline-primary text-warm-white leading-[1.05] mt-6 text-balance",
+                  )}
+                  style={{ fontSize: "clamp(2.5rem, 6vw, 5.5rem)" }}
+                >
+                  {data.heroTitle}
+                </h1>
+                {data.heroSubtitle ? (
+                  <p
+                    className={cn(
+                      aboutRevealDelay(3),
+                      "body-text text-ivory/75 mt-6 max-w-2xl text-lg md:text-xl leading-[1.6]",
+                    )}
+                  >
+                    {data.heroSubtitle}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="relative bg-deep-forest px-6 py-24 md:px-16 md:py-36"
+          aria-label="About Lula Lake Sound"
+        >
+          <div className="mx-auto grid max-w-7xl grid-cols-1 gap-16 lg:grid-cols-12 lg:gap-24">
+            <div className={cn(aboutRevealDelay(0), "lg:col-span-7")}>
+              <BodyCopy data={data} />
+              {pullQuote ? (
+                <blockquote
+                  className={cn(
+                    aboutRevealDelay(1),
+                    "mt-10 lg:mt-12 border-l-2 border-gold/50 pl-8 py-2",
+                  )}
+                >
+                  <p
+                    className="headline-secondary italic leading-[1.4] text-sand/90"
+                    style={{ fontSize: "clamp(1.375rem, 2.2vw, 1.875rem)" }}
+                  >
+                    &ldquo;{pullQuote}&rdquo;
+                  </p>
+                </blockquote>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-12 lg:col-span-5">
+              <div
+                className={cn(
+                  aboutRevealDelay(2),
+                  "grid grid-cols-1 gap-10 sm:grid-cols-2 sm:gap-8",
+                )}
+              >
+                <Headshot member={owner} fallbackRole="Owner" />
+                <Headshot member={designer} fallbackRole="Studio designer" />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {data.highlights && data.highlights.length > 0 ? (
+          <section
+            className="bg-washed-black border-t border-sand/10 px-6 py-20 md:px-16"
+            aria-label="Studio highlights"
+          >
+            <div className="mx-auto max-w-7xl">
+              <p
+                className={cn(
+                  aboutRevealDelay(0),
+                  "label-text mb-10 tracking-[0.2em] text-sand/50 text-[11px]",
+                )}
+              >
+                At a glance
+              </p>
+              <ul className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                {data.highlights.map((highlight, i) => (
+                  <li
+                    key={`${i}-${highlight.slice(0, 12)}`}
+                    className={cn(
+                      aboutRevealDelay(Math.min(i + 1, MAX_REVEAL_DELAY)),
+                      "body-text text-ivory/75 text-lg leading-[1.6] border-l border-sand/10 pl-5",
+                    )}
+                  >
+                    {highlight}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        ) : null}
+
+        <section
+          className="bg-deep-forest px-6 py-24 md:px-16 md:py-32"
+          aria-label="Get in touch"
+        >
+          <div className="mx-auto max-w-3xl text-center">
+            <p
+              className={cn(
+                aboutRevealDelay(0),
+                "label-text mb-4 tracking-[0.2em] text-sand/60 text-[11px]",
+              )}
+            >
+              Come visit
+            </p>
+            <h2
+              className={cn(
+                aboutRevealDelay(1),
+                "headline-primary text-warm-white leading-[1.1] text-balance text-3xl md:text-5xl",
+              )}
+            >
+              Ready to make something with us?
+            </h2>
+            <p
+              className={cn(
+                aboutRevealDelay(2),
+                "body-text text-ivory/70 mt-6 text-lg leading-[1.7]",
+              )}
+            >
+              Whether you&rsquo;re planning a tracking day or an immersive
+              residency, we&rsquo;d love to hear about the project.
+            </p>
+            <div
+              className={cn(
+                aboutRevealDelay(3),
+                "mt-10 flex flex-wrap items-center justify-center gap-6",
+              )}
+            >
+              <Link
+                href="/#artist-inquiries"
+                className="label-text tracking-[0.2em] text-[11px] text-sand border-b border-sand/60 pb-1 transition-colors hover:text-warm-white hover:border-warm-white"
+              >
+                Start a conversation
+              </Link>
+              <Link
+                href="/#the-space"
+                className="label-text tracking-[0.2em] text-[11px] text-ivory/60 border-b border-ivory/20 pb-1 transition-colors hover:text-sand hover:border-sand/50"
+              >
+                Tour the studio
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,19 +1,77 @@
-import { preloadQuery } from "convex/nextjs";
+import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { api } from "../../../convex/_generated/api";
 import { AboutClient } from "./about-client";
 
-export const metadata: Metadata = {
-  title: "About",
-  description:
-    "Learn about Lula Lake Sound — a creative recording and production studio.",
-};
+/**
+ * Public `/about` route (INF-46).
+ *
+ * Renders the redesigned Variant A "Cinematic Editorial" About page when the
+ * CMS-controlled `published` flag is on; returns a 404 when it is off so the
+ * page stays hidden behind the feature flag as required by the client
+ * acceptance criteria. Content (hero copy, body HTML, pull quote, team
+ * headshots) is sourced from the Convex `about` section.
+ *
+ * Metadata and the visibility check share the single preload below so we
+ * never double-hit the `public.getPublishedAbout` query for a single request.
+ */
+
+async function safePreloadAbout() {
+  try {
+    return await preloadQuery(api.public.getPublishedAbout);
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const preloaded = await safePreloadAbout();
+  if (!preloaded) {
+    return { title: "About" };
+  }
+  const data = preloadedQueryResult(preloaded);
+  if (!data.published) {
+    return { title: "About" };
+  }
+  const title =
+    data.seoTitle && data.seoTitle.trim().length > 0
+      ? data.seoTitle
+      : `${data.heroTitle} — Lula Lake Sound`;
+  const description =
+    data.seoDescription && data.seoDescription.trim().length > 0
+      ? data.seoDescription
+      : (data.heroSubtitle ??
+        "Learn about Lula Lake Sound — a creative recording and production studio on Lookout Mountain.");
+  return {
+    title,
+    description,
+    alternates: { canonical: "/about" },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      url: "/about",
+      siteName: "Lula Lake Sound",
+    },
+  };
+}
 
 export default async function AboutPage() {
   const [aboutPreloaded, pricingPreloaded] = await Promise.all([
-    preloadQuery(api.public.getPublishedAbout),
+    safePreloadAbout(),
     preloadQuery(api.public.getPublishedPricingFlags),
   ]);
+
+  if (!aboutPreloaded) {
+    notFound();
+  }
+
+  const data = preloadedQueryResult(aboutPreloaded);
+  if (!data.published) {
+    notFound();
+  }
+
   return (
     <AboutClient
       aboutPreloaded={aboutPreloaded}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,14 @@
 import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { api } from "../../../convex/_generated/api";
 import { AboutClient } from "./about-client";
+
+/** One preload per request for metadata + page (same render pass). */
+const preloadPublishedAbout = cache(() =>
+  preloadQuery(api.public.getPublishedAbout),
+);
 
 /**
  * Public `/about` route (INF-46).
@@ -13,23 +19,14 @@ import { AboutClient } from "./about-client";
  * acceptance criteria. Content (hero copy, body HTML, pull quote, team
  * headshots) is sourced from the Convex `about` section.
  *
- * Metadata and the visibility check share the single preload below so we
- * never double-hit the `public.getPublishedAbout` query for a single request.
+ * `generateMetadata` and the page share one cached preload of
+ * `public.getPublishedAbout` per request. Preload failures are not caught so
+ * Convex/network errors surface as request failures instead of being
+ * misreported as a 404 via `notFound()`.
  */
 
-async function safePreloadAbout() {
-  try {
-    return await preloadQuery(api.public.getPublishedAbout);
-  } catch {
-    return null;
-  }
-}
-
 export async function generateMetadata(): Promise<Metadata> {
-  const preloaded = await safePreloadAbout();
-  if (!preloaded) {
-    return { title: "About" };
-  }
+  const preloaded = await preloadPublishedAbout();
   const data = preloadedQueryResult(preloaded);
   if (!data.published) {
     return { title: "About" };
@@ -59,13 +56,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function AboutPage() {
   const [aboutPreloaded, pricingPreloaded] = await Promise.all([
-    safePreloadAbout(),
+    preloadPublishedAbout(),
     preloadQuery(api.public.getPublishedPricingFlags),
   ]);
-
-  if (!aboutPreloaded) {
-    notFound();
-  }
 
   const data = preloadedQueryResult(aboutPreloaded);
   if (!data.published) {

--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -33,11 +33,12 @@ import { useUser } from "@clerk/nextjs";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Effect } from "effect";
 import { toast } from "sonner";
-import { ArrowDown, ArrowUp, Plus, X } from "lucide-react";
+import { ArrowDown, ArrowUp, Check, Plus, Trash2, X } from "lucide-react";
 import type { Id } from "../../../../convex/_generated/dataModel";
 import { api } from "../../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
@@ -57,12 +58,22 @@ export type AboutTeamMemberRow = {
 };
 
 type AboutContent = {
+  /** INF-46 visibility flag — gates the public `/about` route and nav link. */
+  published: boolean;
+  /**
+   * INF-46 follow-up — storage id of the hero image. The owner picks from
+   * the existing studio gallery; we intentionally reuse already-uploaded
+   * blobs rather than adding a bespoke upload surface here.
+   */
+  heroImageStorageId?: Id<"_storage">;
   heroTitle: string;
   heroSubtitle?: string;
   /** Rich-text body (Tiptap HTML). Preferred over legacy `body` blocks. */
   bodyHtml?: string;
   /** Kept for back-compat with pre-INF-98 stored rows. Not edited anymore. */
   body: AboutBlock[];
+  /** INF-46 editorial pull quote rendered below the headshots. */
+  pullQuote?: string;
   highlights?: string[];
   seoTitle?: string;
   seoDescription?: string;
@@ -184,6 +195,14 @@ function toAboutContent(raw: unknown): AboutContent {
     : [];
 
   return {
+    // INF-46: default hidden so rows saved before this field existed stay
+    // off until the owner explicitly enables the page.
+    published: typeof r.published === "boolean" ? r.published : false,
+    heroImageStorageId:
+      typeof r.heroImageStorageId === "string" &&
+      r.heroImageStorageId.length > 0
+        ? (r.heroImageStorageId as Id<"_storage">)
+        : undefined,
     heroTitle: typeof r.heroTitle === "string" ? r.heroTitle : "",
     heroSubtitle:
       typeof r.heroSubtitle === "string" ? r.heroSubtitle : undefined,
@@ -191,6 +210,10 @@ function toAboutContent(raw: unknown): AboutContent {
     // even on rows that haven't been re-saved since INF-98.
     bodyHtml: storedHtml ?? (body.length > 0 ? blocksToHtml(body) : undefined),
     body,
+    pullQuote:
+      typeof r.pullQuote === "string" && r.pullQuote.trim().length > 0
+        ? r.pullQuote
+        : undefined,
     highlights: Array.isArray(r.highlights)
       ? (r.highlights as unknown[]).filter(
           (h): h is string => typeof h === "string",
@@ -332,10 +355,34 @@ function AboutForm() {
     setLocalDraft(next);
   }, []);
 
+  const setPublished = useCallback(
+    (value: boolean) => {
+      if (!source) return;
+      mutate({ ...source, published: value });
+    },
+    [source, mutate],
+  );
+
+  const setHeroImageStorageId = useCallback(
+    (value: Id<"_storage"> | undefined) => {
+      if (!source) return;
+      mutate({ ...source, heroImageStorageId: value });
+    },
+    [source, mutate],
+  );
+
   const setHeroTitle = useCallback(
     (value: string) => {
       if (!source) return;
       mutate({ ...source, heroTitle: value });
+    },
+    [source, mutate],
+  );
+
+  const setPullQuote = useCallback(
+    (value: string) => {
+      if (!source) return;
+      mutate({ ...source, pullQuote: trimToUndefined(value) });
     },
     [source, mutate],
   );
@@ -427,10 +474,15 @@ function AboutForm() {
         saveDraft({
           section: "about",
           content: {
+            published: source?.published ?? false,
+            ...(source?.heroImageStorageId !== undefined
+              ? { heroImageStorageId: source.heroImageStorageId }
+              : {}),
             heroTitle: source?.heroTitle ?? "",
             heroSubtitle: source?.heroSubtitle,
             bodyHtml: source?.bodyHtml,
             body: source?.body ?? [],
+            pullQuote: source?.pullQuote,
             highlights: source?.highlights,
             seoTitle: source?.seoTitle,
             seoDescription: source?.seoDescription,
@@ -500,6 +552,31 @@ function AboutForm() {
     <div className="space-y-8 pb-24">
       <div className="space-y-8">
           <fieldset className="space-y-3">
+            <legend className="label-text text-muted-foreground">
+              Visibility
+            </legend>
+            <div className="flex items-start gap-3">
+              <Switch
+                id="about-published"
+                checked={source.published}
+                onCheckedChange={setPublished}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor="about-published"
+                  className="body-text-small cursor-pointer text-foreground"
+                >
+                  Show About page on site
+                </label>
+                <p className="body-text-small text-muted-foreground">
+                  Hides the public <code>/about</code> route and the header
+                  nav link when off. Preview still shows the draft value.
+                </p>
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="space-y-3">
             <legend className="label-text text-muted-foreground">Hero</legend>
             <label className="block space-y-1">
               <span className="body-text-small text-muted-foreground">
@@ -529,6 +606,32 @@ function AboutForm() {
           </fieldset>
 
           <fieldset className="space-y-3">
+            <legend className="label-text text-muted-foreground">
+              Hero image
+            </legend>
+            <p className="body-text-small text-muted-foreground">
+              Pick a photo from the studio gallery or upload a bespoke
+              image just for this page. Gallery uploads are managed from
+              the{" "}
+              <a
+                href="/admin/photos"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Photos
+              </a>{" "}
+              admin; bespoke uploads won&rsquo;t appear in the public
+              gallery.
+            </p>
+            <HeroImagePicker
+              selectedStorageId={source.heroImageStorageId}
+              onChange={setHeroImageStorageId}
+              generateUploadUrl={generateUploadUrl}
+              uploadBusyKey={uploadBusy}
+              setUploadBusyKey={setUploadBusy}
+            />
+          </fieldset>
+
+          <fieldset className="space-y-3">
             <legend className="label-text text-muted-foreground">Body</legend>
             <p className="body-text-small text-muted-foreground">
               Rich text — toolbar or markdown shortcuts (
@@ -544,6 +647,23 @@ function AboutForm() {
               placeholder="Tell the studio's story…"
               onChange={setBodyHtml}
               resetToken={editorResetToken}
+            />
+          </fieldset>
+
+          <fieldset className="space-y-3">
+            <legend className="label-text text-muted-foreground">
+              Pull quote
+            </legend>
+            <p className="body-text-small text-muted-foreground">
+              Editorial callout rendered below the owner / studio-designer
+              headshots. Leave blank to hide the quote block.
+            </p>
+            <Textarea
+              rows={2}
+              value={source.pullQuote ?? ""}
+              onChange={(e) => setPullQuote(e.target.value)}
+              placeholder="The mountain doesn't rush. Neither should the music."
+              className="text-foreground placeholder:text-muted-foreground"
             />
           </fieldset>
 
@@ -653,6 +773,7 @@ function AboutForm() {
         busy={busy}
         inlineError={inlineError}
         autosaveStatus={autosaveStatus}
+        previewHref="/preview/about"
         onPublish={() => {
           if (issues.length > 0) {
             setInlineError("Fix the blocking issues above before publishing.");
@@ -671,6 +792,269 @@ function AboutForm() {
         }}
         onDiscardConfirm={handleDiscardConfirm}
       />
+    </div>
+  );
+}
+
+interface HeroImagePickerProps {
+  readonly selectedStorageId: Id<"_storage"> | undefined;
+  readonly onChange: (storageId: Id<"_storage"> | undefined) => void;
+  readonly generateUploadUrl: () => Promise<{ uploadUrl: string }>;
+  readonly uploadBusyKey: string | null;
+  readonly setUploadBusyKey: (key: string | null) => void;
+}
+
+/**
+ * Inline picker for the About hero image.
+ *
+ * The owner can either pick a photo from the studio gallery (sourced from
+ * `api.admin.photos.listDraftPhotos` so unpublished uploads are also
+ * selectable) or upload a bespoke image just for the About page that
+ * intentionally does NOT land in the public gallery. Both cases resolve to
+ * a Convex `_storage` id, so the public About page renders them the same
+ * way via `storage.getUrl`.
+ *
+ * When the currently selected id isn't a gallery photo we fall back to a
+ * direct URL lookup (`api.admin.about.getHeroImageUrl`) so the thumbnail
+ * still renders. Only when the underlying blob has been deleted (URL
+ * resolves to `null`) do we surface a recoverable warning.
+ */
+const HERO_IMAGE_MAX_BYTES = 50 * 1024 * 1024;
+const HERO_IMAGE_ACCEPT = "image/jpeg,image/png,image/webp";
+
+type GalleryPickerPhoto = NonNullable<
+  ReturnType<typeof useQuery<typeof api.admin.photos.listDraftPhotos>>
+>["photos"][number] & { url: string };
+
+function HeroImagePicker({
+  selectedStorageId,
+  onChange,
+  generateUploadUrl,
+  uploadBusyKey,
+  setUploadBusyKey,
+}: HeroImagePickerProps) {
+  const draft = useQuery(api.admin.photos.listDraftPhotos);
+
+  const photos = useMemo<GalleryPickerPhoto[]>(
+    () =>
+      (draft?.photos ?? []).filter(
+        (p): p is GalleryPickerPhoto =>
+          typeof p.url === "string" && p.url.length > 0,
+      ),
+    [draft],
+  );
+
+  const selectedInGallery = useMemo(
+    () => photos.find((p) => p.storageId === selectedStorageId),
+    [photos, selectedStorageId],
+  );
+
+  // Resolve a URL for bespoke (non-gallery) hero uploads so we can still
+  // show a preview. Skipped when the selected id is already in the gallery
+  // list (we reuse the gallery-provided URL) or nothing is selected.
+  const bespokeUrl = useQuery(
+    api.admin.about.getHeroImageUrl,
+    selectedStorageId !== undefined && !selectedInGallery
+      ? { storageId: selectedStorageId }
+      : "skip",
+  );
+
+  const isUploading = uploadBusyKey === "hero-image-upload";
+
+  const onUploadFile = async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      toast.error("Choose an image file (JPEG, PNG, or WebP).");
+      return;
+    }
+    if (file.size > HERO_IMAGE_MAX_BYTES) {
+      toast.error(
+        `Image must be ${Math.floor(HERO_IMAGE_MAX_BYTES / (1024 * 1024))}MB or smaller.`,
+      );
+      return;
+    }
+    setUploadBusyKey("hero-image-upload");
+    try {
+      const { uploadUrl } = await generateUploadUrl();
+      const storageId = await uploadHeadshotToConvex(uploadUrl, file);
+      onChange(storageId);
+      toast.success("Hero image uploaded.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Upload failed.");
+    } finally {
+      setUploadBusyKey(null);
+    }
+  };
+
+  const selectedUrl = selectedInGallery?.url ?? bespokeUrl ?? null;
+  // Only treat the selection as orphaned once we've heard back from both
+  // the gallery list and the bespoke URL query. Otherwise the first render
+  // after selection flashes a false warning.
+  const selectedIsOrphaned =
+    selectedStorageId !== undefined &&
+    draft !== undefined &&
+    !selectedInGallery &&
+    bespokeUrl === null;
+
+  const uploadButton = (
+    <>
+      <input
+        id="about-hero-upload-input"
+        type="file"
+        accept={HERO_IMAGE_ACCEPT}
+        className="hidden"
+        tabIndex={-1}
+        disabled={uploadBusyKey !== null}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          e.target.value = "";
+          if (f) void onUploadFile(f);
+        }}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={uploadBusyKey !== null}
+        onClick={() => {
+          document.getElementById("about-hero-upload-input")?.click();
+        }}
+      >
+        {isUploading
+          ? "Uploading…"
+          : selectedStorageId !== undefined
+            ? "Upload different image"
+            : "Upload new image"}
+      </Button>
+    </>
+  );
+
+  if (draft === undefined) {
+    return (
+      <p className="rounded-md border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">
+        Loading gallery photos…
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {selectedIsOrphaned ? (
+        <div className="flex items-start justify-between gap-3 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs">
+          <p className="text-amber-800 dark:text-amber-200">
+            The previously selected image is no longer available. Pick a
+            new one, upload another, or clear the selection.
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0 text-amber-800 hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100"
+            onClick={() => onChange(undefined)}
+          >
+            <Trash2 className="mr-1 size-3.5" aria-hidden />
+            Clear
+          </Button>
+        </div>
+      ) : null}
+
+      {selectedUrl ? (
+        <div className="flex items-center gap-3 rounded-md border border-border bg-muted/30 p-3">
+          <div className="relative size-16 shrink-0 overflow-hidden rounded-md border border-border bg-muted">
+            {/* eslint-disable-next-line @next/next/no-img-element -- signed Convex URL, not eligible for `next/image` in admin surfaces. */}
+            <img
+              src={selectedUrl}
+              alt=""
+              aria-hidden
+              className="size-full object-cover"
+            />
+          </div>
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="body-text-small truncate text-foreground">
+              {selectedInGallery
+                ? selectedInGallery.alt ||
+                  selectedInGallery.originalFileName ||
+                  "Selected photo"
+                : "Custom upload"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {selectedInGallery
+                ? "This photo will appear as the About page hero."
+                : "Bespoke upload — not part of the public gallery."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onChange(undefined)}
+          >
+            <Trash2 className="mr-1 size-3.5" aria-hidden />
+            Remove
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="body-text-small text-muted-foreground">
+          {photos.length === 0
+            ? "No gallery photos yet — upload a bespoke image for the hero."
+            : "Pick from the gallery below or upload a bespoke image."}
+        </p>
+        {uploadButton}
+      </div>
+
+      {photos.length > 0 ? (
+        <div
+          role="radiogroup"
+          aria-label="Hero image"
+          className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6"
+        >
+          {photos.map((photo) => {
+            const isSelected = photo.storageId === selectedStorageId;
+            return (
+              <button
+                key={photo.stableId}
+                type="button"
+                role="radio"
+                aria-checked={isSelected}
+                aria-label={
+                  photo.alt ||
+                  photo.originalFileName ||
+                  `Use ${photo.stableId} as hero image`
+                }
+                onClick={() => {
+                  onChange(isSelected ? undefined : photo.storageId);
+                }}
+                className={cn(
+                  "group relative aspect-square overflow-hidden rounded-md border transition",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  isSelected
+                    ? "border-primary ring-2 ring-primary/40"
+                    : "border-border hover:border-foreground/40",
+                )}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element -- admin-only thumbnail, signed Convex URL. */}
+                <img
+                  src={photo.url}
+                  alt=""
+                  aria-hidden
+                  className={cn(
+                    "size-full object-cover transition group-hover:scale-[1.02]",
+                    !isSelected && "opacity-90 group-hover:opacity-100",
+                  )}
+                />
+                {isSelected ? (
+                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-primary/20">
+                    <span className="inline-flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground shadow">
+                      <Check className="size-3.5" aria-hidden />
+                    </span>
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -30,7 +30,14 @@ import {
   useMutation,
 } from "convex/react";
 import { useUser } from "@clerk/nextjs";
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  memo,
+  startTransition,
+} from "react";
 import { Effect } from "effect";
 import { toast } from "sonner";
 import { ArrowDown, ArrowUp, Check, Plus, Trash2, X } from "lucide-react";
@@ -45,7 +52,7 @@ import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 import { useAutosaveDraft } from "@/lib/use-autosave-draft";
-import { RichTextEditor } from "./rich-text-editor";
+import { RichTextEditor, type RichTextEditorHandle } from "./rich-text-editor";
 
 type AboutBlock = { type: "paragraph" | "heading"; text: string };
 
@@ -82,6 +89,12 @@ type AboutContent = {
 
 /** Keep in sync with `MAX_ABOUT_TEAM_MEMBERS` in `convex/aboutTeamStorage.ts`. */
 const MAX_TEAM_MEMBERS = 20;
+
+/**
+ * Debounce HTML for the publish-issues panel so typing the body doesn't
+ * force full-form validation work on every pause.
+ */
+const ISSUES_BODY_HTML_DEBOUNCE_MS = 1500;
 
 /** SEO character guidance — typical search-engine display limits. */
 const SEO_TITLE_RECOMMENDED = 60;
@@ -294,6 +307,55 @@ function collectAboutIssues(
   return issues;
 }
 
+const AboutIssuesPanel = memo(function AboutIssuesPanel({
+  base,
+  debouncedBodyHtml,
+  bodyDirty,
+}: {
+  readonly base: AboutContent;
+  readonly debouncedBodyHtml: string | null;
+  readonly bodyDirty: boolean;
+}) {
+  const issuesSource = useMemo((): AboutContent => {
+    if (!bodyDirty) return base;
+    return {
+      ...base,
+      bodyHtml: debouncedBodyHtml ?? base.bodyHtml ?? "",
+      body: [],
+    };
+  }, [base, bodyDirty, debouncedBodyHtml]);
+
+  const issues = useMemo(
+    () => collectAboutIssues(issuesSource),
+    [issuesSource],
+  );
+
+  if (issues.length === 0) return null;
+
+  return (
+    <div
+      role="status"
+      className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm"
+    >
+      <p className="mb-1 font-medium text-amber-700 dark:text-amber-300">
+        {issues.length === 1
+          ? "1 issue blocks publish"
+          : `${issues.length} issues block publish`}
+      </p>
+      <ul className="list-disc space-y-0.5 pl-5 text-amber-800/90 dark:text-amber-200/90">
+        {issues.slice(0, 6).map((issue, i) => (
+          <li key={`${issue.path}-${i}`}>{issue.message}</li>
+        ))}
+        {issues.length > 6 ? (
+          <li className="text-amber-900/70 dark:text-amber-100/70">
+            …and {issues.length - 6} more.
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+});
+
 export function AboutEditor() {
   return (
     <>
@@ -325,126 +387,147 @@ function AboutForm() {
   const [localDraft, setLocalDraft] = useState<AboutContent | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [inlineError, setInlineError] = useState<string | null>(null);
-  const [editorResetToken, setEditorResetToken] = useState(0);
+  /** Body lives in Tiptap; this flag drives autosave + merged validation. */
+  const [bodyDirty, setBodyDirty] = useState(false);
+  /** Debounced HTML for publish-issue panel (avoids parent re-render per key). */
+  const [debouncedBodyHtml, setDebouncedBodyHtml] = useState<string | null>(
+    null,
+  );
+  const bodyRef = useRef<RichTextEditorHandle>(null);
+  const issuesBodyHtmlDebounceRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
-  // Snapshot of the initial HTML the Tiptap editor was mounted with for the
-  // current `editorResetToken`. Tiptap owns its internal state and would
-  // otherwise fight controlled `content` prop changes on every keystroke.
-  const initialHtmlRef = useRef<string | null>(null);
-
-  const source: AboutContent | undefined = useMemo(() => {
-    if (localDraft) return localDraft;
+  const serverContent: AboutContent | undefined = useMemo(() => {
     if (!section) return undefined;
     return toAboutContent(section.draftSnapshot ?? section.publishedSnapshot);
-  }, [localDraft, section]);
+  }, [section]);
 
-  // Lock in the `initialHtml` for the current editor instance the first time
-  // we have a source. Re-captured whenever `editorResetToken` changes, which
-  // is exactly when we want to remount (discard / first load).
-  const initialHtml = useMemo(() => {
-    if (!source) return "";
-    if (initialHtmlRef.current !== null) return initialHtmlRef.current;
-    const html = source.bodyHtml ?? "";
-    initialHtmlRef.current = html;
-    return html;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorResetToken, source !== undefined]);
+  const base: AboutContent | undefined = localDraft ?? serverContent;
 
-  const mutate = useCallback((next: AboutContent) => {
-    setInlineError(null);
-    setLocalDraft(next);
-  }, []);
+  const initialHtml = base?.bodyHtml ?? "";
 
   const setPublished = useCallback(
     (value: boolean) => {
-      if (!source) return;
-      mutate({ ...source, published: value });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, published: value };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setHeroImageStorageId = useCallback(
     (value: Id<"_storage"> | undefined) => {
-      if (!source) return;
-      mutate({ ...source, heroImageStorageId: value });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, heroImageStorageId: value };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setHeroTitle = useCallback(
     (value: string) => {
-      if (!source) return;
-      mutate({ ...source, heroTitle: value });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, heroTitle: value };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setPullQuote = useCallback(
     (value: string) => {
-      if (!source) return;
-      mutate({ ...source, pullQuote: trimToUndefined(value) });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, pullQuote: trimToUndefined(value) };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setHeroSubtitle = useCallback(
     (value: string) => {
-      if (!source) return;
-      mutate({ ...source, heroSubtitle: trimToUndefined(value) });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, heroSubtitle: trimToUndefined(value) };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setSeoTitle = useCallback(
     (value: string) => {
-      if (!source) return;
-      mutate({ ...source, seoTitle: trimToUndefined(value) });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, seoTitle: trimToUndefined(value) };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setSeoDescription = useCallback(
     (value: string) => {
-      if (!source) return;
-      mutate({ ...source, seoDescription: trimToUndefined(value) });
-    },
-    [source, mutate],
-  );
-
-  const setBodyHtml = useCallback(
-    (html: string) => {
-      if (!source) return;
-      mutate({
-        ...source,
-        bodyHtml: html,
-        // Drop legacy blocks — once the owner edits, the rich HTML is the
-        // authoritative body and we don't want divergent fields.
-        body: [],
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, seoDescription: trimToUndefined(value) };
       });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setHighlights = useCallback(
     (next: string[]) => {
-      if (!source) return;
-      mutate({
-        ...source,
-        highlights: next.length > 0 ? next : undefined,
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return {
+          ...current,
+          highlights: next.length > 0 ? next : undefined,
+        };
       });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const setTeamMembers = useCallback(
     (next: AboutTeamMemberRow[]) => {
-      if (!source) return;
-      mutate({ ...source, teamMembers: next });
+      setInlineError(null);
+      setLocalDraft((prev) => {
+        const current = prev ?? serverContent;
+        if (!current) return prev;
+        return { ...current, teamMembers: next };
+      });
     },
-    [source, mutate],
+    [serverContent],
   );
 
   const [uploadBusy, setUploadBusy] = useState<string | null>(null);
+
+  const clearLocalBodyUiState = useCallback(() => {
+    setBodyDirty(false);
+    setDebouncedBodyHtml(null);
+    if (issuesBodyHtmlDebounceRef.current !== null) {
+      clearTimeout(issuesBodyHtmlDebounceRef.current);
+      issuesBodyHtmlDebounceRef.current = null;
+    }
+  }, []);
 
   const runAction = useCallback(
     async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
@@ -455,51 +538,80 @@ function AboutForm() {
       });
       if (outcome !== undefined) {
         setLocalDraft(null);
+        clearLocalBodyUiState();
       }
       setBusy(null);
       return outcome;
     },
-    [],
+    [clearLocalBodyUiState],
   );
 
   const hasDraftOnServer = section?.hasDraftChanges ?? false;
-  const hasLocalEdits = localDraft !== null;
+  const hasLocalEdits = localDraft !== null || bodyDirty;
 
-  const { status: autosaveStatus, flush: flushAutosave } = useAutosaveDraft({
-    dirty: hasLocalEdits && source !== undefined,
-    debounceResetKey: localDraft,
-    pauseWhen: busy !== null,
-    saveEffect: () =>
-      convexMutationEffect(() =>
-        saveDraft({
-          section: "about",
-          content: {
-            published: source?.published ?? false,
-            ...(source?.heroImageStorageId !== undefined
-              ? { heroImageStorageId: source.heroImageStorageId }
-              : {}),
-            heroTitle: source?.heroTitle ?? "",
-            heroSubtitle: source?.heroSubtitle,
-            bodyHtml: source?.bodyHtml,
-            body: source?.body ?? [],
-            pullQuote: source?.pullQuote,
-            highlights: source?.highlights,
-            seoTitle: source?.seoTitle,
-            seoDescription: source?.seoDescription,
-            teamMembers: (source?.teamMembers ?? []).map((m) => ({
-              id: m.id,
-              name: m.name,
-              title: m.title,
-              ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
-            })),
-          },
-        }),
-      ),
-    onSaved: () => setLocalDraft(null),
-  });
+  const { status: autosaveStatus, flush: flushAutosave, kick: kickAutosave } =
+    useAutosaveDraft({
+      dirty: hasLocalEdits && base !== undefined,
+      debounceResetKey: localDraft,
+      pauseWhen: busy !== null,
+      saveEffect: () => {
+        const contentBase = (localDraft ?? serverContent)!;
+        const bodyHtml = bodyDirty
+          ? (bodyRef.current?.getHTML() ?? "")
+          : (contentBase.bodyHtml ?? "");
+        const bodyBlocks = bodyDirty ? [] : (contentBase.body ?? []);
+        return convexMutationEffect(() =>
+          saveDraft({
+            section: "about",
+            content: {
+              published: contentBase.published,
+              ...(contentBase.heroImageStorageId !== undefined
+                ? { heroImageStorageId: contentBase.heroImageStorageId }
+                : {}),
+              heroTitle: contentBase.heroTitle,
+              heroSubtitle: contentBase.heroSubtitle,
+              bodyHtml,
+              body: bodyBlocks,
+              pullQuote: contentBase.pullQuote,
+              highlights: contentBase.highlights,
+              seoTitle: contentBase.seoTitle,
+              seoDescription: contentBase.seoDescription,
+              teamMembers: (contentBase.teamMembers ?? []).map((m) => ({
+                id: m.id,
+                name: m.name,
+                title: m.title,
+                ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
+              })),
+            },
+          }),
+        );
+      },
+      onSaved: () => {
+        setLocalDraft(null);
+        clearLocalBodyUiState();
+      },
+    });
+
+  const handleBodyDirty = useCallback(() => {
+    setBodyDirty(true);
+    kickAutosave();
+    if (issuesBodyHtmlDebounceRef.current !== null) {
+      clearTimeout(issuesBodyHtmlDebounceRef.current);
+    }
+    issuesBodyHtmlDebounceRef.current = setTimeout(() => {
+      issuesBodyHtmlDebounceRef.current = null;
+      startTransition(() => {
+        setDebouncedBodyHtml(bodyRef.current?.getHTML() ?? "");
+      });
+    }, ISSUES_BODY_HTML_DEBOUNCE_MS);
+  }, [kickAutosave]);
 
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
+    const publishedHtml =
+      section !== undefined
+        ? (toAboutContent(section.publishedSnapshot).bodyHtml ?? "")
+        : "";
     if (hasDraftOnServer) {
       setBusy("Discarding…");
       const outcome = await runAdminEffect(
@@ -512,21 +624,15 @@ function AboutForm() {
       }
     }
     setLocalDraft(null);
-    // Force Tiptap to remount with the now-canonical published HTML.
-    initialHtmlRef.current = null;
-    setEditorResetToken((n) => n + 1);
+    clearLocalBodyUiState();
+    bodyRef.current?.reset(publishedHtml);
     toast.success(
       hasDraftOnServer
         ? "Draft discarded. The editor now matches the published site."
         : "Unsaved changes discarded.",
     );
     return true;
-  }, [discard, hasDraftOnServer]);
-
-  const issues = useMemo(
-    () => (source ? collectAboutIssues(source) : []),
-    [source],
-  );
+  }, [clearLocalBodyUiState, discard, hasDraftOnServer, section]);
 
   if (section === undefined) {
     return (
@@ -534,7 +640,7 @@ function AboutForm() {
     );
   }
 
-  if (!source) {
+  if (!base) {
     return (
       <p className="body-text text-muted-foreground">
         No About content available.
@@ -545,8 +651,8 @@ function AboutForm() {
   const publishedByLabel =
     section.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
 
-  const seoTitleValue = source.seoTitle ?? "";
-  const seoDescriptionValue = source.seoDescription ?? "";
+  const seoTitleValue = base.seoTitle ?? "";
+  const seoDescriptionValue = base.seoDescription ?? "";
 
   return (
     <div className="space-y-8 pb-24">
@@ -558,7 +664,7 @@ function AboutForm() {
             <div className="flex items-start gap-3">
               <Switch
                 id="about-published"
-                checked={source.published}
+                checked={base.published}
                 onCheckedChange={setPublished}
               />
               <div className="space-y-1">
@@ -584,10 +690,10 @@ function AboutForm() {
               </span>
               <Input
                 type="text"
-                value={source.heroTitle}
+                value={base.heroTitle}
                 onChange={(e) => setHeroTitle(e.target.value)}
                 placeholder="About Lula Lake Sound"
-                aria-invalid={source.heroTitle.trim().length === 0}
+                aria-invalid={base.heroTitle.trim().length === 0}
                 className="text-foreground placeholder:text-muted-foreground"
               />
             </label>
@@ -597,7 +703,7 @@ function AboutForm() {
               </span>
               <Textarea
                 rows={2}
-                value={source.heroSubtitle ?? ""}
+                value={base.heroSubtitle ?? ""}
                 onChange={(e) => setHeroSubtitle(e.target.value)}
                 placeholder="A creative space for music production and recording."
                 className="text-foreground placeholder:text-muted-foreground"
@@ -623,7 +729,7 @@ function AboutForm() {
               gallery.
             </p>
             <HeroImagePicker
-              selectedStorageId={source.heroImageStorageId}
+              selectedStorageId={base.heroImageStorageId}
               onChange={setHeroImageStorageId}
               generateUploadUrl={generateUploadUrl}
               uploadBusyKey={uploadBusy}
@@ -642,11 +748,10 @@ function AboutForm() {
               <code className="rounded bg-muted px-1">- </code>).
             </p>
             <RichTextEditor
-              key={editorResetToken}
+              ref={bodyRef}
               initialHtml={initialHtml}
               placeholder="Tell the studio's story…"
-              onChange={setBodyHtml}
-              resetToken={editorResetToken}
+              onDirty={handleBodyDirty}
             />
           </fieldset>
 
@@ -655,12 +760,12 @@ function AboutForm() {
               Pull quote
             </legend>
             <p className="body-text-small text-muted-foreground">
-              Editorial callout rendered below the owner / studio-designer
-              headshots. Leave blank to hide the quote block.
+              Editorial callout rendered below the text body.
+              Leave blank to hide the quote block.
             </p>
             <Textarea
               rows={2}
-              value={source.pullQuote ?? ""}
+              value={base.pullQuote ?? ""}
               onChange={(e) => setPullQuote(e.target.value)}
               placeholder="The mountain doesn't rush. Neither should the music."
               className="text-foreground placeholder:text-muted-foreground"
@@ -674,7 +779,7 @@ function AboutForm() {
               Convex file storage (same limits as the gallery).
             </p>
             <TeamMembersEditor
-              members={source.teamMembers}
+              members={base.teamMembers}
               onChange={setTeamMembers}
               generateUploadUrl={generateUploadUrl}
               uploadBusyKey={uploadBusy}
@@ -690,7 +795,7 @@ function AboutForm() {
               Short bulleted callouts — e.g. key studio facts.
             </p>
             <HighlightsEditor
-              highlights={source.highlights ?? []}
+              highlights={base.highlights ?? []}
               onChange={setHighlights}
             />
           </fieldset>
@@ -739,28 +844,11 @@ function AboutForm() {
             </label>
           </fieldset>
 
-          {issues.length > 0 ? (
-            <div
-              role="status"
-              className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm"
-            >
-              <p className="mb-1 font-medium text-amber-700 dark:text-amber-300">
-                {issues.length === 1
-                  ? "1 issue blocks publish"
-                  : `${issues.length} issues block publish`}
-              </p>
-              <ul className="list-disc space-y-0.5 pl-5 text-amber-800/90 dark:text-amber-200/90">
-                {issues.slice(0, 6).map((issue, i) => (
-                  <li key={`${issue.path}-${i}`}>{issue.message}</li>
-                ))}
-                {issues.length > 6 ? (
-                  <li className="text-amber-900/70 dark:text-amber-100/70">
-                    …and {issues.length - 6} more.
-                  </li>
-                ) : null}
-              </ul>
-            </div>
-          ) : null}
+          <AboutIssuesPanel
+            base={base}
+            debouncedBodyHtml={debouncedBodyHtml}
+            bodyDirty={bodyDirty}
+          />
       </div>
 
       <CmsPublishToolbar
@@ -775,7 +863,16 @@ function AboutForm() {
         autosaveStatus={autosaveStatus}
         previewHref="/preview/about"
         onPublish={() => {
-          if (issues.length > 0) {
+          const liveBody = bodyDirty
+            ? (bodyRef.current?.getHTML() ?? "")
+            : (base.bodyHtml ?? "");
+          const publishSnapshot: AboutContent = {
+            ...base,
+            bodyHtml: liveBody,
+            body: [],
+          };
+          const publishIssues = collectAboutIssues(publishSnapshot);
+          if (publishIssues.length > 0) {
             setInlineError("Fix the blocking issues above before publishing.");
             return;
           }
@@ -826,7 +923,7 @@ type GalleryPickerPhoto = NonNullable<
   ReturnType<typeof useQuery<typeof api.admin.photos.listDraftPhotos>>
 >["photos"][number] & { url: string };
 
-function HeroImagePicker({
+const HeroImagePicker = memo(function HeroImagePicker({
   selectedStorageId,
   onChange,
   generateUploadUrl,
@@ -1057,7 +1154,7 @@ function HeroImagePicker({
       ) : null}
     </div>
   );
-}
+});
 
 interface TeamMembersEditorProps {
   readonly members: AboutTeamMemberRow[];
@@ -1067,7 +1164,7 @@ interface TeamMembersEditorProps {
   readonly setUploadBusyKey: (key: string | null) => void;
 }
 
-function TeamMembersEditor({
+const TeamMembersEditor = memo(function TeamMembersEditor({
   members,
   onChange,
   generateUploadUrl,
@@ -1303,14 +1400,17 @@ function TeamMembersEditor({
       </Button>
     </div>
   );
-}
+});
 
 interface HighlightsEditorProps {
   readonly highlights: readonly string[];
   readonly onChange: (next: string[]) => void;
 }
 
-function HighlightsEditor({ highlights, onChange }: HighlightsEditorProps) {
+const HighlightsEditor = memo(function HighlightsEditor({
+  highlights,
+  onChange,
+}: HighlightsEditorProps) {
   const update = (idx: number, value: string) => {
     const next = [...highlights];
     next[idx] = value;
@@ -1363,7 +1463,7 @@ function HighlightsEditor({ highlights, onChange }: HighlightsEditorProps) {
       </Button>
     </div>
   );
-}
+});
 
 interface CharCounterProps {
   readonly value: string;

--- a/src/app/admin/about/rich-text-editor.tsx
+++ b/src/app/admin/about/rich-text-editor.tsx
@@ -81,6 +81,8 @@ type ToolbarMarkState = {
   readonly isBullet: boolean;
   readonly isOrdered: boolean;
   readonly isLink: boolean;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
 };
 
 function toolbarMarkStateEqual(
@@ -99,7 +101,9 @@ function toolbarMarkStateEqual(
     a.isQuote === b.isQuote &&
     a.isBullet === b.isBullet &&
     a.isOrdered === b.isOrdered &&
-    a.isLink === b.isLink
+    a.isLink === b.isLink &&
+    a.canUndo === b.canUndo &&
+    a.canRedo === b.canRedo
   );
 }
 
@@ -210,6 +214,8 @@ const EditorToolbar = memo(function EditorToolbar({
       isBullet: snapshot.editor.isActive("bulletList"),
       isOrdered: snapshot.editor.isActive("orderedList"),
       isLink: snapshot.editor.isActive("link"),
+      canUndo: snapshot.editor.can().undo(),
+      canRedo: snapshot.editor.can().redo(),
     }),
     equalityFn: toolbarMarkStateEqual,
   });
@@ -331,12 +337,14 @@ const EditorToolbar = memo(function EditorToolbar({
         <ToolbarButton
           label="Undo (⌘Z)"
           onClick={() => editor.chain().focus().undo().run()}
+          disabled={!t.canUndo}
         >
           <Undo2 className="size-3.5" aria-hidden />
         </ToolbarButton>
         <ToolbarButton
           label="Redo (⌘⇧Z)"
           onClick={() => editor.chain().focus().redo().run()}
+          disabled={!t.canRedo}
         >
           <Redo2 className="size-3.5" aria-hidden />
         </ToolbarButton>

--- a/src/app/admin/about/rich-text-editor.tsx
+++ b/src/app/admin/about/rich-text-editor.tsx
@@ -23,8 +23,19 @@
  * https://tiptap.dev/docs/editor/getting-started/install/nextjs#integrating-editor-with-nextjs.
  */
 
-import { useEditor, EditorContent, type Editor } from "@tiptap/react";
-import { useMemo, useCallback } from "react";
+import {
+  useEditor,
+  EditorContent,
+  type Editor,
+  useEditorState,
+} from "@tiptap/react";
+import {
+  useMemo,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+  memo,
+} from "react";
 import {
   Bold,
   Italic,
@@ -44,27 +55,60 @@ import {
 import { cn } from "@/lib/utils";
 import { makeAboutTiptapExtensions } from "@/lib/about-tiptap-extensions";
 
-interface RichTextEditorProps {
-  /** Initial HTML. Editor is uncontrolled internally; parent reads updates via `onChange`. */
-  readonly initialHtml: string;
-  readonly placeholder?: string;
-  readonly onChange: (html: string) => void;
-  /** Increment to force-remount (e.g. after discard). */
-  readonly resetToken?: number;
+export interface RichTextEditorHandle {
+  getHTML: () => string;
+  /** Replace document HTML without emitting `onDirty` (e.g. discard). */
+  reset: (html: string) => void;
 }
 
-/**
- * Editable Tiptap instance with a static toolbar. Reports HTML via `onChange`
- * on every transaction; the parent owns draft state + autosave.
- */
-export function RichTextEditor({
-  initialHtml,
-  placeholder,
-  onChange,
-  resetToken,
-}: RichTextEditorProps) {
+interface RichTextEditorProps {
+  /** Initial HTML on first mount. Editor is uncontrolled; parent reads via ref. */
+  readonly initialHtml: string;
+  readonly placeholder?: string;
+  /** Called on each transaction so the parent can restart autosave debounce. */
+  readonly onDirty?: () => void;
+}
+
+type ToolbarMarkState = {
+  readonly isBold: boolean;
+  readonly isItalic: boolean;
+  readonly isStrike: boolean;
+  readonly isCode: boolean;
+  readonly isH1: boolean;
+  readonly isH2: boolean;
+  readonly isH3: boolean;
+  readonly isQuote: boolean;
+  readonly isBullet: boolean;
+  readonly isOrdered: boolean;
+  readonly isLink: boolean;
+};
+
+function toolbarMarkStateEqual(
+  a: ToolbarMarkState,
+  b: ToolbarMarkState | null,
+): boolean {
+  if (b === null) return false;
+  return (
+    a.isBold === b.isBold &&
+    a.isItalic === b.isItalic &&
+    a.isStrike === b.isStrike &&
+    a.isCode === b.isCode &&
+    a.isH1 === b.isH1 &&
+    a.isH2 === b.isH2 &&
+    a.isH3 === b.isH3 &&
+    a.isQuote === b.isQuote &&
+    a.isBullet === b.isBullet &&
+    a.isOrdered === b.isOrdered &&
+    a.isLink === b.isLink
+  );
+}
+
+const RichTextEditorImpl = forwardRef<
+  RichTextEditorHandle,
+  RichTextEditorProps
+>(function RichTextEditor({ initialHtml, placeholder, onDirty }, ref) {
   const extensions = useMemo(
-    () => makeAboutTiptapExtensions(placeholder),
+    () => makeAboutTiptapExtensions(placeholder, { autolink: false }),
     [placeholder],
   );
 
@@ -74,7 +118,7 @@ export function RichTextEditor({
       content: initialHtml,
       editable: true,
       immediatelyRender: false,
-      onUpdate: ({ editor }) => onChange(editor.getHTML()),
+      onUpdate: () => onDirty?.(),
       editorProps: {
         attributes: {
           class: cn(
@@ -84,9 +128,18 @@ export function RichTextEditor({
         },
       },
     },
-    // Passing resetToken in the deps array forces useEditor to re-create the
-    // editor instance when we want to discard external state.
-    [resetToken],
+    [extensions],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getHTML: () => editor?.getHTML() ?? "",
+      reset: (html: string) => {
+        editor?.commands.setContent(html, { emitUpdate: false });
+      },
+    }),
+    [editor],
   );
 
   if (!editor) {
@@ -97,29 +150,39 @@ export function RichTextEditor({
     <div className="dark overflow-hidden rounded-lg border border-border bg-washed-black">
       <div className="relative">
         <div
-          className="pointer-events-none absolute inset-0 bg-texture-stone opacity-[0.22]"
+          className="pointer-events-none absolute inset-0 translate-z-0 bg-texture-stone opacity-[0.22]"
           aria-hidden
         />
         <div className="relative z-10">
           <EditorToolbar editor={editor} />
-          <EditorContent editor={editor} />
+          <div className="min-w-0 [contain:paint]">
+            <EditorContent editor={editor} className="min-w-0" />
+          </div>
         </div>
       </div>
     </div>
   );
-}
+});
+
+RichTextEditorImpl.displayName = "RichTextEditor";
+
+/**
+ * Editable Tiptap instance with a static toolbar. Parent reads HTML via ref.
+ */
+export const RichTextEditor = memo(RichTextEditorImpl);
+RichTextEditor.displayName = "RichTextEditor";
 
 function EditorSkeleton() {
   return (
     <div className="dark overflow-hidden rounded-lg border border-border bg-washed-black">
       <div className="relative">
         <div
-          className="pointer-events-none absolute inset-0 bg-texture-stone opacity-[0.22]"
+          className="pointer-events-none absolute inset-0 translate-z-0 bg-texture-stone opacity-[0.22]"
           aria-hidden
         />
         <div className="relative z-10">
           <div className="flex h-10 flex-wrap items-center gap-0.5 border-b border-sand/15 bg-black/35 px-1 py-1" />
-          <div className="min-h-[18rem] px-5 py-6 md:px-8 md:py-8" />
+          <div className="min-h-[18rem] [contain:paint] px-5 py-6 md:px-8 md:py-8" />
         </div>
       </div>
     </div>
@@ -130,7 +193,27 @@ interface EditorToolbarProps {
   readonly editor: Editor;
 }
 
-function EditorToolbar({ editor }: EditorToolbarProps) {
+const EditorToolbar = memo(function EditorToolbar({
+  editor,
+}: EditorToolbarProps) {
+  const t = useEditorState({
+    editor,
+    selector: (snapshot): ToolbarMarkState => ({
+      isBold: snapshot.editor.isActive("bold"),
+      isItalic: snapshot.editor.isActive("italic"),
+      isStrike: snapshot.editor.isActive("strike"),
+      isCode: snapshot.editor.isActive("code"),
+      isH1: snapshot.editor.isActive("heading", { level: 1 }),
+      isH2: snapshot.editor.isActive("heading", { level: 2 }),
+      isH3: snapshot.editor.isActive("heading", { level: 3 }),
+      isQuote: snapshot.editor.isActive("blockquote"),
+      isBullet: snapshot.editor.isActive("bulletList"),
+      isOrdered: snapshot.editor.isActive("orderedList"),
+      isLink: snapshot.editor.isActive("link"),
+    }),
+    equalityFn: toolbarMarkStateEqual,
+  });
+
   const promptLink = useCallback(() => {
     const previousUrl = editor.getAttributes("link").href as string | undefined;
     const url = window.prompt("Link URL", previousUrl ?? "https://");
@@ -152,28 +235,28 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
       <ToolbarButton
         label="Bold (⌘B)"
         onClick={() => editor.chain().focus().toggleBold().run()}
-        active={editor.isActive("bold")}
+        active={t.isBold}
       >
         <Bold className="size-3.5" aria-hidden />
       </ToolbarButton>
       <ToolbarButton
         label="Italic (⌘I)"
         onClick={() => editor.chain().focus().toggleItalic().run()}
-        active={editor.isActive("italic")}
+        active={t.isItalic}
       >
         <Italic className="size-3.5" aria-hidden />
       </ToolbarButton>
       <ToolbarButton
         label="Strikethrough"
         onClick={() => editor.chain().focus().toggleStrike().run()}
-        active={editor.isActive("strike")}
+        active={t.isStrike}
       >
         <Strikethrough className="size-3.5" aria-hidden />
       </ToolbarButton>
       <ToolbarButton
         label="Inline code"
         onClick={() => editor.chain().focus().toggleCode().run()}
-        active={editor.isActive("code")}
+        active={t.isCode}
       >
         <Code className="size-3.5" aria-hidden />
       </ToolbarButton>
@@ -185,7 +268,7 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
         onClick={() =>
           editor.chain().focus().toggleHeading({ level: 1 }).run()
         }
-        active={editor.isActive("heading", { level: 1 })}
+        active={t.isH1}
       >
         <Heading1 className="size-3.5" aria-hidden />
       </ToolbarButton>
@@ -194,7 +277,7 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
         onClick={() =>
           editor.chain().focus().toggleHeading({ level: 2 }).run()
         }
-        active={editor.isActive("heading", { level: 2 })}
+        active={t.isH2}
       >
         <Heading2 className="size-3.5" aria-hidden />
       </ToolbarButton>
@@ -203,7 +286,7 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
         onClick={() =>
           editor.chain().focus().toggleHeading({ level: 3 }).run()
         }
-        active={editor.isActive("heading", { level: 3 })}
+        active={t.isH3}
       >
         <Heading3 className="size-3.5" aria-hidden />
       </ToolbarButton>
@@ -213,21 +296,21 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
       <ToolbarButton
         label="Quote"
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
-        active={editor.isActive("blockquote")}
+        active={t.isQuote}
       >
         <Quote className="size-3.5" aria-hidden />
       </ToolbarButton>
       <ToolbarButton
         label="Bullet list"
         onClick={() => editor.chain().focus().toggleBulletList().run()}
-        active={editor.isActive("bulletList")}
+        active={t.isBullet}
       >
         <List className="size-3.5" aria-hidden />
       </ToolbarButton>
       <ToolbarButton
         label="Numbered list"
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
-        active={editor.isActive("orderedList")}
+        active={t.isOrdered}
       >
         <ListOrdered className="size-3.5" aria-hidden />
       </ToolbarButton>
@@ -240,11 +323,7 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
 
       <ToolbarDivider />
 
-      <ToolbarButton
-        label="Link"
-        onClick={promptLink}
-        active={editor.isActive("link")}
-      >
+      <ToolbarButton label="Link" onClick={promptLink} active={t.isLink}>
         <LinkIcon className="size-3.5" aria-hidden />
       </ToolbarButton>
 
@@ -252,21 +331,19 @@ function EditorToolbar({ editor }: EditorToolbarProps) {
         <ToolbarButton
           label="Undo (⌘Z)"
           onClick={() => editor.chain().focus().undo().run()}
-          disabled={!editor.can().undo()}
         >
           <Undo2 className="size-3.5" aria-hidden />
         </ToolbarButton>
         <ToolbarButton
           label="Redo (⌘⇧Z)"
           onClick={() => editor.chain().focus().redo().run()}
-          disabled={!editor.can().redo()}
         >
           <Redo2 className="size-3.5" aria-hidden />
         </ToolbarButton>
       </div>
     </div>
   );
-}
+});
 
 interface ToolbarButtonProps {
   readonly label: string;

--- a/src/app/preview/about/page.tsx
+++ b/src/app/preview/about/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { AboutLayout } from "../../about/about-layout";
+import { PreviewBanner } from "@/components/preview-banner";
+
+/**
+ * Owner-only preview of the About page using the draft CMS snapshot. Mirrors
+ * `/preview` (homepage): unauthenticated visitors are told to sign in, and
+ * the preview query itself returns `null` for non-owners so drafts never
+ * leak. The `published` flag is taken from the draft so the owner can verify
+ * how the public page will look with the feature flag either on or off.
+ */
+function AboutPreviewContent() {
+  const about = useQuery(api.aboutPreviewDraft.getPreviewAbout);
+  const pricingPreview = useQuery(
+    api.pricingPreviewDraft.getPreviewPricingFlags,
+  );
+
+  if (about === undefined || pricingPreview === undefined) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+        <p className="text-ivory/60">Loading preview…</p>
+      </div>
+    );
+  }
+
+  if (about === null || pricingPreview === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+        <p className="text-ivory/60">
+          Preview is not available. You may not have permission to view draft
+          content.
+        </p>
+      </div>
+    );
+  }
+
+  const { hasDraftChanges: _aboutDrafty, ...data } = about;
+  void _aboutDrafty;
+  const showPricing = pricingPreview.flags.priceTabEnabled === true;
+  const hasDraftChanges =
+    about.hasDraftChanges || pricingPreview.hasDraftChanges;
+
+  return (
+    <AboutLayout
+      data={data}
+      showPricing={showPricing}
+      banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
+    />
+  );
+}
+
+export default function AboutPreviewPage() {
+  return (
+    <>
+      <AuthLoading>
+        <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+          <p className="text-ivory/60">Authenticating…</p>
+        </div>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+          <p className="text-ivory/60">
+            Sign in required to preview draft content.
+          </p>
+        </div>
+      </Unauthenticated>
+
+      <Authenticated>
+        <AboutPreviewContent />
+      </Authenticated>
+    </>
+  );
+}

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -12,11 +12,16 @@ function PreviewContent() {
   );
   const gearPreview = useQuery(api.gearPreviewDraft.getPreviewGear);
   const photoPreview = useQuery(api.photosPreviewDraft.getPreviewGalleryPhotos);
+  // INF-46: surface the draft About visibility in the homepage nav so owners
+  // can confirm the feature-flag toggle before publishing. Preview query is
+  // owner-only and returns `null` for non-owners.
+  const aboutPreview = useQuery(api.aboutPreviewDraft.getPreviewAbout);
 
   if (
     pricingFlags === undefined ||
     gearPreview === undefined ||
-    photoPreview === undefined
+    photoPreview === undefined ||
+    aboutPreview === undefined
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
@@ -28,7 +33,8 @@ function PreviewContent() {
   if (
     pricingFlags === null ||
     gearPreview === null ||
-    photoPreview === null
+    photoPreview === null ||
+    aboutPreview === null
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
@@ -42,7 +48,8 @@ function PreviewContent() {
   const hasDraftChanges =
     pricingFlags.hasDraftChanges ||
     gearPreview.hasDraftChanges ||
-    photoPreview.hasDraftChanges;
+    photoPreview.hasDraftChanges ||
+    aboutPreview.hasDraftChanges;
 
   return (
     <HomepageShell
@@ -52,6 +59,7 @@ function PreviewContent() {
       }}
       gear={{ categories: gearPreview.categories }}
       photos={photoPreview.photos}
+      aboutVisibility={{ published: aboutPreview.published === true }}
       banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,6 +16,12 @@ interface HeaderProps {
    * than quietly shipping a broken link.
    */
   readonly showAbout?: boolean;
+  /**
+   * Public marketing About URL, or `/preview/about` when the shell is mounted
+   * under owner preview so draft visibility does not send users to a gated
+   * `/about` 404 before publish.
+   */
+  readonly aboutHref?: string;
 }
 
 /**
@@ -30,6 +36,7 @@ export function Header({
   scrollY,
   showPricing = false,
   showAbout = false,
+  aboutHref = "/about",
 }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -54,7 +61,7 @@ export function Header({
           {
             kind: "route" as const,
             key: "about",
-            href: "/about",
+            href: aboutHref,
             label: "About",
           },
         ]

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,13 @@ import { cn } from "@/lib/utils";
 interface HeaderProps {
   readonly scrollY: number;
   readonly showPricing?: boolean;
+  /**
+   * INF-46 — hides the primary-nav "About" link (desktop + mobile) when the
+   * CMS-controlled About page is disabled. Defaults to `false` so deploys
+   * that forget to plumb the flag keep the new About page hidden rather
+   * than quietly shipping a broken link.
+   */
+  readonly showAbout?: boolean;
 }
 
 /**
@@ -19,7 +26,11 @@ interface HeaderProps {
  * near-opaque washed-black wash once the user has committed to scrolling so
  * the nav text stays legible against hero imagery.
  */
-export function Header({ scrollY, showPricing = false }: HeaderProps) {
+export function Header({
+  scrollY,
+  showPricing = false,
+  showAbout = false,
+}: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const progress = Math.min(scrollY / 140, 1);
@@ -38,7 +49,16 @@ export function Header({ scrollY, showPricing = false }: HeaderProps) {
     | { kind: "hash"; id: string; label: string };
 
   const navigationItems: NavItem[] = [
-    { kind: "route", key: "about", href: "/about", label: "About" },
+    ...(showAbout
+      ? [
+          {
+            kind: "route" as const,
+            key: "about",
+            href: "/about",
+            label: "About",
+          },
+        ]
+      : []),
     { kind: "hash", id: "the-space", label: "The Studio" },
     { kind: "hash", id: "equipment-specs", label: "Gear" },
     ...(showPricing

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useQuery } from "convex/react";
 import { useState, useCallback } from "react";
+import { api } from "../../convex/_generated/api";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { MarketingPricingSection } from "@/components/dynamic-pricing";
@@ -26,6 +28,14 @@ interface HomepageShellProps {
   readonly gear: GearPayload | null | undefined;
   /** Published (or preview) gallery payload. */
   readonly photos: GalleryPhoto[] | null | undefined;
+  /**
+   * INF-46 About-page visibility flag. `null` / `undefined` keeps the nav
+   * link hidden — the About page is opt-in via the CMS.
+   */
+  readonly aboutVisibility?:
+    | { readonly published: boolean }
+    | null
+    | undefined;
   readonly banner?: React.ReactNode;
 }
 
@@ -33,6 +43,7 @@ export function HomepageShell({
   pricingFlags,
   gear,
   photos,
+  aboutVisibility,
   banner,
 }: HomepageShellProps) {
   const [scrollY, setScrollY] = useState(0);
@@ -72,10 +83,21 @@ export function HomepageShell({
     };
   }, []);
 
+  // If the caller hasn't provided a draft/preload visibility value (the
+  // public homepage path), subscribe live so the nav updates reactively when
+  // the owner flips the INF-46 flag in the CMS.
+  const liveAboutVisibility = useQuery(
+    api.public.getPublishedAboutVisibility,
+    aboutVisibility === undefined ? {} : "skip",
+  );
+  const resolvedAboutVisibility =
+    aboutVisibility === undefined ? liveAboutVisibility : aboutVisibility;
+
   const logoScale = calculateLogoScale(scrollY);
   const showPricing =
     pricingFlags === undefined ||
     (pricingFlags !== null && pricingFlags.flags.priceTabEnabled === true);
+  const showAbout = resolvedAboutVisibility?.published === true;
 
   return (
     <div
@@ -83,7 +105,11 @@ export function HomepageShell({
       className="dark relative min-h-screen bg-washed-black text-ivory grain-overlay"
     >
       {banner}
-      <Header scrollY={scrollY} showPricing={showPricing} />
+      <Header
+        scrollY={scrollY}
+        showPricing={showPricing}
+        showAbout={showAbout}
+      />
       <Hero logoScale={logoScale} />
 
       <main className="relative z-10">

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "convex/react";
+import { usePathname } from "next/navigation";
 import { useState, useCallback } from "react";
 import { api } from "../../convex/_generated/api";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
@@ -47,6 +48,11 @@ export function HomepageShell({
   banner,
 }: HomepageShellProps) {
   const [scrollY, setScrollY] = useState(0);
+  const pathname = usePathname();
+  const aboutHref =
+    pathname === "/preview" || pathname.startsWith("/preview/")
+      ? "/preview/about"
+      : "/about";
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
     if (!node) return;
@@ -109,6 +115,7 @@ export function HomepageShell({
         scrollY={scrollY}
         showPricing={showPricing}
         showAbout={showAbout}
+        aboutHref={aboutHref}
       />
       <Hero logoScale={logoScale} />
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,9 +7,10 @@ import { cn } from "@/lib/utils"
  * Lula Lake Sound Button.
  *
  * Editorial, near-square corners and generous horizontal padding to read more
- * like a printed card than a SaaS CTA. Default variant pairs sand-on-washed-
- * black (the brand's quiet-luxury primary pairing); outline is a thin ivory
- * stroke that fills on hover. No drop shadows, no gradients.
+ * like a printed card than a SaaS CTA. Default stays sand-on-washed-black
+ * for the marketing shell. Outline / ghost use shadcn semantic tokens so the
+ * Studio CMS light theme keeps readable contrast (sand-on-cream was failing
+ * WCAG for controls).
  */
 const buttonVariants = cva(
   [
@@ -28,15 +29,15 @@ const buttonVariants = cva(
         /** Solid sand on washed-black — primary CTA. */
         default:
           "border-transparent bg-sand text-washed-black hover:bg-warm-white",
-        /** Thin ivory stroke that fills on hover — quiet secondary. */
+        /** Theme-aware stroke; sand on dark site, rust on light CMS. */
         outline:
-          "border-sand/40 bg-transparent text-sand hover:bg-sand hover:text-washed-black",
+          "border-primary/55 bg-transparent text-primary hover:bg-primary hover:text-primary-foreground",
         /** Rust ink on sand — used when you need richer brand tone. */
         secondary:
           "border-transparent bg-rust text-warm-white hover:bg-maroon",
         /** Type-only, with a thin underline reveal on hover. */
         ghost:
-          "border-transparent bg-transparent text-sand/80 hover:text-sand hover:underline hover:underline-offset-[6px]",
+          "border-transparent bg-transparent text-muted-foreground hover:text-foreground hover:underline hover:underline-offset-[6px]",
         /**
          * Gold-on-washed-black emphasis. Reserved for single moments of
          * recommendation/selection per brand guide §3.2 (Gold is an accent
@@ -48,7 +49,7 @@ const buttonVariants = cva(
         destructive:
           "border-transparent bg-fire/90 text-warm-white hover:bg-fire",
         link:
-          "border-transparent h-auto px-0 text-sand underline underline-offset-[6px] decoration-sand/40 hover:decoration-sand",
+          "border-transparent h-auto px-0 text-primary underline underline-offset-[6px] decoration-primary/40 hover:decoration-primary",
       },
       size: {
         default: "h-10 px-6 py-2 gap-2",

--- a/src/lib/about-tiptap-extensions.ts
+++ b/src/lib/about-tiptap-extensions.ts
@@ -2,15 +2,28 @@ import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 
+export type AboutTiptapExtensionsOptions = {
+  /**
+   * When true (default), typed/pasted URLs become links via an `appendTransaction`
+   * hook that runs linkify on every doc change — noticeably expensive while typing.
+   * The admin editor turns this off; links still work via the toolbar and paste rules.
+   */
+  readonly autolink?: boolean;
+};
+
 /** Shared Tiptap schema for About body HTML (admin editor + public read-only view). */
-export function makeAboutTiptapExtensions(placeholder?: string) {
+export function makeAboutTiptapExtensions(
+  placeholder?: string,
+  options?: AboutTiptapExtensionsOptions,
+) {
+  const autolink = options?.autolink ?? true;
   return [
     StarterKit.configure({
       heading: { levels: [1, 2, 3] },
     }),
     Link.configure({
       openOnClick: false,
-      autolink: true,
+      autolink,
       protocols: ["http", "https", "mailto", "tel"],
       defaultProtocol: "https",
       HTMLAttributes: {

--- a/src/lib/use-autosave-draft.ts
+++ b/src/lib/use-autosave-draft.ts
@@ -47,6 +47,11 @@ export interface UseAutosaveDraftResult {
   /** Current autosave status for UI indicators. */
   readonly status: AutosaveStatus;
   /**
+   * Restart the idle debounce timer without changing `debounceResetKey`
+   * (e.g. rich-text transactions where `dirty` stays `true`).
+   */
+  readonly kick: () => void;
+  /**
    * Force-flush the pending autosave immediately (used e.g. by Publish so
    * any in-flight debounce doesn't get skipped). Resolves when the save
    * completes (or immediately if nothing to save). Returns `false` if a save
@@ -83,6 +88,8 @@ export function useAutosaveDraft({
   const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightRef = useRef(false);
   const mountedRef = useRef(true);
+  const pauseWhenRef = useRef(pauseWhen);
+  pauseWhenRef.current = pauseWhen;
 
   const clearTimer = () => {
     if (timerRef.current !== null) {
@@ -117,6 +124,17 @@ export function useAutosaveDraft({
     }, savedLingerMs);
     return true;
   }, [savedLingerMs]);
+
+  const kick = useCallback(() => {
+    if (pauseWhenRef.current) {
+      return;
+    }
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      void runSave();
+    }, delayMs);
+  }, [delayMs, runSave]);
 
   useEffect(() => {
     if (pauseWhen) {
@@ -157,5 +175,5 @@ export function useAutosaveDraft({
     return await runSave();
   }, [dirty, runSave]);
 
-  return { status, flush };
+  return { status, kick, flush };
 }


### PR DESCRIPTION
Draft PR for INF-46.

- CMS-backed About page (Convex admin/public APIs, shared layout, rich text)
- Owner preview at `/preview/about`
- Nav/header integration
- Improved `Button` outline/ghost/link contrast for light Studio CMS theme

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public routing/nav visibility and CMS snapshot shape (new fields + signed URL materialization), so regressions could hide/show `/about` incorrectly or break rendering if snapshots are malformed; changes are contained to the About/CMS surfaces.
> 
> **Overview**
> Implements INF-46 **CMS-backed About page** with a new `published` feature flag: public `/about` now returns 404 when disabled, metadata is generated from CMS SEO fields, and the header/homepage nav conditionally shows the About link via a lightweight `public.getPublishedAboutVisibility` query.
> 
> Extends the About CMS schema/public materialization to support `heroImageStorageId` (exposed publicly only as `heroImageUrl`) and a `pullQuote`, and adds an owner-only helper query (`admin/about.getHeroImageUrl`) plus admin UI to pick a hero image from gallery or upload a bespoke blob.
> 
> Adds an owner-only `/preview/about` route that renders the same shared `AboutLayout` as production, and updates the About editor/autosave/Tiptap integration (ref-based editor handle, debounced issue validation, optional autolink disable) to support the new fields and avoid `useEffect` patterns.
> 
> Also adjusts `Button` outline/ghost/link variants to use theme tokens for better contrast in the light CMS theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79ea2748f4e16ff41d822604bbe2567b4f32d292. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->