### PR TITLE
feat(admin): audio portfolio CMS (INF-96)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,10 +8,13 @@
  * @module
  */
 
+import type * as audioPreviewDraft from "../audioPreviewDraft.js";
+import type * as audioTracks from "../audioTracks.js";
 import type * as aboutPreviewDraft from "../aboutPreviewDraft.js";
 import type * as aboutTeamStorage from "../aboutTeamStorage.js";
 import type * as admin_about from "../admin/about.js";
 import type * as admin_aboutTeam from "../admin/aboutTeam.js";
+import type * as admin_audio from "../admin/audio.js";
 import type * as admin_gear from "../admin/gear.js";
 import type * as admin_photos from "../admin/photos.js";
 import type * as admin_pricing from "../admin/pricing.js";
@@ -48,8 +51,11 @@ import type {
 declare const fullApi: ApiFromModules<{
   aboutPreviewDraft: typeof aboutPreviewDraft;
   aboutTeamStorage: typeof aboutTeamStorage;
+  audioPreviewDraft: typeof audioPreviewDraft;
+  audioTracks: typeof audioTracks;
   "admin/about": typeof admin_about;
   "admin/aboutTeam": typeof admin_aboutTeam;
+  "admin/audio": typeof admin_audio;
   "admin/gear": typeof admin_gear;
   "admin/photos": typeof admin_photos;
   "admin/pricing": typeof admin_pricing;

--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -1,0 +1,461 @@
+import { v } from "convex/values";
+import { mutation, query, type MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import {
+  ALLOWED_AUDIO_CONTENT_TYPES,
+  MAX_AUDIO_FILE_BYTES,
+  MAX_AUDIO_TRACKS,
+  type AudioPublishIssue,
+  type AudioTrackDoc,
+  deleteStorageIfUnreferencedAcrossCms,
+  ensureAudioTrackMeta,
+  getStorageMetadata,
+  isAllowedAudioContentType,
+  loadAudioTracks,
+  materializeAudioTracks,
+  patchAudioMetaAfterDraftChange,
+  replaceAudioScope,
+} from "../audioTracks";
+import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
+import { requireCmsOwner } from "../lib/auth";
+
+const MAX_TITLE_LENGTH = 120;
+const MAX_FILENAME_LENGTH = 255;
+
+function generateTrackStableId(): string {
+  return `audio_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeTitle(raw: string): string {
+  const value = raw.trim();
+  if (value.length === 0) {
+    cmsValidationError("Title is required.", "title");
+  }
+  if (value.length > MAX_TITLE_LENGTH) {
+    cmsValidationError(
+      `Title must be at most ${MAX_TITLE_LENGTH} characters.`,
+      "title",
+    );
+  }
+  return value;
+}
+
+function normalizeFileName(raw?: string | null): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  if (value.length > MAX_FILENAME_LENGTH) {
+    cmsValidationError(
+      `Filename must be at most ${MAX_FILENAME_LENGTH} characters.`,
+      "originalFileName",
+    );
+  }
+  return value;
+}
+
+function validateStorageMetadataOrThrow(
+  storage: Awaited<ReturnType<typeof getStorageMetadata>>,
+): asserts storage is NonNullable<
+  Awaited<ReturnType<typeof getStorageMetadata>>
+> & { contentType: string } {
+  if (!storage) {
+    cmsValidationError("Uploaded file was not found in storage.", "storageId");
+  }
+  if (!storage.contentType) {
+    cmsValidationError(
+      "Uploaded file is missing a content type. Use MP3, WAV, FLAC, M4A/AAC, or OGG.",
+      "storageId",
+    );
+  }
+  if (!isAllowedAudioContentType(storage.contentType)) {
+    cmsValidationError(
+      "Only MP3, WAV, FLAC, M4A/AAC, and OGG audio files are allowed.",
+      "storageId",
+    );
+  }
+  if (storage.size > MAX_AUDIO_FILE_BYTES) {
+    cmsValidationError(
+      `Audio must be ${Math.floor(MAX_AUDIO_FILE_BYTES / (1024 * 1024))}MB or smaller.`,
+      "storageId",
+    );
+  }
+}
+
+function collectTrackIssues(
+  rows: AudioTrackDoc[],
+  storageById: Map<Id<"_storage">, Awaited<ReturnType<typeof getStorageMetadata>>>,
+): AudioPublishIssue[] {
+  const issues: AudioPublishIssue[] = [];
+  const stableIds = new Set<string>();
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const base = `tracks[${i}]`;
+
+    if (row.title.trim().length === 0) {
+      issues.push({
+        path: `${base}.title`,
+        message: "Title is required.",
+      });
+    }
+    if (row.title.length > MAX_TITLE_LENGTH) {
+      issues.push({
+        path: `${base}.title`,
+        message: `Title must be at most ${MAX_TITLE_LENGTH} characters.`,
+      });
+    }
+    if (stableIds.has(row.stableId)) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: `Duplicate stableId: ${row.stableId}`,
+      });
+    } else {
+      stableIds.add(row.stableId);
+    }
+
+    const storage = storageById.get(row.storageId) ?? null;
+    if (!storage) {
+      issues.push({
+        path: `${base}.storageId`,
+        message: "Referenced storage blob is missing.",
+      });
+      continue;
+    }
+    if (!storage.contentType) {
+      issues.push({
+        path: `${base}.storageId`,
+        message: "Storage blob is missing a content type.",
+      });
+      continue;
+    }
+    if (!isAllowedAudioContentType(storage.contentType)) {
+      issues.push({
+        path: `${base}.storageId`,
+        message: `Unsupported content type: ${storage.contentType}`,
+      });
+    }
+    if (storage.size > MAX_AUDIO_FILE_BYTES) {
+      issues.push({
+        path: `${base}.storageId`,
+        message: `Audio exceeds ${Math.floor(MAX_AUDIO_FILE_BYTES / (1024 * 1024))}MB.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+async function getDraftTrackByStableId(
+  ctx: MutationCtx,
+  stableId: string,
+): Promise<AudioTrackDoc | null> {
+  return await ctx.db
+    .query("audioTracks")
+    .withIndex("by_scope_and_stableId", (q) =>
+      q.eq("scope", "draft").eq("stableId", stableId),
+    )
+    .unique();
+}
+
+async function resequenceDraftTracks(ctx: MutationCtx): Promise<void> {
+  const draft = await loadAudioTracks(ctx, "draft");
+  for (let i = 0; i < draft.length; i++) {
+    if (draft[i].sortOrder !== i) {
+      await ctx.db.patch(draft[i]._id, { sortOrder: i });
+    }
+  }
+}
+
+export async function validateDraftAudioForPublish(
+  ctx: MutationCtx,
+  rows: AudioTrackDoc[],
+): Promise<AudioPublishIssue[]> {
+  const storageRecords = await Promise.all(
+    Array.from(new Set(rows.map((row) => row.storageId))).map(async (storageId) => [
+      storageId,
+      await getStorageMetadata(ctx, storageId),
+    ] as const),
+  );
+  return collectTrackIssues(rows, new Map(storageRecords));
+}
+
+export const listDraftAudioTracks = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const rows = await loadAudioTracks(ctx, "draft");
+    const meta = await ctx.db
+      .query("audioTrackMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+
+    return {
+      tracks: await materializeAudioTracks(ctx, rows),
+      hasDraftChanges: meta?.hasDraftChanges ?? false,
+      publishedAt: meta?.publishedAt ?? null,
+      publishedBy: meta?.publishedBy ?? null,
+      updatedAt: meta?.updatedAt ?? null,
+      updatedBy: meta?.updatedBy ?? null,
+      limits: {
+        maxTracks: MAX_AUDIO_TRACKS,
+        maxFileBytes: MAX_AUDIO_FILE_BYTES,
+        acceptedMimeTypes: [...ALLOWED_AUDIO_CONTENT_TYPES],
+      },
+    };
+  },
+});
+
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    return { uploadUrl: await ctx.storage.generateUploadUrl() };
+  },
+});
+
+export const saveUploadedAudioTrack = mutation({
+  args: {
+    storageId: v.id("_storage"),
+    title: v.string(),
+    originalFileName: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureAudioTrackMeta(ctx);
+
+    const draft = await loadAudioTracks(ctx, "draft");
+    if (draft.length >= MAX_AUDIO_TRACKS) {
+      await deleteStorageIfUnreferencedAcrossCms(ctx, args.storageId);
+      cmsValidationError(
+        `Audio portfolio supports up to ${MAX_AUDIO_TRACKS} tracks.`,
+        "storageId",
+      );
+    }
+
+    try {
+      const storage = await getStorageMetadata(ctx, args.storageId);
+      validateStorageMetadataOrThrow(storage);
+      const contentType = storage.contentType;
+      const originalFileName = normalizeFileName(args.originalFileName);
+
+      const sortOrder =
+        draft.length === 0
+          ? 0
+          : Math.max(...draft.map((row) => row.sortOrder)) + 1;
+
+      await ctx.db.insert("audioTracks", {
+        scope: "draft",
+        stableId: generateTrackStableId(),
+        storageId: args.storageId,
+        title: normalizeTitle(args.title),
+        sortOrder,
+        contentType,
+        sizeBytes: storage.size,
+        ...(originalFileName !== undefined ? { originalFileName } : {}),
+      });
+    } catch (error) {
+      await deleteStorageIfUnreferencedAcrossCms(ctx, args.storageId);
+      throw error;
+    }
+
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const updateDraftAudioTrackTitle = mutation({
+  args: {
+    stableId: v.string(),
+    title: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftTrackByStableId(ctx, args.stableId);
+    if (!row) {
+      cmsNotFound("audioTrack", args.stableId);
+    }
+
+    await ctx.db.patch(row._id, {
+      title: normalizeTitle(args.title),
+    });
+
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+/**
+ * Atomically point the draft row at `newStorageId`, then delete the previous blob
+ * when nothing else references it (avoids a window where the old URL is still live
+ * but the row already points elsewhere — the row keeps the old id until patch).
+ */
+export const replaceDraftAudioTrackFile = mutation({
+  args: {
+    stableId: v.string(),
+    newStorageId: v.id("_storage"),
+    originalFileName: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftTrackByStableId(ctx, args.stableId);
+    if (!row) {
+      await deleteStorageIfUnreferencedAcrossCms(ctx, args.newStorageId);
+      cmsNotFound("audioTrack", args.stableId);
+    }
+
+    const previousStorageId = row.storageId;
+
+    try {
+      const storage = await getStorageMetadata(ctx, args.newStorageId);
+      validateStorageMetadataOrThrow(storage);
+      const contentType = storage.contentType;
+      const originalFileName = normalizeFileName(args.originalFileName);
+
+      await ctx.db.patch(row._id, {
+        storageId: args.newStorageId,
+        contentType,
+        sizeBytes: storage.size,
+        ...(originalFileName !== undefined ? { originalFileName } : {}),
+      });
+    } catch (error) {
+      await deleteStorageIfUnreferencedAcrossCms(ctx, args.newStorageId);
+      throw error;
+    }
+
+    if (previousStorageId !== args.newStorageId) {
+      await deleteStorageIfUnreferencedAcrossCms(ctx, previousStorageId);
+    }
+
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const reorderDraftAudioTracks = mutation({
+  args: { orderedStableIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const draft = await loadAudioTracks(ctx, "draft");
+    if (draft.length !== args.orderedStableIds.length) {
+      cmsValidationError(
+        "Reorder payload must include every draft track exactly once.",
+        "orderedStableIds",
+      );
+    }
+
+    const draftIds = new Set(draft.map((row) => row.stableId));
+    const orderedIds = new Set(args.orderedStableIds);
+    if (
+      orderedIds.size !== args.orderedStableIds.length ||
+      draftIds.size !== orderedIds.size ||
+      args.orderedStableIds.some((stableId) => !draftIds.has(stableId))
+    ) {
+      cmsValidationError(
+        "Reorder payload must include every draft track exactly once.",
+        "orderedStableIds",
+      );
+    }
+
+    const byStableId = new Map(draft.map((row) => [row.stableId, row]));
+    for (let i = 0; i < args.orderedStableIds.length; i++) {
+      const trackRow = byStableId.get(args.orderedStableIds[i]);
+      if (!trackRow) {
+        cmsNotFound("audioTrack", args.orderedStableIds[i]);
+      }
+      if (trackRow.sortOrder !== i) {
+        await ctx.db.patch(trackRow._id, { sortOrder: i });
+      }
+    }
+
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const removeDraftAudioTrack = mutation({
+  args: { stableId: v.string() },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftTrackByStableId(ctx, args.stableId);
+    if (!row) {
+      return { ok: true as const, removed: false };
+    }
+
+    await ctx.db.delete(row._id);
+    await resequenceDraftTracks(ctx);
+    await deleteStorageIfUnreferencedAcrossCms(ctx, row.storageId);
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, removed: true };
+  },
+});
+
+export async function publishAudioDraftCore(
+  ctx: MutationCtx,
+  args: { userId: string; updatedBy: string },
+): Promise<{
+  ok: true;
+  kind: "published";
+  publishedAt: number;
+  publishedBy: string;
+}> {
+  const { userId, updatedBy } = args;
+  const draft = await loadAudioTracks(ctx, "draft");
+  const issues = await validateDraftAudioForPublish(ctx, draft);
+  if (issues.length > 0) {
+    cmsPublishValidationFailed(
+      "audio",
+      "Publish validation failed.",
+      issues,
+    );
+  }
+
+  await replaceAudioScope(ctx, "draft", "published");
+
+  const now = Date.now();
+  const { id: metaId } = await ensureAudioTrackMeta(ctx);
+  await ctx.db.patch(metaId, {
+    hasDraftChanges: false,
+    publishedAt: now,
+    publishedBy: userId,
+    updatedAt: now,
+    updatedBy,
+  });
+
+  return {
+    ok: true as const,
+    kind: "published" as const,
+    publishedAt: now,
+    publishedBy: userId,
+  };
+}
+
+export const publishAudioTracks = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { userId, updatedBy } = await requireCmsOwner(ctx);
+    return await publishAudioDraftCore(ctx, { userId, updatedBy });
+  },
+});
+
+export const discardDraftAudioTracks = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureAudioTrackMeta(ctx);
+    await replaceAudioScope(ctx, "published", "draft");
+
+    const now = Date.now();
+    const { id: metaId } = await ensureAudioTrackMeta(ctx);
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      updatedAt: now,
+      updatedBy,
+    });
+
+    return { ok: true as const, discarded: true };
+  },
+});

--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -14,6 +14,7 @@ import type { Doc } from "../_generated/dataModel";
 import { requireCmsOwner } from "../lib/auth";
 import { cmsPublishValidationFailed } from "../errors";
 import { loadGalleryPhotos } from "../galleryPhotos";
+import { loadAudioTracks } from "../audioTracks";
 import { collectAboutTeamBlobIssues } from "../aboutTeamStorage";
 import type { AboutSnapshot } from "../cmsShared";
 import {
@@ -23,6 +24,10 @@ import {
   rowsWithPublishableDraft,
 } from "../cmsPublishHelpers";
 import { publishGalleryDraftCore, validateDraftForPublish } from "./photos";
+import {
+  publishAudioDraftCore,
+  validateDraftAudioForPublish,
+} from "./audio";
 
 export const publish = mutation({
   args: { section: cmsSectionValidator },
@@ -55,7 +60,13 @@ export const publishSite = mutation({
       .unique();
     const galleryPending = galleryMeta?.hasDraftChanges ?? false;
 
-    if (targets.length === 0 && !galleryPending) {
+    const audioMeta = await ctx.db
+      .query("audioTrackMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+    const audioPending = audioMeta?.hasDraftChanges ?? false;
+
+    if (targets.length === 0 && !galleryPending && !audioPending) {
       return {
         ok: true as const,
         kind: "nothing_to_publish" as const,
@@ -88,6 +99,16 @@ export const publishSite = mutation({
         });
       }
     }
+    if (audioPending) {
+      const draftAudio = await loadAudioTracks(ctx, "draft");
+      const audioIssues = await validateDraftAudioForPublish(ctx, draftAudio);
+      for (const issue of audioIssues) {
+        issues.push({
+          path: `audio.${issue.path}`,
+          message: issue.message,
+        });
+      }
+    }
     if (issues.length > 0) {
       cmsPublishValidationFailed(
         "site",
@@ -113,12 +134,17 @@ export const publishSite = mutation({
       ? await publishGalleryDraftCore(ctx, { userId, updatedBy })
       : undefined;
 
+    const audioResult = audioPending
+      ? await publishAudioDraftCore(ctx, { userId, updatedBy })
+      : undefined;
+
     return {
       ok: true as const,
       kind: "published" as const,
       publishedSections: targets.map((t) => t.section),
       results,
       ...(galleryResult !== undefined ? { gallery: galleryResult } : {}),
+      ...(audioResult !== undefined ? { audio: audioResult } : {}),
     };
   },
 });

--- a/convex/audioPreviewDraft.ts
+++ b/convex/audioPreviewDraft.ts
@@ -1,0 +1,40 @@
+import { query } from "./_generated/server";
+import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
+import { requireCmsOwner } from "./lib/auth";
+
+/**
+ * Owner-only preview of audio portfolio. Returns draft rows when there are
+ * unpublished changes, otherwise published. Returns `null` for non-owners.
+ */
+export const getPreviewAudioTracks = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const meta = await ctx.db
+      .query("audioTrackMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+
+    const hasDraftChanges = meta?.hasDraftChanges ?? false;
+    const rows = await loadAudioTracks(
+      ctx,
+      hasDraftChanges ? "draft" : "published",
+    );
+    const tracks = await materializeAudioTracks(ctx, rows);
+
+    return {
+      tracks: tracks.filter((track) => track.url !== null),
+      hasDraftChanges,
+    };
+  },
+});

--- a/convex/audioTracks.ts
+++ b/convex/audioTracks.ts
@@ -1,0 +1,232 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+
+export const ALLOWED_AUDIO_CONTENT_TYPES = [
+  "audio/mpeg",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/flac",
+  "audio/mp4",
+  "audio/aac",
+  "audio/ogg",
+] as const;
+
+export const MAX_AUDIO_FILE_BYTES = 100 * 1024 * 1024;
+export const MAX_AUDIO_TRACKS = 30;
+const AUDIO_QUERY_LIMIT = 128;
+
+export type AudioScope = Doc<"audioTracks">["scope"];
+export type AudioTrackDoc = Doc<"audioTracks">;
+export type AudioTrackMetaDoc = Doc<"audioTrackMeta">;
+export type AudioPublishIssue = { path: string; message: string };
+
+export type StorageMetadataRecord = {
+  _id: Id<"_storage">;
+  _creationTime: number;
+  contentType?: string;
+  sha256: string;
+  size: number;
+};
+
+function comparableTrack(row: AudioTrackDoc) {
+  return {
+    stableId: row.stableId,
+    storageId: row.storageId,
+    title: row.title,
+    sortOrder: row.sortOrder,
+    contentType: row.contentType,
+    sizeBytes: row.sizeBytes,
+    originalFileName: row.originalFileName ?? null,
+  };
+}
+
+export function audioDraftMatchesPublished(
+  draft: AudioTrackDoc[],
+  published: AudioTrackDoc[],
+): boolean {
+  if (draft.length !== published.length) {
+    return false;
+  }
+  for (let i = 0; i < draft.length; i++) {
+    if (
+      JSON.stringify(comparableTrack(draft[i])) !==
+      JSON.stringify(comparableTrack(published[i]))
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function loadAudioTracks(
+  ctx: QueryCtx | MutationCtx,
+  scope: AudioScope,
+): Promise<AudioTrackDoc[]> {
+  return await ctx.db
+    .query("audioTracks")
+    .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+    .take(AUDIO_QUERY_LIMIT);
+}
+
+export async function ensureAudioTrackMeta(
+  ctx: MutationCtx,
+): Promise<{ id: Doc<"audioTrackMeta">["_id"]; row: AudioTrackMetaDoc }> {
+  const existing = await ctx.db
+    .query("audioTrackMeta")
+    .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+    .unique();
+
+  if (existing) {
+    return { id: existing._id, row: existing };
+  }
+
+  const now = Date.now();
+  const id = await ctx.db.insert("audioTrackMeta", {
+    singletonKey: "default",
+    hasDraftChanges: false,
+    publishedAt: null,
+    updatedAt: now,
+  });
+  const row = await ctx.db.get(id);
+  if (!row) {
+    throw new Error("Failed to create audio track meta row.");
+  }
+  return { id, row };
+}
+
+export async function getStorageMetadata(
+  ctx: QueryCtx | MutationCtx,
+  storageId: Id<"_storage">,
+): Promise<StorageMetadataRecord | null> {
+  return (await ctx.db.system.get(
+    "_storage",
+    storageId,
+  )) as StorageMetadataRecord | null;
+}
+
+/**
+ * Deletes a storage blob only when no gallery photo or audio track references it.
+ */
+export async function deleteStorageIfUnreferencedAcrossCms(
+  ctx: MutationCtx,
+  storageId: Id<"_storage">,
+): Promise<boolean> {
+  const galleryRefs = await ctx.db
+    .query("galleryPhotos")
+    .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+    .take(1);
+  if (galleryRefs.length > 0) {
+    return false;
+  }
+
+  const audioRefs = await ctx.db
+    .query("audioTracks")
+    .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+    .take(1);
+  if (audioRefs.length > 0) {
+    return false;
+  }
+
+  const storage = await getStorageMetadata(ctx, storageId);
+  if (!storage) {
+    return false;
+  }
+
+  await ctx.storage.delete(storageId);
+  return true;
+}
+
+export async function replaceAudioScope(
+  ctx: MutationCtx,
+  fromScope: AudioScope,
+  toScope: AudioScope,
+): Promise<void> {
+  const [source, target] = await Promise.all([
+    loadAudioTracks(ctx, fromScope),
+    loadAudioTracks(ctx, toScope),
+  ]);
+
+  const sourceStorageIds = new Set(source.map((row) => row.storageId));
+  const targetOnlyStorageIds = Array.from(
+    new Set(
+      target
+        .map((row) => row.storageId)
+        .filter((storageId) => !sourceStorageIds.has(storageId)),
+    ),
+  );
+
+  for (const row of target) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const row of source) {
+    await ctx.db.insert("audioTracks", {
+      scope: toScope,
+      stableId: row.stableId,
+      storageId: row.storageId,
+      title: row.title,
+      sortOrder: row.sortOrder,
+      contentType: row.contentType,
+      sizeBytes: row.sizeBytes,
+      ...(row.originalFileName !== undefined
+        ? { originalFileName: row.originalFileName }
+        : {}),
+    });
+  }
+
+  for (const storageId of targetOnlyStorageIds) {
+    await deleteStorageIfUnreferencedAcrossCms(ctx, storageId);
+  }
+}
+
+export async function patchAudioMetaAfterDraftChange(
+  ctx: MutationCtx,
+  updatedBy: string,
+): Promise<void> {
+  const [draft, published, meta] = await Promise.all([
+    loadAudioTracks(ctx, "draft"),
+    loadAudioTracks(ctx, "published"),
+    ensureAudioTrackMeta(ctx),
+  ]);
+
+  await ctx.db.patch(meta.id, {
+    hasDraftChanges: !audioDraftMatchesPublished(draft, published),
+    updatedAt: Date.now(),
+    updatedBy,
+  });
+}
+
+export async function materializeAudioTracks(
+  ctx: QueryCtx | MutationCtx,
+  rows: AudioTrackDoc[],
+): Promise<
+  Array<{
+    stableId: string;
+    storageId: Id<"_storage">;
+    url: string | null;
+    title: string;
+    sortOrder: number;
+    contentType: string;
+    sizeBytes: number;
+    originalFileName: string | null;
+  }>
+> {
+  return await Promise.all(
+    rows.map(async (row) => ({
+      stableId: row.stableId,
+      storageId: row.storageId,
+      url: await ctx.storage.getUrl(row.storageId),
+      title: row.title,
+      sortOrder: row.sortOrder,
+      contentType: row.contentType,
+      sizeBytes: row.sizeBytes,
+      originalFileName: row.originalFileName ?? null,
+    })),
+  );
+}
+
+export function isAllowedAudioContentType(
+  contentType: string,
+): contentType is (typeof ALLOWED_AUDIO_CONTENT_TYPES)[number] {
+  return (ALLOWED_AUDIO_CONTENT_TYPES as readonly string[]).includes(contentType);
+}

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { deleteStorageIfUnreferencedAcrossCms } from "./audioTracks";
 
 export const ALLOWED_GALLERY_IMAGE_TYPES = [
   "image/jpeg",
@@ -108,21 +109,7 @@ export async function deleteStorageIfUnreferenced(
   ctx: MutationCtx,
   storageId: Id<"_storage">,
 ): Promise<boolean> {
-  const refs = await ctx.db
-    .query("galleryPhotos")
-    .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
-    .take(1);
-  if (refs.length > 0) {
-    return false;
-  }
-
-  const storage = await getStorageMetadata(ctx, storageId);
-  if (!storage) {
-    return false;
-  }
-
-  await ctx.storage.delete(storageId);
-  return true;
+  return deleteStorageIfUnreferencedAcrossCms(ctx, storageId);
 }
 
 export async function replaceGalleryScope(

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -8,6 +8,7 @@ import {
 import { loadGearDocs, mapSortedGearTree } from "./gearTree";
 import type { Doc } from "./_generated/dataModel";
 import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
+import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
 
 /**
  * **Public (anonymous) site reads** — published snapshot only.
@@ -132,5 +133,17 @@ export const getPublishedGalleryPhotos = query({
     const rows = await loadGalleryPhotos(ctx, "published");
     const photos = await materializeGalleryPhotos(ctx, rows);
     return photos.filter((photo) => photo.url !== null);
+  },
+});
+
+/**
+ * Published audio portfolio tracks only. Anonymous; reads `scope === "published"`.
+ */
+export const getPublishedAudioTracks = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await loadAudioTracks(ctx, "published");
+    const tracks = await materializeAudioTracks(ctx, rows);
+    return tracks.filter((track) => track.url !== null);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -112,4 +112,30 @@ export default defineSchema({
     .index("by_scope_and_sort", ["scope", "sortOrder"])
     .index("by_scope_and_stableId", ["scope", "stableId"])
     .index("by_storageId", ["storageId"]),
+
+  /**
+   * Audio portfolio samples (INF-96): draft/published rows mirror gallery photos.
+   */
+  audioTrackMeta: defineTable({
+    singletonKey: v.literal("default"),
+    hasDraftChanges: v.boolean(),
+    publishedAt: v.union(v.number(), v.null()),
+    publishedBy: v.optional(v.string()),
+    updatedAt: v.number(),
+    updatedBy: v.optional(v.string()),
+  }).index("by_singleton", ["singletonKey"]),
+
+  audioTracks: defineTable({
+    scope: gearScopeValidator,
+    stableId: v.string(),
+    storageId: v.id("_storage"),
+    title: v.string(),
+    sortOrder: v.number(),
+    contentType: v.string(),
+    sizeBytes: v.number(),
+    originalFileName: v.optional(v.string()),
+  })
+    .index("by_scope_and_sort", ["scope", "sortOrder"])
+    .index("by_scope_and_stableId", ["scope", "stableId"])
+    .index("by_storageId", ["storageId"]),
 });

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -1,0 +1,1199 @@
+"use client";
+
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useMutation,
+  useQuery,
+} from "convex/react";
+import { useUser } from "@clerk/nextjs";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent as ReactDragEvent,
+} from "react";
+import { Effect, pipe } from "effect";
+import { toast } from "sonner";
+import {
+  ArrowDown,
+  ArrowUp,
+  GripVertical,
+  Loader2,
+  Music2,
+  RefreshCw,
+  Save,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import { runAdminEffect } from "@/lib/admin-run-effect";
+import { cn } from "@/lib/utils";
+
+const MAX_TITLE_LENGTH = 120;
+const REORDER_MIME = "application/x-lls-audio-reorder";
+
+type AudioTrackItem = {
+  stableId: string;
+  storageId: Id<"_storage">;
+  url: string | null;
+  title: string;
+  sortOrder: number;
+  contentType: string;
+  sizeBytes: number;
+  originalFileName: string | null;
+};
+
+type TitleEdits = Record<string, string>;
+
+type RowAction = "saving" | "replacing" | "deleting";
+type RowBusy = Record<string, RowAction | undefined>;
+
+type UploadProgressEntry = {
+  readonly id: string;
+  readonly name: string;
+  readonly progress: number;
+  readonly status: "uploading" | "saving" | "done" | "error";
+  readonly error?: string;
+};
+
+function defaultTitleFromFileName(fileName: string): string {
+  const withoutExtension = fileName.replace(/\.[^.]+$/, "");
+  const normalized = withoutExtension
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (normalized.length === 0) {
+    return "Untitled track";
+  }
+  const titled = normalized[0].toUpperCase() + normalized.slice(1);
+  return titled.length > MAX_TITLE_LENGTH
+    ? titled.slice(0, MAX_TITLE_LENGTH)
+    : titled;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function validateTitle(title: string): string | null {
+  const trimmed = title.trim();
+  if (trimmed.length === 0) {
+    return "Title is required.";
+  }
+  if (trimmed.length > MAX_TITLE_LENGTH) {
+    return `Title must be at most ${MAX_TITLE_LENGTH} characters.`;
+  }
+  return null;
+}
+
+function sequentialEffects(
+  effects: Array<Effect.Effect<unknown, CmsAppError>>,
+): Effect.Effect<void, CmsAppError> {
+  return effects.reduce(
+    (acc, effect) => pipe(acc, Effect.flatMap(() => effect)),
+    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
+  );
+}
+
+async function uploadFileWithProgress(
+  uploadUrl: string,
+  file: File,
+  onProgress: (fraction: number) => void,
+): Promise<Id<"_storage">> {
+  return await new Promise<Id<"_storage">>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", uploadUrl);
+    xhr.setRequestHeader("Content-Type", file.type || "application/octet-stream");
+    xhr.upload.addEventListener("progress", (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress(Math.min(1, event.loaded / event.total));
+      }
+    });
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const parsed = JSON.parse(xhr.responseText) as {
+            storageId: Id<"_storage">;
+          };
+          onProgress(1);
+          resolve(parsed.storageId);
+        } catch {
+          reject(new Error("Upload succeeded but response was malformed."));
+        }
+      } else {
+        reject(
+          new Error(
+            `Upload failed (${xhr.status} ${xhr.statusText || "unknown"}).`,
+          ),
+        );
+      }
+    });
+    xhr.addEventListener("error", () =>
+      reject(new Error("Network error during upload.")),
+    );
+    xhr.addEventListener("abort", () =>
+      reject(new Error("Upload was aborted.")),
+    );
+    xhr.send(file);
+  });
+}
+
+export function AudioEditor() {
+  return (
+    <>
+      <AuthLoading>
+        <p className="body-text text-foreground/80">Authenticating…</p>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <p className="body-text text-foreground/80">
+          Sign in to manage audio samples.
+        </p>
+      </Unauthenticated>
+
+      <Authenticated>
+        <AudioEditorForm />
+      </Authenticated>
+    </>
+  );
+}
+
+function AudioEditorForm() {
+  const { user } = useUser();
+  const data = useQuery(api.admin.audio.listDraftAudioTracks);
+  const generateUploadUrl = useMutation(api.admin.audio.generateUploadUrl);
+  const saveUploadedAudioTrack = useMutation(api.admin.audio.saveUploadedAudioTrack);
+  const updateDraftAudioTrackTitle = useMutation(
+    api.admin.audio.updateDraftAudioTrackTitle,
+  );
+  const replaceDraftAudioTrackFile = useMutation(
+    api.admin.audio.replaceDraftAudioTrackFile,
+  );
+  const reorderDraftAudioTracks = useMutation(
+    api.admin.audio.reorderDraftAudioTracks,
+  );
+  const removeDraftAudioTrack = useMutation(api.admin.audio.removeDraftAudioTrack);
+  const publishAudioTracks = useMutation(api.admin.audio.publishAudioTracks);
+  const discardDraftAudioTracks = useMutation(
+    api.admin.audio.discardDraftAudioTracks,
+  );
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const replaceInputRef = useRef<HTMLInputElement | null>(null);
+  const dragDepthRef = useRef(0);
+  const uploadDismissTimerRef = useRef<number | null>(null);
+
+  const [busy, setBusy] = useState<string | null>(null);
+  const [rowBusy, setRowBusy] = useState<RowBusy>({});
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [edits, setEdits] = useState<TitleEdits>({});
+  const [deleteStableId, setDeleteStableId] = useState<string | null>(null);
+  const replaceTargetStableIdRef = useRef<string | null>(null);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const [uploadQueue, setUploadQueue] = useState<UploadProgressEntry[]>([]);
+
+  const [draggingStableId, setDraggingStableId] = useState<string | null>(null);
+  const [reorderTarget, setReorderTarget] = useState<{
+    stableId: string;
+    position: "before" | "after";
+  } | null>(null);
+
+  const tracks = useMemo(
+    () => (data?.tracks ?? []) as AudioTrackItem[],
+    [data],
+  );
+
+  const setRowAction = useCallback(
+    (stableId: string, action: RowAction | undefined) => {
+      setRowBusy((prev) => {
+        const next = { ...prev };
+        if (action === undefined) {
+          delete next[stableId];
+        } else {
+          next[stableId] = action;
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const runAction = useCallback(
+    async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
+      setInlineError(null);
+      setBusy(label);
+      const outcome = await runAdminEffect(program, {
+        onErrorMessage: setInlineError,
+      });
+      setBusy(null);
+      return outcome;
+    },
+    [],
+  );
+
+  const hasDraftOnServer = data?.hasDraftChanges ?? false;
+  const hasLocalEdits = Object.keys(edits).length > 0;
+
+  const publishedByLabel =
+    data?.publishedBy && user?.id === data.publishedBy ? "You" : undefined;
+
+  const getEditableTitle = useCallback(
+    (track: AudioTrackItem) => edits[track.stableId] ?? track.title,
+    [edits],
+  );
+
+  const updateTitleEdit = useCallback((track: AudioTrackItem, title: string) => {
+    setEdits((current) => {
+      if (title === track.title) {
+        const rest = { ...current };
+        delete rest[track.stableId];
+        return rest;
+      }
+      return { ...current, [track.stableId]: title };
+    });
+  }, []);
+
+  const clearTitleEdit = useCallback((stableId: string) => {
+    setEdits((current) => {
+      const rest = { ...current };
+      delete rest[stableId];
+      return rest;
+    });
+  }, []);
+
+  const saveTrackTitle = useCallback(
+    async (track: AudioTrackItem): Promise<boolean> => {
+      const title = getEditableTitle(track);
+      const validationError = validateTitle(title);
+      if (validationError) {
+        setInlineError(validationError);
+        toast.error(validationError);
+        return false;
+      }
+
+      setInlineError(null);
+      setRowAction(track.stableId, "saving");
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() =>
+          updateDraftAudioTrackTitle({
+            stableId: track.stableId,
+            title: title.trim(),
+          }),
+        ),
+        { onErrorMessage: setInlineError },
+      );
+      setRowAction(track.stableId, undefined);
+
+      if (outcome === undefined) {
+        return false;
+      }
+
+      clearTitleEdit(track.stableId);
+      toast.success("Title saved.");
+      return true;
+    },
+    [clearTitleEdit, getEditableTitle, setRowAction, updateDraftAudioTrackTitle],
+  );
+
+  const savePendingEdits = useCallback(async (): Promise<boolean> => {
+    const dirty = tracks.filter((t) => edits[t.stableId] !== undefined);
+    if (dirty.length === 0) {
+      return true;
+    }
+
+    for (const track of dirty) {
+      const title = getEditableTitle(track);
+      const validationError = validateTitle(title);
+      if (validationError) {
+        setInlineError(validationError);
+        toast.error(
+          `${track.originalFileName ?? "Track"}: ${validationError}`,
+        );
+        return false;
+      }
+    }
+
+    const effects = dirty.map((track) =>
+      convexMutationEffect(() =>
+        updateDraftAudioTrackTitle({
+          stableId: track.stableId,
+          title: getEditableTitle(track).trim(),
+        }),
+      ),
+    );
+
+    const outcome = await runAction("Saving…", sequentialEffects(effects));
+    if (outcome === undefined) {
+      return false;
+    }
+
+    setEdits({});
+    return true;
+  }, [edits, getEditableTitle, runAction, tracks, updateDraftAudioTrackTitle]);
+
+  const persistOrder = useCallback(
+    async (orderedStableIds: string[]): Promise<boolean> => {
+      const outcome = await runAction(
+        "Reordering…",
+        convexMutationEffect(() =>
+          reorderDraftAudioTracks({ orderedStableIds }),
+        ),
+      );
+      return outcome !== undefined;
+    },
+    [reorderDraftAudioTracks, runAction],
+  );
+
+  const moveTrack = useCallback(
+    async (stableId: string, direction: -1 | 1) => {
+      const index = tracks.findIndex((t) => t.stableId === stableId);
+      if (index === -1) return;
+      const target = index + direction;
+      if (target < 0 || target >= tracks.length) return;
+
+      const reordered = [...tracks];
+      const [moved] = reordered.splice(index, 1);
+      reordered.splice(target, 0, moved);
+
+      const ok = await persistOrder(reordered.map((t) => t.stableId));
+      if (ok) {
+        toast.success("Track order updated.");
+      }
+    },
+    [persistOrder, tracks],
+  );
+
+  const handleRowDragStart = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>, stableId: string) => {
+      if (busy !== null) {
+        event.preventDefault();
+        return;
+      }
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData(REORDER_MIME, stableId);
+      event.dataTransfer.setData("text/plain", stableId);
+      setDraggingStableId(stableId);
+    },
+    [busy],
+  );
+
+  const handleRowDragOver = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>, overStableId: string) => {
+      if (!event.dataTransfer.types.includes(REORDER_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "move";
+
+      const rect = event.currentTarget.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      const position = event.clientY < midpoint ? "before" : "after";
+      setReorderTarget((prev) =>
+        prev?.stableId === overStableId && prev.position === position
+          ? prev
+          : { stableId: overStableId, position },
+      );
+    },
+    [],
+  );
+
+  const handleRowDrop = useCallback(
+    async (event: ReactDragEvent<HTMLDivElement>, overStableId: string) => {
+      if (!event.dataTransfer.types.includes(REORDER_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const sourceId = event.dataTransfer.getData(REORDER_MIME);
+      const position =
+        reorderTarget?.stableId === overStableId
+          ? reorderTarget.position
+          : "after";
+      setDraggingStableId(null);
+      setReorderTarget(null);
+
+      if (!sourceId || sourceId === overStableId) return;
+
+      const sourceIndex = tracks.findIndex((t) => t.stableId === sourceId);
+      const targetIndex = tracks.findIndex((t) => t.stableId === overStableId);
+      if (sourceIndex === -1 || targetIndex === -1) return;
+
+      const reordered = [...tracks];
+      const [moved] = reordered.splice(sourceIndex, 1);
+      const targetIndexInReordered = reordered.findIndex(
+        (t) => t.stableId === overStableId,
+      );
+      if (targetIndexInReordered === -1) return;
+      const insertAt =
+        position === "before"
+          ? targetIndexInReordered
+          : targetIndexInReordered + 1;
+      reordered.splice(insertAt, 0, moved);
+
+      const orderedIds = reordered.map((t) => t.stableId);
+      const unchanged = orderedIds.every(
+        (id, idx) => tracks[idx]?.stableId === id,
+      );
+      if (unchanged) return;
+
+      const ok = await persistOrder(orderedIds);
+      if (ok) {
+        toast.success("Track order updated.");
+      }
+    },
+    [persistOrder, tracks, reorderTarget],
+  );
+
+  const handleRowDragEnd = useCallback(() => {
+    setDraggingStableId(null);
+    setReorderTarget(null);
+  }, []);
+
+  const updateUploadEntry = useCallback(
+    (id: string, patch: Partial<UploadProgressEntry>) => {
+      setUploadQueue((prev) =>
+        prev.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)),
+      );
+    },
+    [],
+  );
+
+  const processNewTrackFiles = useCallback(
+    async (incomingFiles: File[]) => {
+      if (incomingFiles.length === 0 || !data) {
+        return;
+      }
+
+      setInlineError(null);
+
+      const remainingSlots = Math.max(
+        0,
+        data.limits.maxTracks - tracks.length,
+      );
+      if (remainingSlots === 0) {
+        toast.error(
+          `Portfolio is full (${data.limits.maxTracks}). Remove a track first.`,
+        );
+        return;
+      }
+
+      let filesToUpload = incomingFiles;
+      if (incomingFiles.length > remainingSlots) {
+        toast.error(
+          `Only ${remainingSlots} slot${remainingSlots === 1 ? "" : "s"} left; skipping the rest.`,
+        );
+        filesToUpload = incomingFiles.slice(0, remainingSlots);
+      }
+
+      setBusy("Uploading…");
+
+      if (uploadDismissTimerRef.current !== null) {
+        window.clearTimeout(uploadDismissTimerRef.current);
+        uploadDismissTimerRef.current = null;
+      }
+
+      let successCount = 0;
+      for (const file of filesToUpload) {
+        const entryId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+        setUploadQueue((prev) => [
+          ...prev,
+          {
+            id: entryId,
+            name: file.name,
+            progress: 0,
+            status: "uploading",
+          },
+        ]);
+
+        const accepted = data.limits.acceptedMimeTypes as readonly string[];
+        if (file.type && !accepted.includes(file.type)) {
+          const msg = `${file.name}: use MP3, WAV, FLAC, M4A/AAC, or OGG.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+        if (file.size > data.limits.maxFileBytes) {
+          const msg = `${file.name}: file must be ${Math.floor(
+            data.limits.maxFileBytes / (1024 * 1024),
+          )}MB or smaller.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+
+        const upload = await runAdminEffect(
+          convexMutationEffect(() => generateUploadUrl({})),
+          { onErrorMessage: setInlineError },
+        );
+        if (!upload) {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: "Could not get upload URL.",
+          });
+          break;
+        }
+
+        let storageId: Id<"_storage"> | undefined;
+        try {
+          storageId = await uploadFileWithProgress(
+            upload.uploadUrl,
+            file,
+            (fraction) => updateUploadEntry(entryId, { progress: fraction }),
+          );
+        } catch (e) {
+          const msg =
+            e instanceof Error ? e.message : "Upload failed unexpectedly.";
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+
+        updateUploadEntry(entryId, { status: "saving", progress: 1 });
+        const saved = await runAdminEffect(
+          convexMutationEffect(() =>
+            saveUploadedAudioTrack({
+              storageId,
+              title: defaultTitleFromFileName(file.name),
+              originalFileName: file.name,
+            }),
+          ),
+          { onErrorMessage: setInlineError },
+        );
+
+        if (saved === undefined) {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: "Could not save track to draft.",
+          });
+          break;
+        }
+
+        successCount += 1;
+        updateUploadEntry(entryId, { status: "done" });
+      }
+
+      setBusy(null);
+      if (successCount > 0) {
+        toast.success(
+          successCount === 1 ? "Track uploaded." : `${successCount} tracks uploaded.`,
+        );
+      }
+    },
+    [
+      data,
+      generateUploadUrl,
+      saveUploadedAudioTrack,
+      tracks.length,
+      updateUploadEntry,
+    ],
+  );
+
+  const handleReplaceFileSelected = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const stableId = replaceTargetStableIdRef.current;
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      replaceTargetStableIdRef.current = null;
+
+      if (!stableId || !file || !data) {
+        return;
+      }
+
+      const accepted = data.limits.acceptedMimeTypes as readonly string[];
+      if (file.type && !accepted.includes(file.type)) {
+        toast.error(`${file.name}: use MP3, WAV, FLAC, M4A/AAC, or OGG.`);
+        return;
+      }
+      if (file.size > data.limits.maxFileBytes) {
+        toast.error(
+          `${file.name}: file must be ${Math.floor(
+            data.limits.maxFileBytes / (1024 * 1024),
+          )}MB or smaller.`,
+        );
+        return;
+      }
+
+      setRowAction(stableId, "replacing");
+      setInlineError(null);
+
+      const upload = await runAdminEffect(
+        convexMutationEffect(() => generateUploadUrl({})),
+        { onErrorMessage: setInlineError },
+      );
+      if (!upload) {
+        setRowAction(stableId, undefined);
+        return;
+      }
+
+      let storageId: Id<"_storage"> | undefined;
+      try {
+        storageId = await uploadFileWithProgress(upload.uploadUrl, file, () => {
+          /* no tray for replace */
+        });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Upload failed.";
+        toast.error(msg);
+        setRowAction(stableId, undefined);
+        return;
+      }
+
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() =>
+          replaceDraftAudioTrackFile({
+            stableId,
+            newStorageId: storageId,
+            originalFileName: file.name,
+          }),
+        ),
+        { onErrorMessage: setInlineError },
+      );
+      setRowAction(stableId, undefined);
+
+      if (outcome !== undefined) {
+        toast.success("Audio file replaced.");
+      }
+    },
+    [data, generateUploadUrl, replaceDraftAudioTrackFile, setRowAction],
+  );
+
+  const handleFileSelection = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const list = event.target.files;
+      event.target.value = "";
+      if (!list || list.length === 0) return;
+      void processNewTrackFiles(Array.from(list));
+    },
+    [processNewTrackFiles],
+  );
+
+  const handleDragEnter = useCallback((event: ReactDragEvent) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    dragDepthRef.current += 1;
+    setIsDraggingOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: ReactDragEvent) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setIsDraggingOver(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((event: ReactDragEvent) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: ReactDragEvent) => {
+      dragDepthRef.current = 0;
+      setIsDraggingOver(false);
+      if (!event.dataTransfer.types.includes("Files")) return;
+      event.preventDefault();
+      const files = Array.from(event.dataTransfer.files ?? []);
+      void processNewTrackFiles(files);
+    },
+    [processNewTrackFiles],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteStableId) return;
+    setInlineError(null);
+    setRowAction(deleteStableId, "deleting");
+    const outcome = await runAdminEffect(
+      convexMutationEffect(() =>
+        removeDraftAudioTrack({ stableId: deleteStableId }),
+      ),
+      { onErrorMessage: setInlineError },
+    );
+    setRowAction(deleteStableId, undefined);
+    setDeleteStableId(null);
+
+    if (outcome !== undefined) {
+      clearTitleEdit(deleteStableId);
+      toast.success("Track removed.");
+    }
+  }, [clearTitleEdit, deleteStableId, removeDraftAudioTrack, setRowAction]);
+
+  const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
+    setInlineError(null);
+    if (hasDraftOnServer) {
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() => discardDraftAudioTracks({})),
+        { onErrorMessage: setInlineError },
+      );
+      if (outcome === undefined) {
+        return false;
+      }
+    }
+
+    setEdits({});
+    toast.success(
+      hasDraftOnServer
+        ? "Draft discarded. The editor now matches the published site."
+        : "Unsaved changes discarded.",
+    );
+    return true;
+  }, [discardDraftAudioTracks, hasDraftOnServer]);
+
+  const handlePublish = useCallback(async () => {
+    const saved = await savePendingEdits();
+    if (!saved) {
+      return;
+    }
+
+    const outcome = await runAction(
+      "Publishing…",
+      convexMutationEffect(() => publishAudioTracks({})),
+    );
+    if (outcome !== undefined) {
+      toast.success("Audio portfolio published.");
+    }
+  }, [publishAudioTracks, runAction, savePendingEdits]);
+
+  if (data === undefined) {
+    return <p className="body-text text-foreground/80">Loading audio tracks…</p>;
+  }
+
+  const anyUploading = uploadQueue.some(
+    (entry) => entry.status === "uploading" || entry.status === "saving",
+  );
+
+  const acceptAttr = [
+    ...data.limits.acceptedMimeTypes,
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".m4a",
+    ".aac",
+    ".ogg",
+  ].join(",");
+
+  return (
+    <div
+      className={cn(
+        "relative space-y-8 pb-24 transition",
+        isDraggingOver &&
+          "rounded-xl ring-2 ring-primary ring-offset-4 ring-offset-background",
+      )}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      <input
+        ref={replaceInputRef}
+        type="file"
+        accept={acceptAttr}
+        className="hidden"
+        onChange={handleReplaceFileSelected}
+      />
+
+      {isDraggingOver && (
+        <div
+          className="pointer-events-none absolute inset-0 z-20 flex items-start justify-center rounded-xl bg-primary/5 pt-16 sm:pt-24"
+          aria-hidden
+        >
+          <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-primary bg-card/95 px-10 py-8 shadow-xl">
+            <Music2 className="size-10 text-primary" aria-hidden />
+            <p className="text-lg font-semibold text-foreground">
+              Drop audio to upload
+            </p>
+            <p className="body-text-small text-muted-foreground">
+              MP3, WAV, FLAC, M4A/AAC, OGG · up to{" "}
+              {Math.floor(data.limits.maxFileBytes / (1024 * 1024))}MB each
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold tracking-tight text-foreground">
+              Audio portfolio
+            </h2>
+            <p className="body-text-small max-w-2xl text-foreground/85">
+              Upload samples for the studio portfolio. Reorder tracks in draft,
+              replace files when you have a new master (the previous file is
+              removed when safe), then publish when you are ready.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:items-end">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={acceptAttr}
+              multiple
+              className="hidden"
+              onChange={handleFileSelection}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={busy !== null || tracks.length >= data.limits.maxTracks}
+            >
+              {busy === "Uploading…" ? (
+                <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+              ) : (
+                <Upload className="mr-1 size-4" aria-hidden />
+              )}
+              Upload tracks
+            </Button>
+            <p className="body-text-small text-right text-foreground/70">
+              Up to {Math.floor(data.limits.maxFileBytes / (1024 * 1024))}MB each.
+              {tracks.length >= data.limits.maxTracks
+                ? ` Limit reached (${data.limits.maxTracks}).`
+                : ` ${tracks.length}/${data.limits.maxTracks} used.`}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {uploadQueue.length > 0 && (
+        <div
+          className="space-y-2 rounded-xl border border-border bg-muted/30 p-4"
+          aria-live="polite"
+          aria-busy={anyUploading}
+        >
+          <p className="body-text-small font-medium text-foreground/85">
+            {anyUploading ? "Uploading…" : "Upload results"}
+          </p>
+          <ul className="space-y-2">
+            {uploadQueue.map((entry) => (
+              <li key={entry.id} className="space-y-1">
+                <div className="flex items-center justify-between gap-3 text-sm">
+                  <span className="truncate text-foreground/85" title={entry.name}>
+                    {entry.name}
+                  </span>
+                  <span
+                    className={cn(
+                      "shrink-0 text-xs",
+                      entry.status === "error"
+                        ? "text-destructive"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {entry.status === "uploading" &&
+                      `${Math.round(entry.progress * 100)}%`}
+                    {entry.status === "saving" && "Saving…"}
+                    {entry.status === "done" && "Done"}
+                    {entry.status === "error" && "Failed"}
+                  </span>
+                </div>
+                <div
+                  className={cn(
+                    "h-1.5 overflow-hidden rounded-full bg-border/70",
+                    entry.status === "error" && "bg-destructive/20",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all",
+                      entry.status === "error"
+                        ? "bg-destructive"
+                        : entry.status === "done"
+                          ? "bg-emerald-500"
+                          : "bg-primary",
+                    )}
+                    style={{
+                      width:
+                        entry.status === "error"
+                          ? "100%"
+                          : `${Math.round(entry.progress * 100)}%`,
+                    }}
+                  />
+                </div>
+                {entry.error && (
+                  <p className="text-xs text-destructive">{entry.error}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {tracks.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
+          <p className="body-text text-foreground/80">
+            No tracks yet. Drop audio files here or use Upload tracks to get started.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {tracks.map((track, index) => {
+            const titleValue = getEditableTitle(track);
+            const isDirty = edits[track.stableId] !== undefined;
+            const rowAction = rowBusy[track.stableId];
+            const isRowBusy = rowAction !== undefined;
+            const isDraggingThis = draggingStableId === track.stableId;
+            const dropHint =
+              reorderTarget?.stableId === track.stableId &&
+              draggingStableId !== null &&
+              draggingStableId !== track.stableId
+                ? reorderTarget.position
+                : null;
+            const titleInvalid = titleValue.trim().length === 0;
+
+            return (
+              <Card
+                key={track.stableId}
+                data-stable-id={track.stableId}
+                className={cn(
+                  "relative flex min-w-0 flex-col gap-2 p-2.5 transition",
+                  isDraggingThis && "opacity-60",
+                  dropHint === "before" &&
+                    "shadow-[0_-2px_0_0_var(--color-primary)]",
+                  dropHint === "after" &&
+                    "shadow-[0_2px_0_0_var(--color-primary)]",
+                  isRowBusy && "pointer-events-none",
+                )}
+                draggable={busy === null}
+                onDragStart={(event) => handleRowDragStart(event, track.stableId)}
+                onDragOver={(event) => handleRowDragOver(event, track.stableId)}
+                onDrop={(event) => void handleRowDrop(event, track.stableId)}
+                onDragEnd={handleRowDragEnd}
+              >
+                <div className="flex items-start justify-between gap-2 rounded-lg border border-border bg-muted/20 p-2">
+                  <div
+                    className="text-muted-foreground/70"
+                    aria-hidden
+                  >
+                    <GripVertical className="size-4" />
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="truncate text-[10px] font-semibold uppercase tracking-wider text-foreground/55">
+                      Track #{index + 1}
+                    </p>
+                    <p className="truncate text-[11px] text-muted-foreground">
+                      {track.originalFileName ?? "Audio file"} ·{" "}
+                      {track.contentType} · {formatBytes(track.sizeBytes)}
+                    </p>
+                    {track.url ? (
+                      <audio
+                        controls
+                        preload="metadata"
+                        src={track.url}
+                        className="mt-1 h-9 w-full max-w-full"
+                      />
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        Preview unavailable (storage missing).
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 flex-col gap-0.5 rounded-md border border-border/60 bg-background/85 p-0.5">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent text-foreground hover:bg-muted/70"
+                      aria-label="Move track up"
+                      disabled={index === 0 || busy !== null || isRowBusy}
+                      onClick={() => void moveTrack(track.stableId, -1)}
+                    >
+                      <ArrowUp className="size-4 stroke-[2.25]" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent text-foreground hover:bg-muted/70"
+                      disabled={
+                        index === tracks.length - 1 ||
+                        busy !== null ||
+                        isRowBusy
+                      }
+                      aria-label="Move track down"
+                      onClick={() => void moveTrack(track.stableId, 1)}
+                    >
+                      <ArrowDown className="size-4 stroke-[2.25]" aria-hidden />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent text-foreground hover:bg-muted/70"
+                      aria-label="Replace audio file"
+                      disabled={busy !== null || isRowBusy}
+                      onClick={() => {
+                        replaceTargetStableIdRef.current = track.stableId;
+                        replaceInputRef.current?.click();
+                      }}
+                    >
+                      {rowAction === "replacing" ? (
+                        <Loader2 className="size-4 animate-spin" aria-hidden />
+                      ) : (
+                        <RefreshCw className="size-4 stroke-[2.25]" aria-hidden />
+                      )}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="bg-transparent text-destructive hover:bg-destructive/10"
+                      aria-label="Delete track"
+                      disabled={busy !== null || isRowBusy}
+                      onClick={() => setDeleteStableId(track.stableId)}
+                    >
+                      <Trash2 className="size-4 stroke-[2.25]" aria-hidden />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="min-w-0 space-y-1.5 px-0.5">
+                  <label className="min-w-0 space-y-0.5">
+                    <span className="text-[11px] font-medium text-foreground/90">
+                      Title
+                      <span className="ml-1 text-destructive" aria-hidden>
+                        *
+                      </span>
+                    </span>
+                    <Input
+                      value={titleValue}
+                      aria-invalid={titleInvalid || undefined}
+                      onChange={(event) =>
+                        updateTitleEdit(track, event.target.value)
+                      }
+                      maxLength={MAX_TITLE_LENGTH}
+                      className="h-7 py-1 text-sm"
+                    />
+                    {titleInvalid && (
+                      <span className="block text-xs text-amber-600 dark:text-amber-400">
+                        Title is required before publish.
+                      </span>
+                    )}
+                  </label>
+
+                  {rowAction === "saving" && (
+                    <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <Loader2 className="size-3 animate-spin" aria-hidden />
+                      Saving…
+                    </p>
+                  )}
+                  {rowAction === "deleting" && (
+                    <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <Loader2 className="size-3 animate-spin" aria-hidden />
+                      Deleting…
+                    </p>
+                  )}
+
+                  <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-1.5">
+                    <p className="text-[11px] text-muted-foreground">
+                      {isDirty
+                        ? "Unsaved title changes."
+                        : "Title saved to draft."}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={!isDirty || busy !== null || isRowBusy}
+                      onClick={() => void saveTrackTitle(track)}
+                    >
+                      {rowAction === "saving" ? (
+                        <Loader2 className="mr-1 size-3.5 animate-spin" aria-hidden />
+                      ) : (
+                        <Save className="mr-1 size-3.5" aria-hidden />
+                      )}
+                      Save
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <CmsPublishToolbar
+        section="audio"
+        sectionLabel="Audio portfolio"
+        hasDraftOnServer={hasDraftOnServer}
+        hasLocalEdits={hasLocalEdits}
+        publishedAt={data.publishedAt}
+        publishedByLabel={publishedByLabel}
+        busy={busy}
+        onPublish={() => void handlePublish()}
+        onDiscardConfirm={handleDiscardConfirm}
+        previewHref="/preview"
+        inlineError={inlineError}
+        autosaveStatus="idle"
+      />
+
+      <AlertDialog
+        open={deleteStableId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteStableId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete track?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the track from the draft and deletes its storage file
+              when nothing else references it.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
+            >
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
+              onClick={() => void handleDeleteConfirm()}
+            >
+              {deleteStableId && rowBusy[deleteStableId] === "deleting" ? (
+                <>
+                  <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+                  Deleting…
+                </>
+              ) : (
+                "Delete track"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -743,10 +743,12 @@ function AudioEditorForm() {
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
     if (hasDraftOnServer) {
+      setBusy("Discarding…");
       const outcome = await runAdminEffect(
         convexMutationEffect(() => discardDraftAudioTracks({})),
         { onErrorMessage: setInlineError },
       );
+      setBusy(null);
       if (outcome === undefined) {
         return false;
       }

--- a/src/app/admin/audio/page.tsx
+++ b/src/app/admin/audio/page.tsx
@@ -1,5 +1,15 @@
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+
+const AudioEditor = dynamic(
+  () => import("./audio-editor").then((m) => ({ default: m.AudioEditor })),
+  {
+    loading: () => (
+      <p className="body-text text-muted-foreground">Loading audio…</p>
+    ),
+  },
+);
 
 export const metadata: Metadata = {
   title: "Audio",
@@ -9,13 +19,9 @@ export default function AudioPage() {
   return (
     <>
       <AdminHeader title="Audio" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-4xl">
-          <div className="rounded-lg border border-border bg-muted/50 p-8 text-center">
-            <p className="body-text text-muted-foreground">
-              Audio sample management coming soon.
-            </p>
-          </div>
+      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
+        <div className="mx-auto max-w-5xl">
+          <AudioEditor />
         </div>
       </div>
     </>

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -3,11 +3,30 @@
 import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import type { PublishedAudioTrack } from "@/components/audio-portfolio";
 import type { GalleryPhoto } from "@/components/the-space";
 
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
 type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
 type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos> | null;
+type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks> | null;
+
+function toPublishedAudioTracks(
+  rows:
+    | Array<{ stableId: string; title: string; url: string | null }>
+    | undefined,
+): PublishedAudioTrack[] | undefined {
+  if (rows === undefined) {
+    return undefined;
+  }
+  return rows
+    .filter((r): r is typeof r & { url: string } => r.url !== null)
+    .map((r) => ({
+      stableId: r.stableId,
+      title: r.title,
+      url: r.url,
+    }));
+}
 
 function PhotosData({
   preloaded,
@@ -42,81 +61,177 @@ function PhotosLive({
   return <>{children(photos)}</>;
 }
 
+function AudioData({
+  preloaded,
+  children,
+}: {
+  preloaded: PreloadedAudio;
+  children: (
+    audioTracks: PublishedAudioTrack[] | undefined,
+  ) => React.ReactNode;
+}) {
+  if (preloaded) {
+    return <AudioFromPreload preloaded={preloaded}>{children}</AudioFromPreload>;
+  }
+  return <AudioLive>{children}</AudioLive>;
+}
+
+function AudioFromPreload({
+  preloaded,
+  children,
+}: {
+  preloaded: NonNullable<PreloadedAudio>;
+  children: (
+    audioTracks: PublishedAudioTrack[] | undefined,
+  ) => React.ReactNode;
+}) {
+  const rows = usePreloadedQuery(preloaded);
+  return <>{children(toPublishedAudioTracks(rows))}</>;
+}
+
+function AudioLive({
+  children,
+}: {
+  children: (
+    audioTracks: PublishedAudioTrack[] | undefined,
+  ) => React.ReactNode;
+}) {
+  const rows = useQuery(api.public.getPublishedAudioTracks);
+  return <>{children(toPublishedAudioTracks(rows))}</>;
+}
+
 function BothPreloaded({
   preloadedPricing,
   preloadedGear,
   photos,
+  audioTracks,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
+  audioTracks: PublishedAudioTrack[] | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = usePreloadedQuery(preloadedGear);
-  return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
+  return (
+    <HomepageShell
+      pricingFlags={pricingFlags}
+      gear={gear}
+      photos={photos}
+      audioTracks={audioTracks}
+    />
+  );
 }
 
 function PricingPreloadedGearLive({
   preloadedPricing,
   photos,
+  audioTracks,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   photos: GalleryPhoto[] | undefined;
+  audioTracks: PublishedAudioTrack[] | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = useQuery(api.public.getPublishedGear);
-  return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
+  return (
+    <HomepageShell
+      pricingFlags={pricingFlags}
+      gear={gear}
+      photos={photos}
+      audioTracks={audioTracks}
+    />
+  );
 }
 
 function PricingLiveGearPreloaded({
   preloadedGear,
   photos,
+  audioTracks,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
+  audioTracks: PublishedAudioTrack[] | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = usePreloadedQuery(preloadedGear);
-  return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
+  return (
+    <HomepageShell
+      pricingFlags={pricingFlags}
+      gear={gear}
+      photos={photos}
+      audioTracks={audioTracks}
+    />
+  );
 }
 
-function BothLive({ photos }: { photos: GalleryPhoto[] | undefined }) {
+function BothLive({
+  photos,
+  audioTracks,
+}: {
+  photos: GalleryPhoto[] | undefined;
+  audioTracks: PublishedAudioTrack[] | undefined;
+}) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = useQuery(api.public.getPublishedGear);
-  return <HomepageShell pricingFlags={pricingFlags} gear={gear} photos={photos} />;
+  return (
+    <HomepageShell
+      pricingFlags={pricingFlags}
+      gear={gear}
+      photos={photos}
+      audioTracks={audioTracks}
+    />
+  );
 }
 
 export function HomeClient({
   preloadedPricing,
   preloadedGear,
   preloadedPhotos,
+  preloadedAudio,
 }: {
   preloadedPricing: PreloadedPricing;
   preloadedGear: PreloadedGear;
   preloadedPhotos: PreloadedPhotos;
+  preloadedAudio: PreloadedAudio;
 }) {
   return (
     <PhotosData preloaded={preloadedPhotos}>
-      {(photos) => {
-        if (preloadedPricing && preloadedGear) {
-          return (
-            <BothPreloaded
-              preloadedPricing={preloadedPricing}
-              preloadedGear={preloadedGear}
-              photos={photos}
-            />
-          );
-        }
-        if (preloadedPricing) {
-          return (
-            <PricingPreloadedGearLive preloadedPricing={preloadedPricing} photos={photos} />
-          );
-        }
-        if (preloadedGear) {
-          return <PricingLiveGearPreloaded preloadedGear={preloadedGear} photos={photos} />;
-        }
-        return <BothLive photos={photos} />;
-      }}
+      {(photos) => (
+        <AudioData preloaded={preloadedAudio}>
+          {(audioTracks) => {
+            if (preloadedPricing && preloadedGear) {
+              return (
+                <BothPreloaded
+                  preloadedPricing={preloadedPricing}
+                  preloadedGear={preloadedGear}
+                  photos={photos}
+                  audioTracks={audioTracks}
+                />
+              );
+            }
+            if (preloadedPricing) {
+              return (
+                <PricingPreloadedGearLive
+                  preloadedPricing={preloadedPricing}
+                  photos={photos}
+                  audioTracks={audioTracks}
+                />
+              );
+            }
+            if (preloadedGear) {
+              return (
+                <PricingLiveGearPreloaded
+                  preloadedGear={preloadedGear}
+                  photos={photos}
+                  audioTracks={audioTracks}
+                />
+              );
+            }
+            return <BothLive photos={photos} audioTracks={audioTracks} />;
+          }}
+        </AudioData>
+      )}
     </PhotosData>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,32 +5,52 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
   try {
-    const [pricingSettled, gearSettled, photosSettled] = await Promise.allSettled([
-      preloadQuery(api.public.getPublishedPricingFlags),
-      preloadQuery(api.public.getPublishedGear),
-      preloadQuery(api.public.getPublishedGalleryPhotos),
-    ]);
+    const [pricingSettled, gearSettled, photosSettled, audioSettled] =
+      await Promise.allSettled([
+        preloadQuery(api.public.getPublishedPricingFlags),
+        preloadQuery(api.public.getPublishedGear),
+        preloadQuery(api.public.getPublishedGalleryPhotos),
+        preloadQuery(api.public.getPublishedAudioTracks),
+      ]);
     const preloadedPricing =
       pricingSettled.status === "fulfilled" ? pricingSettled.value : null;
     const preloadedGear =
       gearSettled.status === "fulfilled" ? gearSettled.value : null;
     const preloadedPhotos =
       photosSettled.status === "fulfilled" ? photosSettled.value : null;
+    const preloadedAudio =
+      audioSettled.status === "fulfilled" ? audioSettled.value : null;
     if (
       preloadedPricing === null &&
       preloadedGear === null &&
-      preloadedPhotos === null
+      preloadedPhotos === null &&
+      preloadedAudio === null
     ) {
-      return <HomepageShell pricingFlags={null} gear={null} photos={null} />;
+      return (
+        <HomepageShell
+          pricingFlags={null}
+          gear={null}
+          photos={null}
+          audioTracks={null}
+        />
+      );
     }
     return (
       <HomeClient
         preloadedPricing={preloadedPricing}
         preloadedGear={preloadedGear}
         preloadedPhotos={preloadedPhotos}
+        preloadedAudio={preloadedAudio}
       />
     );
   } catch {
-    return <HomepageShell pricingFlags={null} gear={null} photos={null} />;
+    return (
+      <HomepageShell
+        pricingFlags={null}
+        gear={null}
+        photos={null}
+        audioTracks={null}
+      />
+    );
   }
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "convex/react";
 import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import type { PublishedAudioTrack } from "@/components/audio-portfolio";
 import { PreviewBanner } from "@/components/preview-banner";
 
 function PreviewContent() {
@@ -12,6 +13,7 @@ function PreviewContent() {
   );
   const gearPreview = useQuery(api.gearPreviewDraft.getPreviewGear);
   const photoPreview = useQuery(api.photosPreviewDraft.getPreviewGalleryPhotos);
+  const audioPreview = useQuery(api.audioPreviewDraft.getPreviewAudioTracks);
   // INF-46: surface the draft About visibility in the homepage nav so owners
   // can confirm the feature-flag toggle before publishing. Preview query is
   // owner-only and returns `null` for non-owners.
@@ -21,6 +23,7 @@ function PreviewContent() {
     pricingFlags === undefined ||
     gearPreview === undefined ||
     photoPreview === undefined ||
+    audioPreview === undefined ||
     aboutPreview === undefined
   ) {
     return (
@@ -34,6 +37,7 @@ function PreviewContent() {
     pricingFlags === null ||
     gearPreview === null ||
     photoPreview === null ||
+    audioPreview === null ||
     aboutPreview === null
   ) {
     return (
@@ -49,7 +53,16 @@ function PreviewContent() {
     pricingFlags.hasDraftChanges ||
     gearPreview.hasDraftChanges ||
     photoPreview.hasDraftChanges ||
+    audioPreview.hasDraftChanges ||
     aboutPreview.hasDraftChanges;
+
+  const audioTracks: PublishedAudioTrack[] = audioPreview.tracks
+    .filter((t): t is typeof t & { url: string } => t.url !== null)
+    .map((t) => ({
+      stableId: t.stableId,
+      title: t.title,
+      url: t.url,
+    }));
 
   return (
     <HomepageShell
@@ -59,6 +72,7 @@ function PreviewContent() {
       }}
       gear={{ categories: gearPreview.categories }}
       photos={photoPreview.photos}
+      audioTracks={audioTracks}
       aboutVisibility={{ published: aboutPreview.published === true }}
       banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -1,102 +1,79 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 
-// Audio portfolio data - in a real implementation, this would come from a CMS or database
-const AUDIO_SAMPLES = [
-  {
-    id: 1,
-    title: "Indie Rock Album",
-    artist: "Mountain Echo",
-    genre: "Indie Rock",
-    description: "Full album recording featuring dynamic drums and atmospheric guitars",
-    audioSrc: "/audio/sample-1.mp3", // Placeholder - would be real audio files
-    coverImage: "/placeholder-album-1.jpg"
-  },
-  {
-    id: 2,
-    title: "Folk EP",
-    artist: "River Stones",
-    genre: "Folk",
-    description: "Intimate acoustic recording with natural room ambience",
-    audioSrc: "/audio/sample-2.mp3",
-    coverImage: "/placeholder-album-2.jpg"
-  },
-  {
-    id: 3,
-    title: "Electronic Single",
-    artist: "Digital Forest",
-    genre: "Electronic",
-    description: "Hybrid recording blending organic and electronic elements",
-    audioSrc: "/audio/sample-3.mp3",
-    coverImage: "/placeholder-album-3.jpg"
-  }
-] as const;
+export type PublishedAudioTrack = {
+  readonly stableId: string;
+  readonly title: string;
+  readonly url: string;
+};
 
-export function AudioPortfolio() {
+type AudioPortfolioProps = {
+  /** Published or preview tracks with signed URLs. Empty array shows a quiet empty state. */
+  readonly tracks: PublishedAudioTrack[] | null | undefined;
+};
+
+export function AudioPortfolio({ tracks }: AudioPortfolioProps) {
+  const list = tracks ?? [];
+
   return (
-    <section id="audio-portfolio" className="py-20 px-4 bg-forest relative">
-      <div className="absolute inset-0 opacity-20 bg-texture-stone"></div>
-      
-      <div className="relative z-10 max-w-6xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-sand mb-6 font-acumin">
+    <section id="audio-portfolio" className="relative bg-forest px-4 py-20">
+      <div className="absolute inset-0 bg-texture-stone opacity-20" />
+
+      <div className="relative z-10 mx-auto max-w-6xl">
+        <div className="mb-16 text-center">
+          <h2 className="mb-6 font-acumin text-3xl font-bold text-sand md:text-4xl">
             STUDIO PORTFOLIO
           </h2>
-          <p className="text-lg text-ivory/80 font-titillium max-w-3xl mx-auto leading-relaxed">
-            Listen to the quality and character that artists achieve at Lula Lake Sound. 
-            From intimate acoustic sessions to full band recordings, hear how our space and expertise bring out the best in every project.
+          <p className="mx-auto max-w-3xl font-titillium text-lg leading-relaxed text-ivory/80">
+            Listen to the quality and character that artists achieve at Lula Lake
+            Sound. From intimate acoustic sessions to full band recordings, hear how
+            our space and expertise bring out the best in every project.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
-          {AUDIO_SAMPLES.map((sample) => (
-            <div key={sample.id} className="bg-washed-black/60 border border-sage/30 rounded-sm p-6 hover:border-sand/50 transition-colors">
-              {/* Album Art Placeholder */}
-              <div className="aspect-square bg-sage/20 rounded-sm mb-4 flex items-center justify-center">
-                <div className="text-sage/60 text-sm font-titillium text-center">
-                  <div className="w-12 h-12 bg-sage/40 rounded-sm mx-auto mb-2"></div>
-                  Album Art
-                </div>
+        {list.length === 0 ? (
+          <div className="mx-auto mb-12 max-w-xl rounded-sm border border-sage/30 bg-washed-black/40 px-6 py-10 text-center">
+            <p className="font-titillium text-sm text-ivory/60">
+              Audio samples will appear here once they are published from the studio
+              CMS.
+            </p>
+          </div>
+        ) : (
+          <div className="mb-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {list.map((track) => (
+              <div
+                key={track.stableId}
+                className="rounded-sm border border-sage/30 bg-washed-black/60 p-6 transition-colors hover:border-sand/50"
+              >
+                <h3 className="mb-4 font-acumin text-lg font-bold text-sand">
+                  {track.title}
+                </h3>
+                <audio
+                  controls
+                  preload="metadata"
+                  src={track.url}
+                  className="h-10 w-full max-w-full"
+                />
               </div>
-              
-              {/* Track Info */}
-              <div className="mb-4">
-                <h3 className="text-sand font-acumin font-bold text-lg mb-1">{sample.title}</h3>
-                <p className="text-ivory/70 font-titillium text-sm mb-1">{sample.artist}</p>
-                <span className="text-sage/80 font-titillium text-xs uppercase tracking-wide">{sample.genre}</span>
-              </div>
-              
-              <p className="text-ivory/60 font-titillium text-sm mb-4 leading-relaxed">
-                {sample.description}
-              </p>
-              
-              {/* Audio Player Placeholder */}
-              <div className="bg-sage/10 border border-sage/30 rounded-sm p-3 mb-4">
-                <div className="flex items-center space-x-3">
-                  <button className="w-8 h-8 bg-sand rounded-full flex items-center justify-center hover:bg-sand/80 transition-colors">
-                    <svg className="w-4 h-4 text-washed-black ml-0.5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8 5v14l11-7z"/>
-                    </svg>
-                  </button>
-                  <div className="flex-1 h-2 bg-sage/30 rounded-full">
-                    <div className="h-full bg-sand rounded-full" style={{ width: '0%' }}></div>
-                  </div>
-                  <span className="text-ivory/50 font-titillium text-xs">0:00</span>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
 
-        {/* CTA Section */}
         <div className="text-center">
-          <p className="text-ivory/70 font-titillium mb-6">
+          <p className="mb-6 font-titillium text-ivory/70">
             Ready to create something extraordinary?
           </p>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             size="lg"
             className="h-10 px-6"
-            onClick={() => document.getElementById('artist-inquiries')?.scrollIntoView({ behavior: 'smooth' })}
+            type="button"
+            onClick={() =>
+              document
+                .getElementById("artist-inquiries")
+                ?.scrollIntoView({ behavior: "smooth" })
+            }
           >
             START YOUR PROJECT
           </Button>
@@ -104,4 +81,4 @@ export function AudioPortfolio() {
       </div>
     </section>
   );
-} 
+}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -12,8 +12,10 @@ import { FAQ } from "@/components/faq";
 import { Header } from "@/components/header";
 import { Hero } from "@/components/hero";
 import { SiteFooter } from "@/components/site-footer";
+import { AudioPortfolio } from "@/components/audio-portfolio";
 import { TheSpace, type GalleryPhoto } from "@/components/the-space";
 import type { PricingFlags } from "@/lib/site-settings";
+import type { PublishedAudioTrack } from "@/components/audio-portfolio";
 
 function calculateLogoScale(scrollY: number): number {
   return Math.max(0.7, 1 - scrollY * 0.0006);
@@ -29,6 +31,8 @@ interface HomepageShellProps {
   readonly gear: GearPayload | null | undefined;
   /** Published (or preview) gallery payload. */
   readonly photos: GalleryPhoto[] | null | undefined;
+  /** Published (or preview) audio tracks with playable URLs. */
+  readonly audioTracks: PublishedAudioTrack[] | null | undefined;
   /**
    * INF-46 About-page visibility flag. `null` / `undefined` keeps the nav
    * link hidden — the About page is opt-in via the CMS.
@@ -44,6 +48,7 @@ export function HomepageShell({
   pricingFlags,
   gear,
   photos,
+  audioTracks,
   aboutVisibility,
   banner,
 }: HomepageShellProps) {
@@ -121,6 +126,7 @@ export function HomepageShell({
 
       <main className="relative z-10">
         <TheSpace photos={photos} />
+        <AudioPortfolio tracks={audioTracks} />
         <EquipmentSpecs gear={gear} />
         <MarketingPricingSection pricingFlags={pricingFlags} />
         <AmenitiesNearby />

--- a/src/lib/route-prewarm.ts
+++ b/src/lib/route-prewarm.ts
@@ -93,6 +93,11 @@ export function prewarmAdminNavigation(
       makeRouteQuerySpec(api.cms.getSection, { section: "pricing" }),
     ]);
   }
+  if (href === "/admin/audio") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.audio.listDraftAudioTracks, {}),
+    ]);
+  }
 }
 
 type PrewarmFn = () => void | Promise<void>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Audio** admin experience from INF-96: draft/publish for portfolio tracks, uploads with type/size validation, drag-and-arrow reorder, inline `<audio>` preview, and **replace file** via patch-then-delete-old-storage for a safe swap. Errors surface through the existing **Effect + Sonner** admin path (`runAdminEffect` / `toast`).

## Backend

- New tables: `audioTrackMeta`, `audioTracks` (draft/published scopes, same pattern as gallery photos).
- `convex/admin/audio.ts`: list, upload URL, save, title update, **replace** (atomic row update then `deleteStorageIfUnreferencedAcrossCms`), reorder, remove, publish, discard.
- `convex/audioTracks.ts`: shared helpers; storage delete checks **both** `galleryPhotos` and `audioTracks` so cross-references stay safe.
- `api.public.getPublishedAudioTracks` for the live site; `audioPreviewDraft.getPreviewAudioTracks` for `/preview`.
- `admin.publish.publishSite` now validates and publishes pending audio drafts alongside gallery.

## Frontend

- `/admin/audio` loads a dynamic `AudioEditor` (aligned with photos admin layout).
- Homepage + preview: `AudioPortfolio` renders published/preview tracks with native audio controls; `page.tsx` preloads audio with other homepage data.

## Note

`convex/_generated/api.d.ts` was updated manually for `admin/audio`, `audioTracks`, and `audioPreviewDraft` because codegen was not available in this environment. Running `bunx convex dev` locally will reconcile generated files with the deployment.

## Testing

- `bun run lint`
- `bun run build`
- `bun test`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-96](https://linear.app/only-football-fans/issue/INF-96/lls-audio-admin-ui-upload-replace-reorder-draftpublish)

<div><a href="https://cursor.com/agents/bc-752f821a-71aa-4c42-b156-6890f795f582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-752f821a-71aa-4c42-b156-6890f795f582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

