### PR TITLE
test: unit tests for convex + CMS admin frontend helpers

### DIFF
--- a/convex/aboutTeamStorage.test.ts
+++ b/convex/aboutTeamStorage.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_ABOUT_TEAM_MEMBERS } from "./aboutTeamStorage";
+
+describe("MAX_ABOUT_TEAM_MEMBERS", () => {
+  test("is positive and reasonably small", () => {
+    expect(MAX_ABOUT_TEAM_MEMBERS).toBeGreaterThan(0);
+    expect(MAX_ABOUT_TEAM_MEMBERS).toBeLessThan(1000);
+  });
+
+  test("is currently 20 — keep in sync with the admin editor cap", () => {
+    expect(MAX_ABOUT_TEAM_MEMBERS).toBe(20);
+  });
+});

--- a/convex/aboutTree.test.ts
+++ b/convex/aboutTree.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  ABOUT_CONTENT_DEFAULTS,
+  aboutDraftMatchesPublished,
+  collectAboutTeamStorageIdsFromTree,
+  normalizeAboutTreeForCompare,
+  type AboutTree,
+} from "./aboutTree";
+
+type ContentDoc = Doc<"aboutContent">;
+type HighlightDoc = Doc<"aboutHighlights">;
+type TeamMemberDoc = Doc<"aboutTeamMembers">;
+
+const baseDoc = {
+  _id: "row" as unknown as Id<"aboutContent">,
+  _creationTime: 0,
+};
+
+function contentDoc(patch: Partial<ContentDoc> = {}): ContentDoc {
+  return {
+    ...baseDoc,
+    scope: "draft",
+    heroTitle: "Hello",
+    ...patch,
+  } as ContentDoc;
+}
+
+function highlight(patch: Partial<HighlightDoc> = {}): HighlightDoc {
+  return {
+    ...baseDoc,
+    _id: `h-${patch.stableId ?? "x"}` as unknown as Id<"aboutHighlights">,
+    scope: "draft",
+    stableId: "h1",
+    text: "one",
+    sort: 0,
+    ...patch,
+  } as HighlightDoc;
+}
+
+function member(patch: Partial<TeamMemberDoc> = {}): TeamMemberDoc {
+  return {
+    ...baseDoc,
+    _id: `m-${patch.stableId ?? "x"}` as unknown as Id<"aboutTeamMembers">,
+    scope: "draft",
+    stableId: "m1",
+    name: "Alice",
+    title: "Engineer",
+    sort: 0,
+    ...patch,
+  } as TeamMemberDoc;
+}
+
+function emptyTree(patch: Partial<AboutTree> = {}): AboutTree {
+  return {
+    content: null,
+    highlights: [],
+    teamMembers: [],
+    ...patch,
+  };
+}
+
+describe("ABOUT_CONTENT_DEFAULTS", () => {
+  test("ships a hero title and a paragraph body block", () => {
+    expect(ABOUT_CONTENT_DEFAULTS.heroTitle.length).toBeGreaterThan(0);
+    expect(ABOUT_CONTENT_DEFAULTS.bodyBlocks?.[0].type).toBe("paragraph");
+  });
+});
+
+describe("normalizeAboutTreeForCompare", () => {
+  test("returns null content when tree is empty", () => {
+    const shape = normalizeAboutTreeForCompare(emptyTree());
+    expect((shape as { content: unknown }).content).toBeNull();
+  });
+
+  test("coerces missing optional fields to null for stability", () => {
+    const tree = emptyTree({ content: contentDoc() });
+    const shape = normalizeAboutTreeForCompare(tree) as {
+      content: Record<string, unknown>;
+    };
+    expect(shape.content.heroSubtitle).toBeNull();
+    expect(shape.content.bodyHtml).toBeNull();
+    expect(shape.content.bodyBlocks).toBeNull();
+    expect(shape.content.pullQuote).toBeNull();
+    expect(shape.content.heroImageStorageId).toBeNull();
+  });
+
+  test("sorts highlights by sort, ties broken by stableId", () => {
+    const tree = emptyTree({
+      highlights: [
+        highlight({ stableId: "b", sort: 1 }),
+        highlight({ stableId: "a", sort: 1 }),
+        highlight({ stableId: "c", sort: 0 }),
+      ],
+    });
+    const shape = normalizeAboutTreeForCompare(tree) as {
+      highlights: { stableId: string }[];
+    };
+    expect(shape.highlights.map((h) => h.stableId)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  test("team members normalize storageId to null when absent", () => {
+    const tree = emptyTree({ teamMembers: [member()] });
+    const shape = normalizeAboutTreeForCompare(tree) as {
+      teamMembers: { storageId: unknown }[];
+    };
+    expect(shape.teamMembers[0].storageId).toBeNull();
+  });
+});
+
+describe("aboutDraftMatchesPublished", () => {
+  test("matches empty draft + published trees", () => {
+    expect(aboutDraftMatchesPublished(emptyTree(), emptyTree())).toBe(true);
+  });
+
+  test("matches identical populated trees", () => {
+    const h = highlight({ stableId: "h", text: "cool", sort: 1 });
+    const m = member({ stableId: "m", name: "A", title: "B" });
+    const c = contentDoc();
+    const tree: AboutTree = {
+      content: c,
+      highlights: [h],
+      teamMembers: [m],
+    };
+    expect(aboutDraftMatchesPublished(tree, tree)).toBe(true);
+  });
+
+  test("mismatched heroTitle is not equal", () => {
+    const a: AboutTree = { content: contentDoc({ heroTitle: "A" }), highlights: [], teamMembers: [] };
+    const b: AboutTree = { content: contentDoc({ heroTitle: "B" }), highlights: [], teamMembers: [] };
+    expect(aboutDraftMatchesPublished(a, b)).toBe(false);
+  });
+
+  test("highlight reorder does not affect equality when sort is the same", () => {
+    const a: AboutTree = {
+      content: null,
+      highlights: [
+        highlight({ stableId: "b", sort: 0 }),
+        highlight({ stableId: "a", sort: 0 }),
+      ],
+      teamMembers: [],
+    };
+    const b: AboutTree = {
+      content: null,
+      highlights: [
+        highlight({ stableId: "a", sort: 0 }),
+        highlight({ stableId: "b", sort: 0 }),
+      ],
+      teamMembers: [],
+    };
+    // Normalization sorts by stableId when sort ties → equal trees.
+    expect(aboutDraftMatchesPublished(a, b)).toBe(true);
+  });
+});
+
+describe("collectAboutTeamStorageIdsFromTree", () => {
+  const sid = (s: string) => s as unknown as Id<"_storage">;
+
+  test("empty set for a tree without hero image or team members", () => {
+    const ids = collectAboutTeamStorageIdsFromTree(emptyTree());
+    expect(ids.size).toBe(0);
+  });
+
+  test("collects hero image storageId", () => {
+    const tree: AboutTree = {
+      content: contentDoc({ heroImageStorageId: sid("hero") }),
+      highlights: [],
+      teamMembers: [],
+    };
+    const ids = collectAboutTeamStorageIdsFromTree(tree);
+    expect(ids.has(sid("hero"))).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("collects team headshot storageIds (dedupes with hero)", () => {
+    const tree: AboutTree = {
+      content: contentDoc({ heroImageStorageId: sid("shared") }),
+      highlights: [],
+      teamMembers: [
+        member({ stableId: "m1", storageId: sid("m1") }),
+        member({ stableId: "m2", storageId: sid("shared") }),
+        member({ stableId: "m3" }),
+      ],
+    };
+    const ids = collectAboutTeamStorageIdsFromTree(tree);
+    expect(ids.size).toBe(2);
+    expect(ids.has(sid("m1"))).toBe(true);
+    expect(ids.has(sid("shared"))).toBe(true);
+  });
+});

--- a/convex/cmsMeta.test.ts
+++ b/convex/cmsMeta.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc } from "./_generated/dataModel";
+import {
+  DEFAULT_IS_ENABLED,
+  anyMarketingFlagDraftPending,
+  effectiveIsEnabled,
+  publishedIsEnabled,
+  sectionHasPendingFlagDraft,
+} from "./cmsMeta";
+
+type SectionRow = Doc<"cmsSections">;
+
+function row(patch: Partial<SectionRow> = {}): SectionRow {
+  return {
+    _id: "row1" as unknown as SectionRow["_id"],
+    _creationTime: 0,
+    section: "about",
+    hasDraftChanges: false,
+    publishedAt: null,
+    updatedAt: 0,
+    ...patch,
+  } as SectionRow;
+}
+
+describe("DEFAULT_IS_ENABLED", () => {
+  test("ships the pricing homepage block on", () => {
+    expect(DEFAULT_IS_ENABLED.pricing).toBe(true);
+    expect(DEFAULT_IS_ENABLED.settings).toBe(true);
+  });
+
+  test("about + recordings default to off (must be explicitly published)", () => {
+    expect(DEFAULT_IS_ENABLED.about).toBe(false);
+    expect(DEFAULT_IS_ENABLED.recordings).toBe(false);
+  });
+});
+
+describe("effectiveIsEnabled", () => {
+  test("null row falls back to section default", () => {
+    expect(effectiveIsEnabled(null, "pricing")).toBe(true);
+    expect(effectiveIsEnabled(null, "about")).toBe(false);
+  });
+
+  test("draft override wins over published value", () => {
+    const r = row({ isEnabled: false, isEnabledDraft: true });
+    expect(effectiveIsEnabled(r, "about")).toBe(true);
+  });
+
+  test("falls back to isEnabled when no draft", () => {
+    const r = row({ isEnabled: true });
+    expect(effectiveIsEnabled(r, "about")).toBe(true);
+  });
+
+  test("isEnabled undefined falls back to default", () => {
+    const r = row({ isEnabled: undefined });
+    expect(effectiveIsEnabled(r, "pricing")).toBe(true);
+    expect(effectiveIsEnabled(r, "about")).toBe(false);
+  });
+});
+
+describe("publishedIsEnabled", () => {
+  test("ignores draft even when set", () => {
+    const r = row({ isEnabled: false, isEnabledDraft: true });
+    expect(publishedIsEnabled(r, "about")).toBe(false);
+  });
+
+  test("falls back to section default when row is missing", () => {
+    expect(publishedIsEnabled(null, "pricing")).toBe(true);
+    expect(publishedIsEnabled(null, "about")).toBe(false);
+  });
+
+  test("falls back to default when isEnabled unset", () => {
+    const r = row({ isEnabled: undefined });
+    expect(publishedIsEnabled(r, "about")).toBe(false);
+  });
+});
+
+describe("sectionHasPendingFlagDraft", () => {
+  test("null row has no pending flag draft", () => {
+    expect(sectionHasPendingFlagDraft(null, "about")).toBe(false);
+  });
+
+  test("row with no draft has no pending flag draft", () => {
+    expect(sectionHasPendingFlagDraft(row(), "about")).toBe(false);
+  });
+
+  test("pending flag draft when draft differs from published", () => {
+    const r = row({ isEnabled: false, isEnabledDraft: true });
+    expect(sectionHasPendingFlagDraft(r, "about")).toBe(true);
+  });
+
+  test("no pending draft when draft matches published", () => {
+    const r = row({ isEnabled: true, isEnabledDraft: true });
+    expect(sectionHasPendingFlagDraft(r, "about")).toBe(false);
+  });
+
+  test("published unset → compares against section default", () => {
+    // Section default for about is false; draft true means pending.
+    const r = row({ isEnabledDraft: true });
+    expect(sectionHasPendingFlagDraft(r, "about")).toBe(true);
+    // Draft false equals default false → not pending.
+    const r2 = row({ isEnabledDraft: false });
+    expect(sectionHasPendingFlagDraft(r2, "about")).toBe(false);
+  });
+});
+
+describe("anyMarketingFlagDraftPending", () => {
+  test("false when no section has a flag draft", () => {
+    expect(
+      anyMarketingFlagDraftPending(row(), row(), row()),
+    ).toBe(false);
+  });
+
+  test("true when about has a pending flag draft", () => {
+    const about = row({ isEnabled: false, isEnabledDraft: true });
+    expect(
+      anyMarketingFlagDraftPending(about, row(), row()),
+    ).toBe(true);
+  });
+
+  test("true when recordings has a pending flag draft", () => {
+    const recordings = row({
+      section: "recordings",
+      isEnabled: false,
+      isEnabledDraft: true,
+    });
+    expect(
+      anyMarketingFlagDraftPending(row(), recordings, row()),
+    ).toBe(true);
+  });
+
+  test("true when pricing has a pending flag draft", () => {
+    const pricing = row({
+      section: "pricing",
+      isEnabled: true,
+      isEnabledDraft: false,
+    });
+    expect(
+      anyMarketingFlagDraftPending(row(), row(), pricing),
+    ).toBe(true);
+  });
+
+  test("null rows are tolerated", () => {
+    expect(anyMarketingFlagDraftPending(null, null, null)).toBe(false);
+  });
+});

--- a/convex/cmsPublishHelpers.test.ts
+++ b/convex/cmsPublishHelpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  DEFAULT_IS_ENABLED,
+  defaultSnapshotForSection,
+  effectiveIsEnabled,
+  publishedIsEnabled,
+  rowsWithPublishableDraft,
+  validatePricingPackageArray,
+} from "./cmsPublishHelpers";
+
+type Row = Doc<"cmsSections">;
+
+function row(patch: Partial<Row> = {}): Row {
+  return {
+    _id: ("row-" + (patch.section ?? "x")) as unknown as Id<"cmsSections">,
+    _creationTime: 0,
+    section: "about",
+    hasDraftChanges: false,
+    publishedAt: null,
+    updatedAt: 0,
+    ...patch,
+  } as Row;
+}
+
+describe("rowsWithPublishableDraft", () => {
+  test("returns only rows where hasDraftChanges is true", () => {
+    const rows = [
+      row({ section: "about", hasDraftChanges: true }),
+      row({ section: "pricing", hasDraftChanges: false }),
+      row({ section: "settings", hasDraftChanges: true }),
+    ];
+    const out = rowsWithPublishableDraft(rows);
+    expect(out.map((r) => r.section)).toEqual(["about", "settings"]);
+  });
+
+  test("empty input returns empty output", () => {
+    expect(rowsWithPublishableDraft([])).toEqual([]);
+  });
+
+  test("does not mutate the input", () => {
+    const rows = [
+      row({ section: "about", hasDraftChanges: true }),
+      row({ section: "pricing", hasDraftChanges: false }),
+    ];
+    const copy = [...rows];
+    rowsWithPublishableDraft(rows);
+    expect(rows).toEqual(copy);
+  });
+});
+
+describe("re-exports", () => {
+  test("exports DEFAULT_IS_ENABLED from cmsMeta", () => {
+    expect(DEFAULT_IS_ENABLED.pricing).toBe(true);
+  });
+
+  test("exports effectiveIsEnabled / publishedIsEnabled from cmsMeta", () => {
+    expect(effectiveIsEnabled(null, "pricing")).toBe(true);
+    expect(publishedIsEnabled(null, "about")).toBe(false);
+  });
+
+  test("exports defaultSnapshotForSection from cmsShared", () => {
+    const settings = defaultSnapshotForSection("settings");
+    expect(settings).toBeDefined();
+  });
+});
+
+describe("validatePricingPackageArray — additional coverage", () => {
+  const valid = {
+    stableId: "pkg_1",
+    name: "Recording",
+    priceCents: 6000,
+    currency: "USD",
+    billingCadence: "hourly",
+    sortOrder: 0,
+  };
+
+  test("flags missing currency", () => {
+    const issues = validatePricingPackageArray([
+      { ...valid, currency: "   " },
+    ]);
+    expect(issues.some((i) => i.path === "packages[0].currency")).toBe(true);
+  });
+
+  test("flags non-numeric sortOrder (NaN)", () => {
+    const issues = validatePricingPackageArray([
+      { ...valid, sortOrder: Number.NaN },
+    ]);
+    expect(issues.some((i) => i.path === "packages[0].sortOrder")).toBe(true);
+  });
+
+  test("flags empty stableId (requires a stable id)", () => {
+    const issues = validatePricingPackageArray([
+      { ...valid, stableId: "" },
+    ]);
+    expect(issues.some((i) => i.path === "packages[0].id")).toBe(true);
+  });
+
+  test("duplicate id reports once for the duplicate row", () => {
+    const issues = validatePricingPackageArray([
+      { ...valid },
+      { ...valid, name: "Dup" },
+    ]);
+    const idIssues = issues.filter((i) => i.path === "packages[1].id");
+    expect(idIssues.length).toBe(1);
+    expect(idIssues[0].message).toContain("Duplicate");
+  });
+});

--- a/convex/cmsShared.test.ts
+++ b/convex/cmsShared.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ABOUT_DEFAULTS,
+  DEFAULT_PRICING_PACKAGES,
+  MARKETING_FEATURE_FLAGS_DEFAULTS,
+  PRICING_DEFAULTS,
+  SETTINGS_DEFAULTS,
+  billingCadenceLabel,
+  cmsSnapshotsEqual,
+  defaultSnapshotForSection,
+  settingsSnapshotsEqual,
+} from "./cmsShared";
+
+describe("SETTINGS_DEFAULTS", () => {
+  test("exposes a non-empty title + description", () => {
+    expect(SETTINGS_DEFAULTS.metadata?.title).toBeTruthy();
+    expect(SETTINGS_DEFAULTS.metadata?.description).toBeTruthy();
+  });
+});
+
+describe("DEFAULT_PRICING_PACKAGES", () => {
+  test("ships with at least one package", () => {
+    expect(DEFAULT_PRICING_PACKAGES.length).toBeGreaterThan(0);
+  });
+
+  test("every package has a valid shape", () => {
+    for (const pkg of DEFAULT_PRICING_PACKAGES) {
+      expect(typeof pkg.id).toBe("string");
+      expect(pkg.id.length).toBeGreaterThan(0);
+      expect(typeof pkg.name).toBe("string");
+      expect(Number.isInteger(pkg.priceCents)).toBe(true);
+      expect(pkg.priceCents).toBeGreaterThanOrEqual(0);
+      expect(typeof pkg.currency).toBe("string");
+      expect(pkg.currency.length).toBeGreaterThan(0);
+      expect(typeof pkg.highlight).toBe("boolean");
+      expect(typeof pkg.isActive).toBe("boolean");
+    }
+  });
+
+  test("exactly one default is the highlight", () => {
+    const highlighted = DEFAULT_PRICING_PACKAGES.filter((p) => p.highlight);
+    expect(highlighted.length).toBe(1);
+  });
+
+  test("default ids are unique", () => {
+    const ids = DEFAULT_PRICING_PACKAGES.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("sort orders are strictly ascending", () => {
+    const sorts = DEFAULT_PRICING_PACKAGES.map((p) => p.sortOrder);
+    const sorted = [...sorts].sort((a, b) => a - b);
+    expect(sorts).toEqual(sorted);
+  });
+});
+
+describe("PRICING_DEFAULTS (legacy shape)", () => {
+  test("re-exposes default packages via `.packages`", () => {
+    expect(PRICING_DEFAULTS.packages).toEqual(DEFAULT_PRICING_PACKAGES);
+  });
+
+  test("flags.priceTabEnabled defaults to true (legacy)", () => {
+    expect(PRICING_DEFAULTS.flags.priceTabEnabled).toBe(true);
+  });
+});
+
+describe("MARKETING_FEATURE_FLAGS_DEFAULTS", () => {
+  test("pricing section ships enabled; about + recordings off", () => {
+    expect(MARKETING_FEATURE_FLAGS_DEFAULTS.pricingSection).toBe(true);
+    expect(MARKETING_FEATURE_FLAGS_DEFAULTS.aboutPage).toBe(false);
+    expect(MARKETING_FEATURE_FLAGS_DEFAULTS.recordingsPage).toBe(false);
+  });
+});
+
+describe("ABOUT_DEFAULTS", () => {
+  test("has a hero title and at least one body block", () => {
+    expect(ABOUT_DEFAULTS.heroTitle.length).toBeGreaterThan(0);
+    expect(Array.isArray(ABOUT_DEFAULTS.body)).toBe(true);
+    expect(ABOUT_DEFAULTS.body.length).toBeGreaterThan(0);
+    expect(ABOUT_DEFAULTS.body[0].type).toBe("paragraph");
+  });
+
+  test("starts with empty highlights and team", () => {
+    expect(ABOUT_DEFAULTS.highlights).toEqual([]);
+    expect(ABOUT_DEFAULTS.teamMembers).toEqual([]);
+  });
+});
+
+describe("defaultSnapshotForSection", () => {
+  test("returns the matching defaults for each section", () => {
+    expect(defaultSnapshotForSection("settings")).toEqual(SETTINGS_DEFAULTS);
+    expect(defaultSnapshotForSection("pricing")).toEqual(PRICING_DEFAULTS);
+    expect(defaultSnapshotForSection("about")).toEqual(ABOUT_DEFAULTS);
+  });
+
+  test("recordings returns an about-shaped placeholder (no content table)", () => {
+    const recording = defaultSnapshotForSection("recordings");
+    // Structural check — should not throw and should at least have heroTitle.
+    expect((recording as { heroTitle?: string }).heroTitle).toBe(
+      ABOUT_DEFAULTS.heroTitle,
+    );
+  });
+});
+
+describe("billingCadenceLabel", () => {
+  test("returns human labels for every defined cadence", () => {
+    expect(billingCadenceLabel("hourly")).toBe("per hour");
+    expect(billingCadenceLabel("six_hour_block")).toBe("per 6-hour block");
+    expect(billingCadenceLabel("daily")).toBe("per day");
+    expect(billingCadenceLabel("per_song")).toBe("per song");
+    expect(billingCadenceLabel("per_album")).toBe("per album");
+    expect(billingCadenceLabel("per_project")).toBe("per project");
+    expect(billingCadenceLabel("flat")).toBe("flat rate");
+  });
+
+  test("returns empty string for custom (callers must use unitLabel)", () => {
+    expect(billingCadenceLabel("custom")).toBe("");
+  });
+});
+
+describe("cmsSnapshotsEqual", () => {
+  test("is true for structurally equal snapshots regardless of key order", () => {
+    const a = { metadata: { title: "a", description: "b" } };
+    const b = { metadata: { description: "b", title: "a" } };
+    expect(cmsSnapshotsEqual(a, b)).toBe(true);
+  });
+
+  test("is false when any nested field differs", () => {
+    const a = { metadata: { title: "a", description: "b" } };
+    const b = { metadata: { title: "a", description: "different" } };
+    expect(cmsSnapshotsEqual(a, b)).toBe(false);
+  });
+
+  test("handles nested arrays deeply", () => {
+    const a = { ...PRICING_DEFAULTS };
+    const b = { ...PRICING_DEFAULTS, packages: [...DEFAULT_PRICING_PACKAGES] };
+    expect(cmsSnapshotsEqual(a, b)).toBe(true);
+  });
+
+  test("mismatched array length is not equal", () => {
+    const a = { ...PRICING_DEFAULTS };
+    const b = { ...PRICING_DEFAULTS, packages: [DEFAULT_PRICING_PACKAGES[0]] };
+    expect(cmsSnapshotsEqual(a, b)).toBe(false);
+  });
+
+  test("handles undefined on both sides (no-op)", () => {
+    expect(cmsSnapshotsEqual(undefined, undefined)).toBe(true);
+  });
+
+  test("one side undefined is not equal", () => {
+    expect(cmsSnapshotsEqual(undefined, SETTINGS_DEFAULTS)).toBe(false);
+  });
+
+  test("null values compared correctly", () => {
+    const a = { metadata: { title: null as unknown as string } };
+    const b = { metadata: { title: null as unknown as string } };
+    expect(cmsSnapshotsEqual(a, b)).toBe(true);
+  });
+
+  test("array order matters", () => {
+    const a = { ...PRICING_DEFAULTS };
+    const reversed = [...DEFAULT_PRICING_PACKAGES].reverse();
+    const b = { ...PRICING_DEFAULTS, packages: reversed };
+    expect(cmsSnapshotsEqual(a, b)).toBe(false);
+  });
+});
+
+describe("settingsSnapshotsEqual (legacy alias)", () => {
+  test("is exactly cmsSnapshotsEqual", () => {
+    expect(settingsSnapshotsEqual).toBe(cmsSnapshotsEqual);
+  });
+});

--- a/convex/errors.test.ts
+++ b/convex/errors.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { ConvexError } from "convex/values";
+import {
+  cmsConflict,
+  cmsNotFound,
+  cmsPublishValidationFailed,
+  cmsUnauthorized,
+  cmsValidationError,
+  type CmsConvexError,
+} from "./errors";
+
+function captureData(fn: () => void): CmsConvexError {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ConvexError) {
+      return err.data as CmsConvexError;
+    }
+    throw err;
+  }
+  throw new Error("expected function to throw");
+}
+
+describe("cmsUnauthorized", () => {
+  test("throws a ConvexError with code UNAUTHORIZED", () => {
+    const data = captureData(() => cmsUnauthorized("Sign in"));
+    expect(data.code).toBe("UNAUTHORIZED");
+    expect(data.message).toBe("Sign in");
+  });
+
+  test("carries kind when supplied", () => {
+    const data = captureData(() =>
+      cmsUnauthorized("Forbidden", "forbidden"),
+    );
+    expect(data.code).toBe("UNAUTHORIZED");
+    if (data.code === "UNAUTHORIZED") {
+      expect(data.kind).toBe("forbidden");
+    }
+  });
+
+  test("omits kind entirely when unspecified (not set to undefined)", () => {
+    const data = captureData(() => cmsUnauthorized("no-kind"));
+    if (data.code === "UNAUTHORIZED") {
+      expect("kind" in data).toBe(false);
+    }
+  });
+});
+
+describe("cmsValidationError", () => {
+  test("throws with VALIDATION_ERROR code and optional field", () => {
+    const data = captureData(() =>
+      cmsValidationError("bad", "name"),
+    );
+    expect(data.code).toBe("VALIDATION_ERROR");
+    if (data.code === "VALIDATION_ERROR") {
+      expect(data.field).toBe("name");
+    }
+  });
+
+  test("omits field when unspecified", () => {
+    const data = captureData(() => cmsValidationError("bad"));
+    if (data.code === "VALIDATION_ERROR") {
+      expect("field" in data).toBe(false);
+    }
+  });
+});
+
+describe("cmsNotFound", () => {
+  test("synthesises a default message", () => {
+    const data = captureData(() => cmsNotFound("user", "abc"));
+    expect(data.code).toBe("NOT_FOUND");
+    if (data.code === "NOT_FOUND") {
+      expect(data.resource).toBe("user");
+      expect(data.id).toBe("abc");
+      expect(data.message).toBe("user not found: abc");
+    }
+  });
+
+  test("accepts a custom message", () => {
+    const data = captureData(() => cmsNotFound("user", "abc", "gone"));
+    if (data.code === "NOT_FOUND") {
+      expect(data.message).toBe("gone");
+    }
+  });
+});
+
+describe("cmsConflict", () => {
+  test("carries optional reason", () => {
+    const data = captureData(() => cmsConflict("bad", "stale"));
+    expect(data.code).toBe("CONFLICT");
+    if (data.code === "CONFLICT") {
+      expect(data.reason).toBe("stale");
+    }
+  });
+
+  test("omits reason when unspecified", () => {
+    const data = captureData(() => cmsConflict("bad"));
+    if (data.code === "CONFLICT") {
+      expect("reason" in data).toBe(false);
+    }
+  });
+});
+
+describe("cmsPublishValidationFailed", () => {
+  test("carries the section + issues list", () => {
+    const data = captureData(() =>
+      cmsPublishValidationFailed("about", "fail", [
+        { path: "heroTitle", message: "required" },
+      ]),
+    );
+    expect(data.code).toBe("PUBLISH_VALIDATION_FAILED");
+    if (data.code === "PUBLISH_VALIDATION_FAILED") {
+      expect(data.section).toBe("about");
+      expect(data.issues).toEqual([
+        { path: "heroTitle", message: "required" },
+      ]);
+    }
+  });
+
+  test("omits issues when the list is empty", () => {
+    const data = captureData(() =>
+      cmsPublishValidationFailed("about", "fail", []),
+    );
+    if (data.code === "PUBLISH_VALIDATION_FAILED") {
+      expect("issues" in data).toBe(false);
+    }
+  });
+
+  test("omits issues when undefined", () => {
+    const data = captureData(() =>
+      cmsPublishValidationFailed("about", "fail"),
+    );
+    if (data.code === "PUBLISH_VALIDATION_FAILED") {
+      expect("issues" in data).toBe(false);
+    }
+  });
+});

--- a/convex/galleryPhotos.test.ts
+++ b/convex/galleryPhotos.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  ALLOWED_GALLERY_IMAGE_TYPES,
+  MAX_GALLERY_IMAGE_BYTES,
+  MAX_GALLERY_PHOTOS,
+  galleryDraftMatchesPublished,
+} from "./galleryPhotos";
+
+type Row = Doc<"galleryPhotos">;
+
+function row(patch: Partial<Row> = {}): Row {
+  return {
+    _id: ("ph-" + (patch.stableId ?? "x")) as unknown as Id<"galleryPhotos">,
+    _creationTime: 0,
+    scope: "draft",
+    stableId: "ph_1",
+    storageId: "st_1" as unknown as Id<"_storage">,
+    alt: "alt",
+    sortOrder: 0,
+    contentType: "image/webp",
+    sizeBytes: 100,
+    ...patch,
+  } as Row;
+}
+
+describe("gallery constants", () => {
+  test("ALLOWED_GALLERY_IMAGE_TYPES covers jpeg, png, webp", () => {
+    expect(ALLOWED_GALLERY_IMAGE_TYPES).toEqual([
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+    ]);
+  });
+
+  test("MAX_GALLERY_IMAGE_BYTES is 50MB", () => {
+    expect(MAX_GALLERY_IMAGE_BYTES).toBe(50 * 1024 * 1024);
+  });
+
+  test("MAX_GALLERY_PHOTOS caps at 40", () => {
+    expect(MAX_GALLERY_PHOTOS).toBe(40);
+  });
+});
+
+describe("galleryDraftMatchesPublished", () => {
+  test("empty arrays match", () => {
+    expect(galleryDraftMatchesPublished([], [])).toBe(true);
+  });
+
+  test("different lengths do not match", () => {
+    expect(galleryDraftMatchesPublished([row()], [])).toBe(false);
+  });
+
+  test("identical rows match (position-sensitive)", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ stableId: "a" }), row({ stableId: "b" })],
+        [row({ stableId: "a" }), row({ stableId: "b" })],
+      ),
+    ).toBe(true);
+  });
+
+  test("row order matters for the callers that already sort by index", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ stableId: "a" }), row({ stableId: "b" })],
+        [row({ stableId: "b" }), row({ stableId: "a" })],
+      ),
+    ).toBe(false);
+  });
+
+  test("different caption is not a match", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ caption: "A" })],
+        [row({ caption: "B" })],
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined caption normalises to null internally", () => {
+    // Both sides undefined caption → equal.
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ caption: undefined })],
+        [row({ caption: undefined })],
+      ),
+    ).toBe(true);
+  });
+
+  test("different storage id is not a match (even if other fields are equal)", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ storageId: "x" as unknown as Id<"_storage"> })],
+        [row({ storageId: "y" as unknown as Id<"_storage"> })],
+      ),
+    ).toBe(false);
+  });
+});

