### PR TITLE
Demo: metadataBase + 404 headline tweak

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,6 +89,7 @@ const titillium = localFont({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://lulalakesound.com"),
   title: "Lula Lake Sound | Recording Studio | Chattanooga, TN",
   description:
     "Nestled in serene mountains just outside of Chattanooga, TN - Lula Lake Sound offers artists a natural creative refuge with state-of-the-art equipment and breathtaking surroundings.",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -57,7 +57,7 @@ export default function NotFound() {
         <p className="label-text text-gold/70 tracking-[0.2em] mb-3">404 &mdash; Dead Air</p>
 
         <h1 className="headline-primary text-warm-white text-[clamp(1.75rem,4vw,2.75rem)] mb-3">
-          Nothing on this channel
+          This track isn&apos;t cued
         </h1>
 
         <p className="body-text text-ivory/50 max-w-sm mx-auto mb-10">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two small, isolated edits for a clean diff demo.

- **Site metadata:** Set `metadataBase` to `https://lulalakesound.com` so relative URLs in metadata resolve consistently for Open Graph and social previews.
- **404 page:** Refresh the main headline to studio-flavored copy while keeping the rest of the page unchanged.

Lint passes (`bun run lint`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223003c9-c6e4-4c34-8c08-dbfec17acc0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223003c9-c6e4-4c34-8c08-dbfec17acc0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

