### PR TITLE
chore(convex): regenerate api.d.ts for cms refactor

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as aboutPreviewDraft from "../aboutPreviewDraft.js";
 import type * as aboutTeamStorage from "../aboutTeamStorage.js";
+import type * as aboutTree from "../aboutTree.js";
 import type * as admin_about from "../admin/about.js";
 import type * as admin_aboutTeam from "../admin/aboutTeam.js";
 import type * as admin_gear from "../admin/gear.js";
@@ -18,6 +19,7 @@ import type * as admin_pricing from "../admin/pricing.js";
 import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
 import type * as cms from "../cms.js";
+import type * as cmsMeta from "../cmsMeta.js";
 import type * as cmsPublishHelpers from "../cmsPublishHelpers.js";
 import type * as cmsShared from "../cmsShared.js";
 import type * as errors from "../errors.js";
@@ -28,17 +30,18 @@ import type * as gearPreviewDraft from "../gearPreviewDraft.js";
 import type * as gearTree from "../gearTree.js";
 import type * as inquiries from "../inquiries.js";
 import type * as lib_auth from "../lib/auth.js";
-import type * as lib_legacyCmsFieldStrip from "../lib/legacyCmsFieldStrip.js";
 import type * as lib_sentryConvex from "../lib/sentryConvex.js";
-import type * as marketingFeatureFlags from "../marketingFeatureFlags.js";
+import type * as migrations_extractSectionContent from "../migrations/extractSectionContent.js";
 import type * as migrations_gearFromEquipmentSpecs from "../migrations/gearFromEquipmentSpecs.js";
 import type * as observability from "../observability.js";
 import type * as photosPreviewDraft from "../photosPreviewDraft.js";
 import type * as pricingPreviewDraft from "../pricingPreviewDraft.js";
+import type * as pricingTree from "../pricingTree.js";
 import type * as public_ from "../public.js";
 import type * as publicSettingsSnapshot from "../publicSettingsSnapshot.js";
 import type * as seed from "../seed.js";
 import type * as sentryNodeReport from "../sentryNodeReport.js";
+import type * as settingsTree from "../settingsTree.js";
 import type * as siteSettingsPreviewDraft from "../siteSettingsPreviewDraft.js";
 
 import type {
@@ -50,6 +53,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   aboutPreviewDraft: typeof aboutPreviewDraft;
   aboutTeamStorage: typeof aboutTeamStorage;
+  aboutTree: typeof aboutTree;
   "admin/about": typeof admin_about;
   "admin/aboutTeam": typeof admin_aboutTeam;
   "admin/gear": typeof admin_gear;
@@ -58,6 +62,7 @@ declare const fullApi: ApiFromModules<{
   "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
   cms: typeof cms;
+  cmsMeta: typeof cmsMeta;
   cmsPublishHelpers: typeof cmsPublishHelpers;
   cmsShared: typeof cmsShared;
   errors: typeof errors;
@@ -68,17 +73,18 @@ declare const fullApi: ApiFromModules<{
   gearTree: typeof gearTree;
   inquiries: typeof inquiries;
   "lib/auth": typeof lib_auth;
-  "lib/legacyCmsFieldStrip": typeof lib_legacyCmsFieldStrip;
   "lib/sentryConvex": typeof lib_sentryConvex;
-  marketingFeatureFlags: typeof marketingFeatureFlags;
+  "migrations/extractSectionContent": typeof migrations_extractSectionContent;
   "migrations/gearFromEquipmentSpecs": typeof migrations_gearFromEquipmentSpecs;
   observability: typeof observability;
   photosPreviewDraft: typeof photosPreviewDraft;
   pricingPreviewDraft: typeof pricingPreviewDraft;
+  pricingTree: typeof pricingTree;
   public: typeof public_;
   publicSettingsSnapshot: typeof publicSettingsSnapshot;
   seed: typeof seed;
   sentryNodeReport: typeof sentryNodeReport;
+  settingsTree: typeof settingsTree;
   siteSettingsPreviewDraft: typeof siteSettingsPreviewDraft;
 }>;
 


### PR DESCRIPTION
Picks up the new cms marketing-flags queries/mutations and drops the deleted marketingFeatureFlags module so the generated API matches the reshaped cmsSections + scoped content tables.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the generated `convex/_generated/api.d.ts` type surface to match existing Convex modules; runtime behavior doesn’t change, but TypeScript callers may need updates if they referenced removed endpoints.
> 
> **Overview**
> Regenerates `convex/_generated/api.d.ts` to reflect the reshaped Convex modules.
> 
> The generated API now includes new entries like `cmsMeta`, `aboutTree`, `pricingTree`, `settingsTree`, and `migrations/extractSectionContent`, and drops removed modules such as `marketingFeatureFlags` and `lib/legacyCmsFieldStrip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c49c2214341dc4e526c35d8a45a207e0e11ff1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->