--- a/convex/gearTree.test.ts
+++ b/convex/gearTree.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  buildSortedGearTreeGroups,
+  gearDraftMatchesPublished,
+  mapSortedGearTree,
+  normalizeGearTreeForCompare,
+} from "./gearTree";
+
+type CategoryDoc = Doc<"gearCategories">;
+type ItemDoc = Doc<"gearItems">;
+
+function category(patch: Partial<CategoryDoc> = {}): CategoryDoc {
+  return {
+    _id: `cat-${patch.stableId ?? "x"}` as unknown as Id<"gearCategories">,
+    _creationTime: 0,
+    scope: "draft",
+    stableId: "cat_1",
+    name: "Microphones",
+    sort: 0,
+    ...patch,
+  } as CategoryDoc;
+}
+
+function item(patch: Partial<ItemDoc> = {}): ItemDoc {
+  return {
+    _id: `it-${patch.stableId ?? "x"}` as unknown as Id<"gearItems">,
+    _creationTime: 0,
+    scope: "draft",
+    stableId: "it_1",
+    categoryStableId: "cat_1",
+    name: "Neumann U87",
+    sort: 0,
+    specs: { kind: "markdown", text: "Legendary." } as ItemDoc["specs"],
+    ...patch,
+  } as ItemDoc;
+}
+
+describe("buildSortedGearTreeGroups", () => {
+  test("groups items by category and sorts groups", () => {
+    const cats = [
+      category({ stableId: "b", sort: 1 }),
+      category({ stableId: "a", sort: 0 }),
+    ];
+    const items = [
+      item({ stableId: "a1", categoryStableId: "a", sort: 0 }),
+      item({ stableId: "b2", categoryStableId: "b", sort: 1 }),
+      item({ stableId: "b1", categoryStableId: "b", sort: 0 }),
+    ];
+    const groups = buildSortedGearTreeGroups(cats, items);
+    expect(groups.map((g) => g.category.stableId)).toEqual(["a", "b"]);
+    expect(groups[1].items.map((i) => i.stableId)).toEqual(["b1", "b2"]);
+  });
+
+  test("category with no items gets an empty group list", () => {
+    const groups = buildSortedGearTreeGroups([category()], []);
+    expect(groups.length).toBe(1);
+    expect(groups[0].items).toEqual([]);
+  });
+});
+
+describe("mapSortedGearTree", () => {
+  test("maps each item through the supplied mapper", () => {
+    const cats = [category({ stableId: "a" })];
+    const items = [item({ stableId: "a1", categoryStableId: "a" })];
+    const rows = mapSortedGearTree(cats, items, (i) => i.stableId);
+    expect(rows).toEqual([
+      { stableId: "a", name: "Microphones", sort: 0, items: ["a1"] },
+    ]);
+  });
+});
+
+describe("normalizeGearTreeForCompare", () => {
+  test("sorts items by (category, sort, stableId) and fills missing url with null", () => {
+    const cats = [category({ stableId: "a" })];
+    const items = [
+      item({ stableId: "z", categoryStableId: "a", sort: 1 }),
+      item({ stableId: "y", categoryStableId: "a", sort: 0 }),
+    ];
+    const shape = normalizeGearTreeForCompare(cats, items) as {
+      items: { stableId: string; url: unknown }[];
+    };
+    expect(shape.items.map((i) => i.stableId)).toEqual(["y", "z"]);
+    expect(shape.items[0].url).toBeNull();
+  });
+
+  test("normalizes kv specs by key for deterministic compare", () => {
+    const cats = [category({ stableId: "a" })];
+    const items = [
+      item({
+        stableId: "i",
+        categoryStableId: "a",
+        specs: {
+          kind: "kv",
+          pairs: [
+            { key: "b", value: "2" },
+            { key: "a", value: "1" },
+          ],
+        },
+      }),
+    ];
+    const shape = normalizeGearTreeForCompare(cats, items) as {
+      items: Array<{ specs: { kind: string; pairs: Array<{ key: string }> } }>;
+    };
+    expect(shape.items[0].specs.pairs.map((p) => p.key)).toEqual(["a", "b"]);
+  });
+});
+
+describe("gearDraftMatchesPublished", () => {
+  test("two empty trees match", () => {
+    expect(
+      gearDraftMatchesPublished(
+        { categories: [], items: [] },
+        { categories: [], items: [] },
+      ),
+    ).toBe(true);
+  });
+
+  test("identical populated trees match", () => {
+    const cats = [category()];
+    const items = [item()];
+    expect(
+      gearDraftMatchesPublished(
+        { categories: cats, items },
+        { categories: cats, items },
+      ),
+    ).toBe(true);
+  });
+
+  test("different item name is not a match", () => {
+    const cats = [category()];
+    expect(
+      gearDraftMatchesPublished(
+        { categories: cats, items: [item({ name: "A" })] },
+        { categories: cats, items: [item({ name: "B" })] },
+      ),
+    ).toBe(false);
+  });
+});

--- a/convex/pricingTree.test.ts
+++ b/convex/pricingTree.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  normalizePricingForCompare,
+  pricingDraftMatchesPublished,
+  pricingPackageFromRow,
+} from "./pricingTree";
+
+type Row = Doc<"pricingPackages">;
+
+function row(patch: Partial<Row> = {}): Row {
+  return {
+    _id: ("row-" + (patch.stableId ?? "x")) as unknown as Id<"pricingPackages">,
+    _creationTime: 0,
+    scope: "draft",
+    stableId: "pkg_1",
+    name: "Recording — Hourly",
+    priceCents: 6000,
+    currency: "USD",
+    billingCadence: "hourly",
+    highlight: false,
+    sortOrder: 0,
+    isActive: true,
+    ...patch,
+  } as Row;
+}
+
+describe("pricingPackageFromRow", () => {
+  test("maps required fields", () => {
+    const pkg = pricingPackageFromRow(row());
+    expect(pkg.id).toBe("pkg_1");
+    expect(pkg.priceCents).toBe(6000);
+    expect(pkg.billingCadence).toBe("hourly");
+    expect(pkg.currency).toBe("USD");
+  });
+
+  test("omits optional fields when undefined", () => {
+    const pkg = pricingPackageFromRow(row());
+    expect("description" in pkg).toBe(false);
+    expect("unitLabel" in pkg).toBe(false);
+    expect("features" in pkg).toBe(false);
+  });
+
+  test("preserves optional fields when present", () => {
+    const pkg = pricingPackageFromRow(
+      row({
+        description: "desc",
+        unitLabel: "per show",
+        features: ["fast", "cheap"],
+        billingCadence: "custom",
+      }),
+    );
+    expect(pkg.description).toBe("desc");
+    expect(pkg.unitLabel).toBe("per show");
+    expect(pkg.features).toEqual(["fast", "cheap"]);
+    expect(pkg.billingCadence).toBe("custom");
+  });
+});
+
+describe("normalizePricingForCompare", () => {
+  test("fills optional fields with null for stable equality", () => {
+    const shape = normalizePricingForCompare([row()]) as Array<{
+      description: unknown;
+      unitLabel: unknown;
+      features: unknown;
+    }>;
+    expect(shape[0].description).toBeNull();
+    expect(shape[0].unitLabel).toBeNull();
+    expect(shape[0].features).toBeNull();
+  });
+
+  test("sorts by sortOrder then stableId", () => {
+    const rows = [
+      row({ stableId: "b", sortOrder: 1 }),
+      row({ stableId: "a", sortOrder: 1 }),
+      row({ stableId: "c", sortOrder: 0 }),
+    ];
+    const shape = normalizePricingForCompare(rows) as Array<{
+      stableId: string;
+    }>;
+    expect(shape.map((r) => r.stableId)).toEqual(["c", "a", "b"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const input = [row({ stableId: "b", sortOrder: 2 }), row({ stableId: "a", sortOrder: 1 })];
+    const before = input.map((r) => r.stableId);
+    normalizePricingForCompare(input);
+    expect(input.map((r) => r.stableId)).toEqual(before);
+  });
+});
+
+describe("pricingDraftMatchesPublished", () => {
+  test("empty tables match", () => {
+    expect(pricingDraftMatchesPublished([], [])).toBe(true);
+  });
+
+  test("draft with packages does not match empty published", () => {
+    expect(pricingDraftMatchesPublished([row()], [])).toBe(false);
+  });
+
+  test("identical catalogues match", () => {
+    const draft = [row()];
+    const published = [row()];
+    expect(pricingDraftMatchesPublished(draft, published)).toBe(true);
+  });
+
+  test("differing priceCents is not a match", () => {
+    expect(
+      pricingDraftMatchesPublished([row({ priceCents: 6000 })], [row({ priceCents: 7000 })]),
+    ).toBe(false);
+  });
+
+  test("order differences are normalized by stableId + sortOrder", () => {
+    const a = [
+      row({ stableId: "b", sortOrder: 1 }),
+      row({ stableId: "a", sortOrder: 0 }),
+    ];
+    const b = [
+      row({ stableId: "a", sortOrder: 0 }),
+      row({ stableId: "b", sortOrder: 1 }),
+    ];
+    expect(pricingDraftMatchesPublished(a, b)).toBe(true);
+  });
+});

--- a/convex/publicSettingsSnapshot.test.ts
+++ b/convex/publicSettingsSnapshot.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_PRICING_PACKAGES } from "./cmsShared";
+import { sanitizePricingPackages } from "./publicSettingsSnapshot";
+
+describe("sanitizePricingPackages", () => {
+  test("returns [] for non-array input", () => {
+    expect(sanitizePricingPackages(null)).toEqual([]);
+    expect(sanitizePricingPackages("nope")).toEqual([]);
+    expect(sanitizePricingPackages({})).toEqual([]);
+  });
+
+  test("accepts default packages verbatim", () => {
+    const out = sanitizePricingPackages(DEFAULT_PRICING_PACKAGES);
+    expect(out.length).toBe(DEFAULT_PRICING_PACKAGES.length);
+  });
+
+  test("drops entries missing required fields", () => {
+    const pkg = { ...DEFAULT_PRICING_PACKAGES[0], id: "" };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("drops entries with invalid billing cadence", () => {
+    const pkg = {
+      ...DEFAULT_PRICING_PACKAGES[0],
+      billingCadence: "nope",
+    };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("drops custom cadence entries without a unit label", () => {
+    const pkg = {
+      ...DEFAULT_PRICING_PACKAGES[0],
+      billingCadence: "custom",
+      unitLabel: undefined,
+    };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("keeps custom cadence entries with a unit label", () => {
+    const pkg = {
+      ...DEFAULT_PRICING_PACKAGES[0],
+      billingCadence: "custom",
+      unitLabel: "per weekend",
+    };
+    expect(sanitizePricingPackages([pkg])).toHaveLength(1);
+  });
+
+  test("rejects non-integer priceCents", () => {
+    const pkg = { ...DEFAULT_PRICING_PACKAGES[0], priceCents: 99.5 };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("rejects negative priceCents", () => {
+    const pkg = { ...DEFAULT_PRICING_PACKAGES[0], priceCents: -1 };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("rejects non-string currency", () => {
+    const pkg = { ...DEFAULT_PRICING_PACKAGES[0], currency: 0 };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+
+  test("sorts by sortOrder then name", () => {
+    const pkgs = [
+      { ...DEFAULT_PRICING_PACKAGES[0], id: "b", sortOrder: 1, name: "B" },
+      { ...DEFAULT_PRICING_PACKAGES[0], id: "a", sortOrder: 0, name: "A" },
+      { ...DEFAULT_PRICING_PACKAGES[0], id: "c", sortOrder: 1, name: "A" },
+    ];
+    const out = sanitizePricingPackages(pkgs);
+    expect(out.map((p) => p.id)).toEqual(["a", "c", "b"]);
+  });
+
+  test("rejects malformed features array (non-string element)", () => {
+    const pkg = {
+      ...DEFAULT_PRICING_PACKAGES[0],
+      features: ["ok", 3 as unknown as string],
+    };
+    expect(sanitizePricingPackages([pkg])).toEqual([]);
+  });
+});

--- a/convex/settingsTree.test.ts
+++ b/convex/settingsTree.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  SETTINGS_METADATA_DEFAULTS,
+  normalizeSettingsForCompare,
+  settingsDraftMatchesPublished,
+} from "./settingsTree";
+
+type Row = Doc<"settingsContent">;
+
+function row(patch: Partial<Row> = {}): Row {
+  return {
+    _id: "settings-row" as unknown as Id<"settingsContent">,
+    _creationTime: 0,
+    scope: "draft",
+    title: "Lula Lake Sound",
+    description: "Music Production and Recording Services",
+    ...patch,
+  } as Row;
+}
+
+describe("SETTINGS_METADATA_DEFAULTS", () => {
+  test("exposes the site title + description", () => {
+    expect(SETTINGS_METADATA_DEFAULTS.title).toBeTruthy();
+    expect(SETTINGS_METADATA_DEFAULTS.description).toBeTruthy();
+  });
+});
+
+describe("normalizeSettingsForCompare", () => {
+  test("returns null for a null row", () => {
+    expect(normalizeSettingsForCompare(null)).toBeNull();
+  });
+
+  test("replaces undefined fields with null for diff stability", () => {
+    const shape = normalizeSettingsForCompare(
+      row({ title: undefined, description: undefined }),
+    ) as { title: unknown; description: unknown };
+    expect(shape.title).toBeNull();
+    expect(shape.description).toBeNull();
+  });
+
+  test("preserves set fields verbatim", () => {
+    const shape = normalizeSettingsForCompare(
+      row({ title: "Hi", description: "Ho" }),
+    ) as { title: string; description: string };
+    expect(shape.title).toBe("Hi");
+    expect(shape.description).toBe("Ho");
+  });
+});
+
+describe("settingsDraftMatchesPublished", () => {
+  test("both null means equal", () => {
+    expect(settingsDraftMatchesPublished(null, null)).toBe(true);
+  });
+
+  test("null vs a row with content is not equal", () => {
+    expect(settingsDraftMatchesPublished(null, row())).toBe(false);
+    expect(settingsDraftMatchesPublished(row(), null)).toBe(false);
+  });
+
+  test("identical rows are equal", () => {
+    expect(settingsDraftMatchesPublished(row(), row())).toBe(true);
+  });
+
+  test("different description is not equal", () => {
+    expect(
+      settingsDraftMatchesPublished(
+        row({ description: "A" }),
+        row({ description: "B" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined-vs-absent normalises to equal", () => {
+    const a = row({ title: undefined });
+    const b = row({ title: undefined });
+    expect(settingsDraftMatchesPublished(a, b)).toBe(true);
+  });
+});

--- a/src/app/admin/about/about-editor.test.ts
+++ b/src/app/admin/about/about-editor.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import {
+  blocksToHtml,
+  collectAboutIssues,
+  escapeHtml,
+  htmlToPlainText,
+  toAboutContent,
+  trimToUndefined,
+  type AboutTeamMemberRow,
+} from "./about-editor";
+
+describe("trimToUndefined", () => {
+  test("non-empty string passes through verbatim (original value, not trimmed)", () => {
+    // Implementation returns `value`, not `trimmed`, so leading/trailing
+    // spaces are retained — only fully-empty values collapse to undefined.
+    expect(trimToUndefined("  Hello  ")).toBe("  Hello  ");
+  });
+
+  test("empty and whitespace-only → undefined", () => {
+    expect(trimToUndefined("")).toBeUndefined();
+    expect(trimToUndefined("   ")).toBeUndefined();
+  });
+});
+
+describe("escapeHtml", () => {
+  test("escapes the standard HTML entities", () => {
+    expect(escapeHtml("<a href=\"x\">'&'</a>")).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;",
+    );
+  });
+
+  test("safe plain text is unchanged", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+});
+
+describe("blocksToHtml", () => {
+  test("empty array returns empty string", () => {
+    expect(blocksToHtml([])).toBe("");
+  });
+
+  test("paragraphs render as <p>", () => {
+    expect(blocksToHtml([{ type: "paragraph", text: "Hi" }])).toBe("<p>Hi</p>");
+  });
+
+  test("headings render as <h2>", () => {
+    expect(blocksToHtml([{ type: "heading", text: "Hi" }])).toBe("<h2>Hi</h2>");
+  });
+
+  test("block text is html-escaped", () => {
+    expect(blocksToHtml([{ type: "paragraph", text: "<b>x</b>" }])).toBe(
+      "<p>&lt;b&gt;x&lt;/b&gt;</p>",
+    );
+  });
+});
+
+describe("htmlToPlainText", () => {
+  test("strips tags (collapsing is left to the caller)", () => {
+    // Each tag becomes a single space, which keeps word boundaries.
+    expect(htmlToPlainText("<p>Hello <b>world</b></p>")).toBe("Hello  world");
+  });
+
+  test("decodes common named entities", () => {
+    expect(htmlToPlainText("<p>a&amp;b</p>")).toBe("a&b");
+    expect(htmlToPlainText("<p>&lt;x&gt;</p>")).toBe("<x>");
+    expect(htmlToPlainText("<p>a&nbsp;b</p>")).toBe("a b");
+  });
+
+  test("empty string stays empty", () => {
+    expect(htmlToPlainText("")).toBe("");
+  });
+});
+
+describe("toAboutContent", () => {
+  test("undefined input yields safe defaults", () => {
+    const c = toAboutContent(undefined);
+    expect(c.heroTitle).toBe("");
+    expect(c.body).toEqual([]);
+    expect(c.teamMembers).toEqual([]);
+    expect(c.bodyHtml).toBeUndefined();
+  });
+
+  test("promotes legacy body blocks to bodyHtml", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      body: [{ type: "paragraph", text: "Hello" }],
+    });
+    expect(c.bodyHtml).toBe("<p>Hello</p>");
+    expect(c.body).toEqual([{ type: "paragraph", text: "Hello" }]);
+  });
+
+  test("prefers stored bodyHtml over legacy blocks", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      bodyHtml: "<p>Stored</p>",
+      body: [{ type: "paragraph", text: "Legacy" }],
+    });
+    expect(c.bodyHtml).toBe("<p>Stored</p>");
+  });
+
+  test("filters out malformed body blocks", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      body: [
+        { type: "paragraph", text: "ok" },
+        null,
+        { type: "bogus", text: "skip" },
+        { type: "paragraph" },
+      ],
+    });
+    expect(c.body).toEqual([{ type: "paragraph", text: "ok" }]);
+  });
+
+  test("filters out malformed team members", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      teamMembers: [
+        { id: "a", name: "Alice", title: "Engineer" },
+        { id: "b" },
+        null,
+        { id: "c", name: 1, title: "x" },
+      ],
+    });
+    expect(c.teamMembers).toEqual([
+      { id: "a", name: "Alice", title: "Engineer" },
+    ]);
+  });
+
+  test("pullQuote empty string becomes undefined", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      pullQuote: "   ",
+    });
+    expect(c.pullQuote).toBeUndefined();
+  });
+
+  test("string highlights are retained", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      highlights: ["a", "b", 1],
+    });
+    expect(c.highlights).toEqual(["a", "b"]);
+  });
+});
+
+describe("collectAboutIssues", () => {
+  function content(
+    patch: Partial<Parameters<typeof collectAboutIssues>[0]> = {},
+  ) {
+    return {
+      heroTitle: "About",
+      bodyHtml: "<p>Body content here</p>",
+      body: [],
+      highlights: [] as string[],
+      teamMembers: [] as AboutTeamMemberRow[],
+      ...patch,
+    };
+  }
+
+  test("valid draft returns no issues", () => {
+    expect(collectAboutIssues(content())).toEqual([]);
+  });
+
+  test("missing hero title reported", () => {
+    const issues = collectAboutIssues(content({ heroTitle: "   " }));
+    expect(issues.some((i) => i.path === "heroTitle")).toBe(true);
+  });
+
+  test("empty body html reported", () => {
+    const issues = collectAboutIssues(content({ bodyHtml: "" }));
+    expect(issues.some((i) => i.path === "bodyHtml")).toBe(true);
+  });
+
+  test("empty highlights reported (per-row)", () => {
+    const issues = collectAboutIssues(content({ highlights: ["ok", "   "] }));
+    expect(issues.some((i) => i.path === "highlights[1]")).toBe(true);
+    expect(issues.some((i) => i.path === "highlights[0]")).toBe(false);
+  });
+
+  test("team member missing storageId / name / title reported", () => {
+    const team: AboutTeamMemberRow[] = [
+      { id: "a", name: "", title: "" },
+    ];
+    const issues = collectAboutIssues(content({ teamMembers: team }));
+    const paths = issues.map((i) => i.path);
+    expect(paths).toContain("teamMembers[0].name");
+    expect(paths).toContain("teamMembers[0].title");
+    expect(paths).toContain("teamMembers[0].storageId");
+  });
+
+  test("over-cap team members reported", () => {
+    const team: AboutTeamMemberRow[] = Array.from({ length: 21 }, (_, i) => ({
+      id: `p-${i}`,
+      name: `N${i}`,
+      title: "T",
+      storageId: "st-x" as never,
+    }));
+    const issues = collectAboutIssues(content({ teamMembers: team }));
+    expect(issues.some((i) => i.path === "teamMembers")).toBe(true);
+  });
+});

--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -104,7 +104,7 @@ const SEO_DESCRIPTION_RECOMMENDED = 160;
 const fieldClass =
   "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/50";
 
-function trimToUndefined(value: string): string | undefined {
+export function trimToUndefined(value: string): string | undefined {
   const trimmed = value.trim();
   return trimmed.length === 0 ? undefined : value;
 }
@@ -113,7 +113,7 @@ function trimToUndefined(value: string): string | undefined {
  * Convert legacy paragraph/heading block arrays to Tiptap-compatible HTML
  * so existing rows upgrade cleanly the first time the owner edits them.
  */
-function blocksToHtml(blocks: AboutBlock[]): string {
+export function blocksToHtml(blocks: AboutBlock[]): string {
   if (blocks.length === 0) return "";
   return blocks
     .map((b) => {
@@ -123,7 +123,7 @@ function blocksToHtml(blocks: AboutBlock[]): string {
     .join("");
 }
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -132,7 +132,7 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function htmlToPlainText(html: string): string {
+export function htmlToPlainText(html: string): string {
   return html
     .replace(/<[^>]*>/g, " ")
     .replace(/&nbsp;/g, " ")
@@ -172,7 +172,7 @@ async function uploadHeadshotToConvex(
 }
 
 /** Normalize whatever came off the wire to the editor shape. */
-function toAboutContent(raw: unknown): AboutContent {
+export function toAboutContent(raw: unknown): AboutContent {
   const r = (raw ?? {}) as Partial<AboutContent> & Record<string, unknown>;
   const body: AboutBlock[] = Array.isArray(r.body)
     ? r.body
@@ -241,7 +241,7 @@ function toAboutContent(raw: unknown): AboutContent {
  * Publish-validation mirror (kept in sync with `collectAboutIssues` in
  * `convex/cmsPublishHelpers.ts`) so blocking issues surface live.
  */
-function collectAboutIssues(
+export function collectAboutIssues(
   draft: AboutContent,
 ): { path: string; message: string }[] {
   const issues: { path: string; message: string }[] = [];

--- a/src/app/admin/gear/gear-editor.test.ts
+++ b/src/app/admin/gear/gear-editor.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import {
+  nextAppendSort,
+  sortCategories,
+  sortItems,
+  specsPreview,
+  validateCategoryName,
+  validateItemName,
+  validateSpecs,
+  validateUrl,
+} from "./gear-editor";
+
+describe("specsPreview", () => {
+  test("markdown specs: trims and joins whitespace", () => {
+    expect(specsPreview({ kind: "markdown", text: "  hello\n\nworld  " })).toBe(
+      "hello world",
+    );
+  });
+
+  test("markdown specs: empty text → em-dash", () => {
+    expect(specsPreview({ kind: "markdown", text: "" })).toBe("—");
+  });
+
+  test("markdown specs: truncates at 96 with ellipsis", () => {
+    const long = "a".repeat(200);
+    const preview = specsPreview({ kind: "markdown", text: long });
+    expect(preview.length).toBe(97);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  test("kv specs: joins pairs with `·`", () => {
+    expect(
+      specsPreview({
+        kind: "kv",
+        pairs: [
+          { key: "Pattern", value: "Cardioid" },
+          { key: "Use", value: "Vocals" },
+        ],
+      }),
+    ).toBe("Pattern: Cardioid · Use: Vocals");
+  });
+
+  test("kv specs: empty pair list → em-dash", () => {
+    expect(specsPreview({ kind: "kv", pairs: [] })).toBe("—");
+  });
+});
+
+describe("validateItemName / validateCategoryName", () => {
+  test("empty name rejected", () => {
+    expect(validateItemName("")).toBe("Name is required.");
+    expect(validateItemName("   ")).toBe("Name is required.");
+    expect(validateCategoryName("")).toBe("Name is required.");
+  });
+
+  test("valid name passes", () => {
+    expect(validateItemName("U87")).toBeNull();
+    expect(validateCategoryName("Microphones")).toBeNull();
+  });
+
+  test("overlong name rejected", () => {
+    const long = "a".repeat(501);
+    expect(validateItemName(long)).toContain("500");
+  });
+});
+
+describe("validateSpecs", () => {
+  test("overlong markdown rejected", () => {
+    const long = "a".repeat(20_001);
+    expect(validateSpecs({ kind: "markdown", text: long })).toContain(
+      "20000",
+    );
+  });
+
+  test("short markdown passes", () => {
+    expect(validateSpecs({ kind: "markdown", text: "hi" })).toBeNull();
+  });
+
+  test("too many kv pairs rejected", () => {
+    const pairs = Array.from({ length: 41 }, (_, i) => ({
+      key: `k${i}`,
+      value: `v${i}`,
+    }));
+    expect(validateSpecs({ kind: "kv", pairs })).toContain("40");
+  });
+
+  test("kv pair with oversized key rejected", () => {
+    expect(
+      validateSpecs({
+        kind: "kv",
+        pairs: [{ key: "a".repeat(201), value: "ok" }],
+      }),
+    ).toContain("200");
+  });
+
+  test("kv pair with oversized value rejected", () => {
+    expect(
+      validateSpecs({
+        kind: "kv",
+        pairs: [{ key: "ok", value: "a".repeat(4_001) }],
+      }),
+    ).toContain("4000");
+  });
+});
+
+describe("validateUrl", () => {
+  test("empty input allowed (field is optional)", () => {
+    expect(validateUrl("")).toBeNull();
+    expect(validateUrl("   ")).toBeNull();
+  });
+
+  test("valid http and https URLs accepted", () => {
+    expect(validateUrl("http://example.com")).toBeNull();
+    expect(validateUrl("https://example.com/path?q=1")).toBeNull();
+  });
+
+  test("non-http(s) protocols rejected", () => {
+    expect(validateUrl("ftp://example.com")).toContain("http");
+    expect(validateUrl("javascript:alert(1)")).toContain("http");
+  });
+
+  test("malformed URL rejected", () => {
+    expect(validateUrl("not a url")).toContain("http");
+  });
+
+  test("overlong URL rejected", () => {
+    const url = `https://example.com/${"x".repeat(3000)}`;
+    expect(validateUrl(url)).toContain("2048");
+  });
+});
+
+describe("sortCategories / sortItems", () => {
+  test("sorts by (sort, stableId)", () => {
+    const input = [
+      { stableId: "b", name: "", sort: 1, items: [] },
+      { stableId: "a", name: "", sort: 1, items: [] },
+      { stableId: "c", name: "", sort: 0, items: [] },
+    ];
+    expect(sortCategories(input).map((c) => c.stableId)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  test("does not mutate input", () => {
+    const input = [
+      { stableId: "b", name: "", sort: 1, items: [] },
+      { stableId: "a", name: "", sort: 0, items: [] },
+    ];
+    const before = input.map((c) => c.stableId);
+    sortCategories(input);
+    expect(input.map((c) => c.stableId)).toEqual(before);
+  });
+
+  test("sortItems sorts identically", () => {
+    const result = sortItems([
+      {
+        stableId: "b",
+        categoryStableId: "c",
+        name: "B",
+        sort: 1,
+        specs: { kind: "markdown", text: "" },
+      },
+      {
+        stableId: "a",
+        categoryStableId: "c",
+        name: "A",
+        sort: 0,
+        specs: { kind: "markdown", text: "" },
+      },
+    ]);
+    expect(result.map((i) => i.stableId)).toEqual(["a", "b"]);
+  });
+});
+
+describe("nextAppendSort", () => {
+  test("empty input → 0", () => {
+    expect(nextAppendSort([])).toBe(0);
+  });
+
+  test("returns max + 1", () => {
+    expect(nextAppendSort([0, 1, 2])).toBe(3);
+    expect(nextAppendSort([5, 9, 3])).toBe(10);
+  });
+
+  test("handles negatives", () => {
+    expect(nextAppendSort([-5, -1])).toBe(0);
+  });
+});

--- a/src/app/admin/gear/gear-editor.tsx
+++ b/src/app/admin/gear/gear-editor.tsx
@@ -95,7 +95,7 @@ function generateItemId(): string {
   return `item_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
 }
 
-function specsPreview(specs: GearSpecs): string {
+export function specsPreview(specs: GearSpecs): string {
   if (specs.kind === "markdown") {
     const t = specs.text.trim().replace(/\s+/g, " ");
     return t.length > SPECS_PREVIEW_LEN
@@ -110,18 +110,18 @@ function specsPreview(specs: GearSpecs): string {
     : joined || "—";
 }
 
-function validateItemName(name: string): string | null {
+export function validateItemName(name: string): string | null {
   const t = name.trim();
   if (t.length === 0) return "Name is required.";
   if (t.length > MAX_NAME_LEN) return `Name must be at most ${MAX_NAME_LEN} characters.`;
   return null;
 }
 
-function validateCategoryName(name: string): string | null {
+export function validateCategoryName(name: string): string | null {
   return validateItemName(name);
 }
 
-function validateSpecs(specs: GearSpecs): string | null {
+export function validateSpecs(specs: GearSpecs): string | null {
   if (specs.kind === "markdown") {
     if (specs.text.length > MAX_MARKDOWN_LEN) {
       return `Details must be at most ${MAX_MARKDOWN_LEN} characters.`;
@@ -143,7 +143,7 @@ function validateSpecs(specs: GearSpecs): string | null {
   return null;
 }
 
-function validateUrl(url: string): string | null {
+export function validateUrl(url: string): string | null {
   const t = url.trim();
   if (t.length === 0) return null;
   if (t.length > MAX_URL_LEN) return `URL must be at most ${MAX_URL_LEN} characters.`;
@@ -158,20 +158,20 @@ function validateUrl(url: string): string | null {
   return null;
 }
 
-function sortCategories(cats: GearCategoryPayload[]): GearCategoryPayload[] {
+export function sortCategories(cats: GearCategoryPayload[]): GearCategoryPayload[] {
   return [...cats].sort(
     (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
   );
 }
 
-function sortItems(items: GearItemPayload[]): GearItemPayload[] {
+export function sortItems(items: GearItemPayload[]): GearItemPayload[] {
   return [...items].sort(
     (a, b) => a.sort - b.sort || a.stableId.localeCompare(b.stableId),
   );
 }
 
 /** Next sort for a new row at the end; avoids colliding with gaps after deletes. */
-function nextAppendSort(sorts: readonly number[]): number {
+export function nextAppendSort(sorts: readonly number[]): number {
   if (sorts.length === 0) return 0;
   return Math.max(...sorts) + 1;
 }

--- a/src/app/admin/photos/photos-editor.test.ts
+++ b/src/app/admin/photos/photos-editor.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  defaultAltFromFileName,
+  formatBytes,
+  validatePhotoFields,
+} from "./photos-editor";
+
+describe("defaultAltFromFileName", () => {
+  test("drops the extension", () => {
+    expect(defaultAltFromFileName("studio.jpg")).toBe("Studio");
+    expect(defaultAltFromFileName("live-room.webp")).toBe("Live room");
+  });
+
+  test("converts dashes/underscores to spaces", () => {
+    expect(defaultAltFromFileName("behind_the_board.png")).toBe(
+      "Behind the board",
+    );
+  });
+
+  test("capitalises the first letter only", () => {
+    expect(defaultAltFromFileName("session one.jpg")).toBe("Session one");
+  });
+
+  test("collapses repeated whitespace", () => {
+    expect(defaultAltFromFileName("a__b--c.jpg")).toBe("A b c");
+  });
+
+  test("empty / whitespace filename → 'Studio photo' fallback", () => {
+    expect(defaultAltFromFileName(".jpg")).toBe("Studio photo");
+    expect(defaultAltFromFileName("   .jpg")).toBe("Studio photo");
+  });
+});
+
+describe("formatBytes", () => {
+  test("bytes scale", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  test("kilobytes scale", () => {
+    expect(formatBytes(2048)).toBe("2.0 KB");
+  });
+
+  test("megabytes scale", () => {
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("validatePhotoFields", () => {
+  test("empty alt rejected", () => {
+    expect(validatePhotoFields("", "caption")).toContain("Alt");
+    expect(validatePhotoFields("   ", "caption")).toContain("Alt");
+  });
+
+  test("alt over 240 chars rejected", () => {
+    expect(validatePhotoFields("a".repeat(241), "")).toContain("240");
+  });
+
+  test("alt exactly 240 chars accepted", () => {
+    expect(validatePhotoFields("a".repeat(240), "")).toBeNull();
+  });
+
+  test("caption over 600 chars rejected", () => {
+    expect(validatePhotoFields("ok", "a".repeat(601))).toContain("600");
+  });
+
+  test("valid alt + short caption passes", () => {
+    expect(validatePhotoFields("cool studio", "")).toBeNull();
+    expect(validatePhotoFields("cool studio", "A caption")).toBeNull();
+  });
+});

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -95,7 +95,7 @@ type UploadProgressEntry = {
   readonly error?: string;
 };
 
-function defaultAltFromFileName(fileName: string): string {
+export function defaultAltFromFileName(fileName: string): string {
   const withoutExtension = fileName.replace(/\.[^.]+$/, "");
   const normalized = withoutExtension
     .replace(/[_-]+/g, " ")
@@ -107,13 +107,13 @@ function defaultAltFromFileName(fileName: string): string {
   return normalized[0].toUpperCase() + normalized.slice(1);
 }
 
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function validatePhotoFields(alt: string, caption: string): string | null {
+export function validatePhotoFields(alt: string, caption: string): string | null {
   const trimmedAlt = alt.trim();
   if (trimmedAlt.length === 0) {
     return "Alt text is required.";

--- a/src/app/admin/pricing/pricing-editor.test.ts
+++ b/src/app/admin/pricing/pricing-editor.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCadence,
+  parsePriceInput,
+  priceCentsToDisplay,
+  renumberSortOrder,
+  toPricingContent,
+} from "./pricing-editor";
+
+describe("isCadence", () => {
+  test.each([
+    "hourly",
+    "six_hour_block",
+    "daily",
+    "per_song",
+    "per_album",
+    "per_project",
+    "flat",
+    "custom",
+  ] as const)("accepts %s", (c: string) => {
+    expect(isCadence(c)).toBe(true);
+  });
+
+  test("rejects unknown cadence strings", () => {
+    expect(isCadence("nope")).toBe(false);
+    expect(isCadence("")).toBe(false);
+  });
+});
+
+describe("parsePriceInput", () => {
+  test("empty → null (caller keeps the previous cents)", () => {
+    expect(parsePriceInput("")).toBeNull();
+    expect(parsePriceInput("   ")).toBeNull();
+  });
+
+  test("non-numeric → null", () => {
+    expect(parsePriceInput("abc")).toBeNull();
+    expect(parsePriceInput(".")).toBeNull();
+  });
+
+  test("negative → null (never accept negative prices)", () => {
+    expect(parsePriceInput("-5")).toBeNull();
+  });
+
+  test("whole dollars round to cents", () => {
+    expect(parsePriceInput("60")).toBe(6000);
+  });
+
+  test("fractional dollars round half-up to nearest cent", () => {
+    expect(parsePriceInput("60.50")).toBe(6050);
+    expect(parsePriceInput("0.01")).toBe(1);
+    expect(parsePriceInput("0.005")).toBe(1);
+  });
+
+  test("leading/trailing whitespace allowed", () => {
+    expect(parsePriceInput("  99.99  ")).toBe(9999);
+  });
+});
+
+describe("priceCentsToDisplay", () => {
+  test("formats cents to a decimal string (2 decimals)", () => {
+    expect(priceCentsToDisplay(6000)).toBe("60.00");
+    expect(priceCentsToDisplay(0)).toBe("0.00");
+    expect(priceCentsToDisplay(999)).toBe("9.99");
+  });
+
+  test("non-finite → empty string", () => {
+    expect(priceCentsToDisplay(Number.NaN)).toBe("");
+    expect(priceCentsToDisplay(Infinity)).toBe("");
+  });
+});
+
+describe("renumberSortOrder", () => {
+  test("assigns 0..n-1 to the sortOrder field in array order", () => {
+    const input = [
+      { id: "a", sortOrder: 10 },
+      { id: "b", sortOrder: 3 },
+      { id: "c", sortOrder: 7 },
+    ];
+    const result = renumberSortOrder(input as never);
+    expect(result.map((r) => r.sortOrder)).toEqual([0, 1, 2]);
+    // Does not mutate input.
+    expect(input[0].sortOrder).toBe(10);
+  });
+
+  test("empty array returns empty array", () => {
+    expect(renumberSortOrder([])).toEqual([]);
+  });
+});
+
+describe("toPricingContent", () => {
+  test("drops server flags (visibility lives on cmsSections.isEnabled)", () => {
+    const result = toPricingContent({
+      flags: { priceTabEnabled: true },
+      packages: [
+        {
+          id: "pkg",
+          name: "Rec",
+          priceCents: 6000,
+          currency: "USD",
+          billingCadence: "hourly",
+          highlight: false,
+          sortOrder: 0,
+          isActive: true,
+        },
+      ],
+    });
+    expect("flags" in (result as unknown as Record<string, unknown>)).toBe(
+      false,
+    );
+    expect(result.packages).toHaveLength(1);
+  });
+
+  test("deep-clones features so editor mutations don't bleed upstream", () => {
+    const features = ["a", "b"];
+    const input = {
+      flags: { priceTabEnabled: true },
+      packages: [
+        {
+          id: "pkg",
+          name: "Rec",
+          priceCents: 6000,
+          currency: "USD",
+          billingCadence: "hourly" as const,
+          highlight: false,
+          sortOrder: 0,
+          isActive: true,
+          features,
+        },
+      ],
+    };
+    const result = toPricingContent(input);
+    result.packages[0].features!.push("c");
+    expect(features).toEqual(["a", "b"]);
+  });
+});

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -87,7 +87,7 @@ const CADENCE_LABELS: Record<BillingCadence, string> = {
 const PRICING_FIELD_INPUT_CLASS =
   "text-foreground placeholder:text-muted-foreground";
 
-function isCadence(value: string): value is BillingCadence {
+export function isCadence(value: string): value is BillingCadence {
   return (VALID_CADENCES as readonly string[]).includes(value);
 }
 
@@ -98,7 +98,7 @@ function generateId(): string {
   return `pkg_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
 }
 
-function toPricingContent(raw: {
+export function toPricingContent(raw: {
   flags?: { priceTabEnabled?: boolean };
   packages: PricingPackage[];
 }): PricingContent {
@@ -119,16 +119,16 @@ function toPricingContent(raw: {
   };
 }
 
-function renumberSortOrder(packages: PricingPackage[]): PricingPackage[] {
+export function renumberSortOrder(packages: PricingPackage[]): PricingPackage[] {
   return packages.map((p, idx) => ({ ...p, sortOrder: idx }));
 }
 
-function priceCentsToDisplay(cents: number): string {
+export function priceCentsToDisplay(cents: number): string {
   if (!Number.isFinite(cents)) return "";
   return (cents / 100).toFixed(2);
 }
 
-function parsePriceInput(value: string): number | null {
+export function parsePriceInput(value: string): number | null {
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
   const num = Number(trimmed);

--- a/src/app/admin/settings/settings-editor.test.ts
+++ b/src/app/admin/settings/settings-editor.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { toSettingsContent } from "./settings-editor";
+
+describe("toSettingsContent", () => {
+  test("keeps metadata verbatim", () => {
+    const result = toSettingsContent({
+      metadata: { title: "Hi", description: "Ho" },
+    });
+    expect(result.metadata).toEqual({ title: "Hi", description: "Ho" });
+  });
+
+  test("preserves legacy flags.priceTabEnabled when present", () => {
+    const result = toSettingsContent({
+      metadata: {},
+      flags: { priceTabEnabled: true },
+    });
+    expect(result.flags).toEqual({ priceTabEnabled: true });
+  });
+
+  test("drops flags when priceTabEnabled is not a boolean", () => {
+    const result = toSettingsContent({
+      metadata: {},
+      flags: { priceTabEnabled: undefined },
+    });
+    expect(result.flags).toBeUndefined();
+  });
+
+  test("drops flags entirely when input omits them", () => {
+    const result = toSettingsContent({ metadata: {} });
+    expect(result.flags).toBeUndefined();
+  });
+
+  test("legacy priceTabEnabled=false round-trips", () => {
+    const result = toSettingsContent({
+      metadata: {},
+      flags: { priceTabEnabled: false },
+    });
+    expect(result.flags).toEqual({ priceTabEnabled: false });
+  });
+});

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -51,7 +51,7 @@ export function SettingsEditor() {
  * legacy `flags`) for the editor. Metadata is editable; legacy `flags` are
  * preserved on save/publish so public reads do not fall back to defaults.
  */
-function toSettingsContent(raw: {
+export function toSettingsContent(raw: {
   metadata?: { title?: string; description?: string };
   flags?: { priceTabEnabled?: boolean };
 }): SettingsContent {

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
+
+describe("ADMIN_MANAGE_NAV_ITEMS", () => {
+  test("includes every CMS admin destination expected by the sidebar", () => {
+    const hrefs = ADMIN_MANAGE_NAV_ITEMS.map((i) => i.href);
+    expect(hrefs).toEqual([
+      "/admin/pricing",
+      "/admin/gear",
+      "/admin/photos",
+      "/admin/videos",
+      "/admin/audio",
+      "/admin/about",
+      "/admin/settings",
+    ]);
+  });
+
+  test("every entry has a title, description, and icon", () => {
+    for (const item of ADMIN_MANAGE_NAV_ITEMS) {
+      expect(item.title.length).toBeGreaterThan(0);
+      expect(item.description.length).toBeGreaterThan(0);
+      expect(item.icon).toBeDefined();
+    }
+  });
+
+  test("all admin hrefs are scoped under /admin", () => {
+    for (const item of ADMIN_MANAGE_NAV_ITEMS) {
+      expect(item.href.startsWith("/admin/")).toBe(true);
+    }
+  });
+
+  test("hrefs are unique", () => {
+    const hrefs = ADMIN_MANAGE_NAV_ITEMS.map((i) => i.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/src/lib/contact-inquiry-schema.test.ts
+++ b/src/lib/contact-inquiry-schema.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { contactInquirySchema } from "@/lib/contact-inquiry-schema";
+
+const valid = {
+  artistName: "Lula Band",
+  contactName: "Jane Doe",
+  email: "jane@example.com",
+  phone: "555-0100",
+  message: "Need a day of tracking.",
+  website: "",
+};
+
+describe("contactInquirySchema", () => {
+  test("accepts a complete, valid submission", () => {
+    const result = contactInquirySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty artist name", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      artistName: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing contact name", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      contactName: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects malformed email", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      email: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty message", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      message: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects message that exceeds the cap", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      message: "a".repeat(10_001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects oversized artistName", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      artistName: "a".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects oversized phone (> 50)", () => {
+    const result = contactInquirySchema.safeParse({
+      ...valid,
+      phone: "1".repeat(51),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts empty phone (field is optional-ish)", () => {
+    const result = contactInquirySchema.safeParse({ ...valid, phone: "" });
+    expect(result.success).toBe(true);
+  });
+
+  test("honeypot `website` must exist but can be empty", () => {
+    const result = contactInquirySchema.safeParse({ ...valid, website: "" });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects when honeypot `website` field is missing", () => {
+    const { website: _website, ...rest } = valid;
+    void _website;
+    const result = contactInquirySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/reveal-delay.test.ts
+++ b/src/lib/reveal-delay.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_REVEAL_DELAY, revealDelay } from "@/lib/reveal-delay";
+
+describe("revealDelay", () => {
+  test("step 0 (or negative) drops the delay suffix", () => {
+    expect(revealDelay(0)).toBe("reveal");
+    expect(revealDelay(-1)).toBe("reveal");
+  });
+
+  test("step 1..MAX returns reveal-delay-N", () => {
+    for (let i = 1; i <= MAX_REVEAL_DELAY; i += 1) {
+      expect(revealDelay(i)).toBe(`reveal reveal-delay-${i}`);
+    }
+  });
+
+  test("step above MAX clamps to MAX", () => {
+    expect(revealDelay(MAX_REVEAL_DELAY + 5)).toBe(
+      `reveal reveal-delay-${MAX_REVEAL_DELAY}`,
+    );
+  });
+});

--- a/src/lib/route-prewarm.test.ts
+++ b/src/lib/route-prewarm.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ConvexReactClient } from "convex/react";
+import type { FunctionReference } from "convex/server";
+import { api } from "@convex/_generated/api";
+import {
+  PREWARM_DEBOUNCE_MS,
+  PREWARM_DEDUPE_MS,
+  PREWARM_EXTEND_MS,
+  buildQueryKey,
+  createRoutePrewarmIntent,
+  makeRouteQuerySpec,
+  prewarmAdminNavigation,
+  prewarmSpecs,
+  resetPrewarmDedupeForTests,
+} from "@/lib/route-prewarm";
+
+type PrewarmArgs = {
+  query: FunctionReference<"query">;
+  args: unknown;
+  extendSubscriptionFor: number;
+};
+
+function makeFakeClient() {
+  const prewarmQuery = mock((_args: PrewarmArgs) => {
+    void _args;
+  });
+  return {
+    prewarmQuery,
+    client: { prewarmQuery } as unknown as ConvexReactClient,
+  };
+}
+
+describe("prewarm constants", () => {
+  test("are reasonable positive numbers", () => {
+    expect(PREWARM_DEBOUNCE_MS).toBeGreaterThan(0);
+    expect(PREWARM_DEDUPE_MS).toBeGreaterThan(0);
+    expect(PREWARM_EXTEND_MS).toBeGreaterThan(PREWARM_DEDUPE_MS);
+  });
+});
+
+describe("buildQueryKey", () => {
+  test("produces a stable string per (name, args) tuple", () => {
+    const a = buildQueryKey("api.foo.bar", { x: 1 });
+    const b = buildQueryKey("api.foo.bar", { x: 1 });
+    expect(a).toBe(b);
+  });
+
+  test("differs when args differ", () => {
+    const a = buildQueryKey("api.foo.bar", { x: 1 });
+    const b = buildQueryKey("api.foo.bar", { x: 2 });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("makeRouteQuerySpec", () => {
+  test("returns a spec with a consistent key", () => {
+    const spec = makeRouteQuerySpec(api.cms.getSection, {
+      section: "pricing",
+    });
+    expect(spec.query).toEqual(api.cms.getSection);
+    expect(spec.args).toEqual({ section: "pricing" });
+    expect(spec.key).toContain("pricing");
+  });
+});
+
+describe("prewarmSpecs", () => {
+  beforeEach(() => {
+    resetPrewarmDedupeForTests();
+  });
+
+  test("calls convex.prewarmQuery for each spec", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    const specs = [
+      makeRouteQuerySpec(api.cms.getSection, { section: "about" }),
+      makeRouteQuerySpec(api.cms.listMarketingFlagsDraft, {}),
+    ];
+    prewarmSpecs(client, specs);
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("dedupes calls that reuse the same key within the window", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    const spec = makeRouteQuerySpec(api.cms.getSection, { section: "about" });
+    prewarmSpecs(client, [spec]);
+    prewarmSpecs(client, [spec]);
+    expect(prewarmQuery.mock.calls.length).toBe(1);
+  });
+
+  test("dedupe can be overridden to 0 so repeat calls still fire", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    const spec = makeRouteQuerySpec(api.cms.getSection, { section: "about" });
+    prewarmSpecs(client, [spec], { dedupeMs: 0 });
+    prewarmSpecs(client, [spec], { dedupeMs: 0 });
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("swallows errors thrown by convex.prewarmQuery (non-fatal)", () => {
+    const prewarmQuery = mock((_args: PrewarmArgs): void => {
+      void _args;
+      throw new Error("network down");
+    });
+    const client = { prewarmQuery } as unknown as ConvexReactClient;
+    const spec = makeRouteQuerySpec(api.cms.getSection, { section: "about" });
+    expect(() => prewarmSpecs(client, [spec])).not.toThrow();
+  });
+
+  test("passes extendSubscriptionFor through", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    const spec = makeRouteQuerySpec(api.cms.getSection, { section: "about" });
+    prewarmSpecs(client, [spec], { extendSubscriptionFor: 1234 });
+    expect(prewarmQuery.mock.calls[0][0].extendSubscriptionFor).toBe(1234);
+  });
+});
+
+describe("prewarmAdminNavigation", () => {
+  beforeEach(() => {
+    resetPrewarmDedupeForTests();
+  });
+
+  test("no-op for unknown href", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/settings/legacy");
+    expect(prewarmQuery.mock.calls.length).toBe(0);
+  });
+
+  test("prewarms pricing (section + marketing flags)", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/pricing");
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("prewarms settings once", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/settings");
+    expect(prewarmQuery.mock.calls.length).toBe(1);
+  });
+
+  test("prewarms about (section + marketing flags)", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/about");
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("prewarms audio (marketing flags only)", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/audio");
+    expect(prewarmQuery.mock.calls.length).toBe(1);
+  });
+});
+
+describe("createRoutePrewarmIntent", () => {
+  const realTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+  let scheduled: Array<{
+    id: number;
+    fn: () => void;
+    ms: number;
+  }> = [];
+  let nextId = 1;
+
+  beforeEach(() => {
+    scheduled = [];
+    nextId = 1;
+    (globalThis as unknown as {
+      setTimeout: typeof setTimeout;
+    }).setTimeout = ((fn: () => void, ms: number) => {
+      const id = nextId++;
+      scheduled.push({ id, fn, ms });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    (globalThis as unknown as {
+      clearTimeout: typeof clearTimeout;
+    }).clearTimeout = ((id: number | undefined) => {
+      if (typeof id !== "number") return;
+      scheduled = scheduled.filter((s) => s.id !== id);
+    }) as typeof clearTimeout;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout =
+      realTimeout;
+    (
+      globalThis as unknown as { clearTimeout: typeof clearTimeout }
+    ).clearTimeout = realClearTimeout;
+  });
+
+  test("hovering schedules the prewarm after the debounce", () => {
+    const prewarm = mock(() => {});
+    const { handlers } = createRoutePrewarmIntent(prewarm, { debounceMs: 25 });
+    handlers.onMouseEnter();
+    expect(prewarm.mock.calls.length).toBe(0);
+    expect(scheduled.length).toBe(1);
+    scheduled[0].fn();
+    expect(prewarm.mock.calls.length).toBe(1);
+  });
+
+  test("mouseleave before the timeout cancels the scheduled prewarm", () => {
+    const prewarm = mock(() => {});
+    const { handlers } = createRoutePrewarmIntent(prewarm, { debounceMs: 25 });
+    handlers.onMouseEnter();
+    handlers.onMouseLeave();
+    expect(scheduled.length).toBe(0);
+    expect(prewarm.mock.calls.length).toBe(0);
+  });
+
+  test("blur cancels a pending intent", () => {
+    const prewarm = mock(() => {});
+    const { handlers } = createRoutePrewarmIntent(prewarm, { debounceMs: 25 });
+    handlers.onFocus();
+    handlers.onBlur();
+    expect(scheduled.length).toBe(0);
+  });
+
+  test("re-schedule while one is pending is a no-op (idempotent)", () => {
+    const prewarm = mock(() => {});
+    const { handlers } = createRoutePrewarmIntent(prewarm, { debounceMs: 25 });
+    handlers.onMouseEnter();
+    handlers.onMouseEnter();
+    expect(scheduled.length).toBe(1);
+  });
+});

--- a/src/lib/sidebar-cookie.test.ts
+++ b/src/lib/sidebar-cookie.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SIDEBAR_COOKIE_NAME,
+  getDefaultSidebarOpenFromCookie,
+} from "@/lib/sidebar-cookie";
+
+describe("SIDEBAR_COOKIE_NAME", () => {
+  test("matches the string the provider writes", () => {
+    expect(SIDEBAR_COOKIE_NAME).toBe("sidebar_state");
+  });
+});
+
+describe("getDefaultSidebarOpenFromCookie", () => {
+  test("'true' → open", () => {
+    expect(getDefaultSidebarOpenFromCookie("true")).toBe(true);
+  });
+
+  test("'false' → closed", () => {
+    expect(getDefaultSidebarOpenFromCookie("false")).toBe(false);
+  });
+
+  test("undefined falls back to open", () => {
+    expect(getDefaultSidebarOpenFromCookie(undefined)).toBe(true);
+  });
+
+  test("unknown strings default to open", () => {
+    expect(getDefaultSidebarOpenFromCookie("maybe")).toBe(true);
+    expect(getDefaultSidebarOpenFromCookie("")).toBe(true);
+  });
+});

--- a/src/lib/site-settings.test.ts
+++ b/src/lib/site-settings.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+  billingCadenceLabel,
+  formatPrice,
+  isHomepagePricingSectionEnabled,
+  previewHasActivePricingPackages,
+  type MarketingFeatureFlags,
+  type PricingFlags,
+  type PricingPackage,
+} from "@/lib/site-settings";
+
+const basePackage: PricingPackage = {
+  id: "pkg_1",
+  name: "Recording",
+  priceCents: 6000,
+  currency: "USD",
+  billingCadence: "hourly",
+  highlight: false,
+  sortOrder: 0,
+  isActive: true,
+};
+
+describe("isHomepagePricingSectionEnabled", () => {
+  test("null / undefined → false (no published flags yet)", () => {
+    expect(isHomepagePricingSectionEnabled(null)).toBe(false);
+    expect(isHomepagePricingSectionEnabled(undefined)).toBe(false);
+  });
+
+  test("missing pricingSection key treated as on", () => {
+    const flags = { aboutPage: false, recordingsPage: false } as unknown as MarketingFeatureFlags;
+    expect(isHomepagePricingSectionEnabled(flags)).toBe(true);
+  });
+
+  test("explicit false disables the block", () => {
+    const flags: MarketingFeatureFlags = {
+      aboutPage: false,
+      recordingsPage: false,
+      pricingSection: false,
+    };
+    expect(isHomepagePricingSectionEnabled(flags)).toBe(false);
+  });
+
+  test("explicit true enables the block", () => {
+    const flags: MarketingFeatureFlags = {
+      aboutPage: false,
+      recordingsPage: false,
+      pricingSection: true,
+    };
+    expect(isHomepagePricingSectionEnabled(flags)).toBe(true);
+  });
+});
+
+describe("previewHasActivePricingPackages", () => {
+  test("returns false for null / undefined inputs", () => {
+    expect(previewHasActivePricingPackages(null)).toBe(false);
+    expect(previewHasActivePricingPackages(undefined)).toBe(false);
+  });
+
+  test("returns false when no active packages", () => {
+    const flags: PricingFlags = {
+      flags: { priceTabEnabled: true },
+      packages: [{ ...basePackage, isActive: false }],
+    };
+    expect(previewHasActivePricingPackages(flags)).toBe(false);
+  });
+
+  test("returns true when any package is active", () => {
+    const flags: PricingFlags = {
+      flags: { priceTabEnabled: true },
+      packages: [{ ...basePackage, isActive: true }],
+    };
+    expect(previewHasActivePricingPackages(flags)).toBe(true);
+  });
+
+  test("returns false when packages undefined", () => {
+    const flags: PricingFlags = { flags: { priceTabEnabled: true } };
+    expect(previewHasActivePricingPackages(flags)).toBe(false);
+  });
+});
+
+describe("billingCadenceLabel re-export", () => {
+  test("re-exports from convex cmsShared", () => {
+    expect(billingCadenceLabel("hourly")).toBe("per hour");
+  });
+});
+
+describe("formatPrice", () => {
+  test("whole-dollar price has no decimals", () => {
+    expect(formatPrice(6000, "USD")).toBe("$60");
+  });
+
+  test("fractional-dollar price shows cents", () => {
+    expect(formatPrice(6050, "USD")).toBe("$60.50");
+  });
+
+  test("zero renders as $0", () => {
+    expect(formatPrice(0, "USD")).toBe("$0");
+  });
+
+  test("falls back to CODE/AMOUNT for unknown currency codes", () => {
+    const v = formatPrice(1000, "ZZZ");
+    // Intl may still format ZZZ if supported; assert the amount appears.
+    expect(v.includes("10")).toBe(true);
+  });
+});

--- a/src/lib/use-marketing-feature-flags-admin.test.ts
+++ b/src/lib/use-marketing-feature-flags-admin.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { mergeAutosaveStatus } from "@/lib/use-marketing-feature-flags-admin";
+import type { AutosaveStatus } from "@/components/admin/cms-publish-toolbar";
+
+describe("mergeAutosaveStatus", () => {
+  const statuses: AutosaveStatus[] = ["idle", "saving", "saved", "error"];
+
+  test("is symmetric (commutative)", () => {
+    for (const a of statuses) {
+      for (const b of statuses) {
+        expect(mergeAutosaveStatus(a, b)).toBe(mergeAutosaveStatus(b, a));
+      }
+    }
+  });
+
+  test("saving beats every other status", () => {
+    for (const other of statuses) {
+      expect(mergeAutosaveStatus("saving", other)).toBe("saving");
+    }
+  });
+
+  test("error beats idle + saved (but not saving)", () => {
+    expect(mergeAutosaveStatus("error", "idle")).toBe("error");
+    expect(mergeAutosaveStatus("error", "saved")).toBe("error");
+    expect(mergeAutosaveStatus("error", "error")).toBe("error");
+    expect(mergeAutosaveStatus("error", "saving")).toBe("saving");
+  });
+
+  test("saved beats idle", () => {
+    expect(mergeAutosaveStatus("saved", "idle")).toBe("saved");
+  });
+
+  test("two idle inputs stay idle", () => {
+    expect(mergeAutosaveStatus("idle", "idle")).toBe("idle");
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  test("joins truthy class names with a space", () => {
+    expect(cn("a", "b")).toBe("a b");
+  });
+
+  test("drops falsy values (null, undefined, false)", () => {
+    expect(cn("a", null, undefined, false, "b")).toBe("a b");
+  });
+
+  test("supports clsx-style object syntax", () => {
+    expect(cn("base", { active: true, disabled: false })).toBe("base active");
+  });
+
+  test("supports nested arrays", () => {
+    expect(cn(["a", ["b", "c"]])).toBe("a b c");
+  });
+
+  test("twMerge collapses duplicate Tailwind utilities (last wins)", () => {
+    expect(cn("px-2", "px-4")).toBe("px-4");
+    expect(cn("text-sm", "text-base")).toBe("text-base");
+  });
+
+  test("empty call returns empty string", () => {
+    expect(cn()).toBe("");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit tests (`bun test`) covering the pure logic in `convex/*` and the CMS admin editors under `src/app/admin/*`, plus the `src/lib/*` utilities that power them.

### Convex (pure module logic)
- `convex/cmsShared.test.ts` — `SETTINGS_DEFAULTS`, `DEFAULT_PRICING_PACKAGES` shape + uniqueness, `billingCadenceLabel`, `cmsSnapshotsEqual`, `defaultSnapshotForSection`
- `convex/cmsMeta.test.ts` — `DEFAULT_IS_ENABLED`, `effectiveIsEnabled`, `publishedIsEnabled`, `sectionHasPendingFlagDraft`, `anyMarketingFlagDraftPending`
- `convex/cmsPublishHelpers.test.ts` — `rowsWithPublishableDraft`, re-exports, additional `validatePricingPackageArray` cases
- `convex/errors.test.ts` — all `cms*` error factories (payload shape + optional-field handling)
- `convex/aboutTree.test.ts` — `normalizeAboutTreeForCompare`, `aboutDraftMatchesPublished`, `collectAboutTeamStorageIdsFromTree`, defaults
- `convex/pricingTree.test.ts` — `pricingPackageFromRow`, `normalizePricingForCompare`, `pricingDraftMatchesPublished`
- `convex/settingsTree.test.ts` — `normalizeSettingsForCompare`, `settingsDraftMatchesPublished`, defaults
- `convex/gearTree.test.ts` — `buildSortedGearTreeGroups`, `mapSortedGearTree`, `normalizeGearTreeForCompare`, `gearDraftMatchesPublished`
- `convex/galleryPhotos.test.ts` — constants + `galleryDraftMatchesPublished`
- `convex/publicSettingsSnapshot.test.ts` — `sanitizePricingPackages` (validates + sorts)
- `convex/aboutTeamStorage.test.ts` — `MAX_ABOUT_TEAM_MEMBERS` contract

### CMS admin frontend helpers
Pure helpers inside each admin editor were already `function`s; this PR promotes them to `export function` so companion tests can exercise them without DOM / React setup.

- `src/app/admin/pricing/pricing-editor.test.ts` — `isCadence`, `parsePriceInput`, `priceCentsToDisplay`, `renumberSortOrder`, `toPricingContent`
- `src/app/admin/gear/gear-editor.test.ts` — `specsPreview`, `validateItemName`, `validateCategoryName`, `validateSpecs`, `validateUrl`, `sortCategories`, `sortItems`, `nextAppendSort`
- `src/app/admin/photos/photos-editor.test.ts` — `defaultAltFromFileName`, `formatBytes`, `validatePhotoFields`
- `src/app/admin/about/about-editor.test.ts` — `trimToUndefined`, `escapeHtml`, `blocksToHtml`, `htmlToPlainText`, `toAboutContent`, `collectAboutIssues`
- `src/app/admin/settings/settings-editor.test.ts` — `toSettingsContent`

### Shared lib
- `src/lib/admin-nav.test.ts`, `src/lib/contact-inquiry-schema.test.ts`, `src/lib/reveal-delay.test.ts`, `src/lib/route-prewarm.test.ts`, `src/lib/sidebar-cookie.test.ts`, `src/lib/site-settings.test.ts`, `src/lib/use-marketing-feature-flags-admin.test.ts`, `src/lib/utils.test.ts`

## Testing

- ✅ `bun test` → 295 tests passed across 26 files (up from 15 / 2 files on `main`)
- ✅ `bun run lint` → no errors
- ✅ `bun run build` → succeeds

## Notes

- The React-rendering layers of the admin editors are intentionally **not** covered here — the repo does not ship `jsdom` / `@testing-library/react`, and adding a DOM runtime is out of scope for this task. Instead, every exported helper that drives editor behaviour (validation, sorting, shape normalisation, price parsing, etc.) is covered directly.
- No runtime behaviour changes; only additional `export` modifiers on helpers already defined inside each editor file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-859576f8-4465-4e55-b906-4da6b505392d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-859576f8-4465-4e55-b906-4da6b505392d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

