### PR TITLE
feat(admin): persistent CMS toolbar, nav guard, and pending-draft indicators

### DIFF
--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -182,6 +182,57 @@ export const saveDraft = mutation({
 });
 
 /**
+ * Aggregate list of CMS surfaces that have a pending draft right now.
+ *
+ * The admin toolbar and sidebar use this to indicate — from any admin route —
+ * which sections still need to be published / discarded. Covers every place
+ * that tracks draft state: the `cmsSections` metadata table (settings,
+ * pricing, about, recordings) plus the two singleton-metadata tables used by
+ * the gear and photo CMS trees.
+ *
+ * Unauthenticated callers get an empty list (rather than an error) so the
+ * admin layout can mount this query before the Clerk session hydrates
+ * without crashing the sidebar / toolbar chrome. Admin routes remain
+ * gated upstream by Clerk.
+ */
+export const listPendingDrafts = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return {
+        sections: [] as Array<
+          "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+        >,
+      };
+    }
+
+    const [cmsRows, gearMeta, galleryMeta] = await Promise.all([
+      ctx.db.query("cmsSections").collect(),
+      ctx.db
+        .query("gearMeta")
+        .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+        .unique(),
+      ctx.db
+        .query("galleryPhotoMeta")
+        .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+        .unique(),
+    ]);
+
+    const sections: Array<
+      "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+    > = [];
+    for (const row of cmsRows) {
+      if (row.hasDraftChanges) sections.push(row.section);
+    }
+    if (gearMeta?.hasDraftChanges) sections.push("gear");
+    if (galleryMeta?.hasDraftChanges) sections.push("photos");
+
+    return { sections };
+  },
+});
+
+/**
  * Owner-only view of the three marketing-visibility flags (about / recordings
  * / homepage pricing block). Reads per-section `cmsSections` rows and returns
  * the historical shape so the admin hook stays simple.

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -192,8 +192,8 @@ export const saveDraft = mutation({
  *
  * Unauthenticated callers get an empty list (rather than an error) so the
  * admin layout can mount this query before the Clerk session hydrates
- * without crashing the sidebar / toolbar chrome. Admin routes remain
- * gated upstream by Clerk.
+ * without crashing the sidebar / toolbar chrome. Authenticated callers
+ * must pass the same owner check as other CMS queries.
  */
 export const listPendingDrafts = query({
   args: {},
@@ -206,6 +206,8 @@ export const listPendingDrafts = query({
         >,
       };
     }
+
+    await requireCmsOwner(ctx);
 
     const [cmsRows, gearMeta, galleryMeta] = await Promise.all([
       ctx.db.query("cmsSections").collect(),

--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -49,7 +49,7 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { convexMutationEffect } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { useAutosaveDraft } from "@/lib/use-autosave-draft";
 import {
   mergeAutosaveStatus,
@@ -675,6 +675,104 @@ function AboutForm() {
     ffAutosaveStatus,
   );
 
+  const publishedByLabel =
+    section?.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
+
+  const handlePublish = useCallback(() => {
+    if (!base) return;
+    const liveBody = bodyDirty
+      ? (bodyRef.current?.getHTML() ?? "")
+      : (base.bodyHtml ?? "");
+    const publishSnapshot: AboutContent = {
+      ...base,
+      bodyHtml: liveBody,
+      body: [],
+    };
+    const publishIssues = collectAboutIssues(publishSnapshot);
+    if (publishIssues.length > 0) {
+      setInlineError("Fix the blocking issues above before publishing.");
+      return;
+    }
+    void (async () => {
+      cancelAutosaveRef.current();
+      cancelFFAutosave();
+      if (hasAboutLocalEdits) {
+        const flushed = await flushAutosave();
+        if (!flushed) return;
+      }
+      if (hasFFLocalEdits) {
+        const flushed = await flushFFAutosave();
+        if (!flushed) return;
+      }
+      setInlineError(null);
+      setBusy("Publishing…");
+      const aboutOutcome = await runAdminEffect(
+        convexMutationEffect(() => publish({ section: "about" })),
+        { onErrorMessage: setInlineError },
+      );
+      if (aboutOutcome === undefined) {
+        setBusy(null);
+        return;
+      }
+      setLocalDraft(null);
+      clearLocalBodyUiState();
+      const ffOutcome = await runAdminEffect(runPublishFF(), {
+        onErrorMessage: setInlineError,
+      });
+      setBusy(null);
+      if (ffOutcome !== undefined) {
+        clearFFLocal();
+        toast.success("Changes published.");
+      }
+    })();
+  }, [
+    base,
+    bodyDirty,
+    cancelFFAutosave,
+    clearFFLocal,
+    clearLocalBodyUiState,
+    flushAutosave,
+    flushFFAutosave,
+    hasAboutLocalEdits,
+    hasFFLocalEdits,
+    publish,
+    runPublishFF,
+  ]);
+
+  /**
+   * Composite flush awaited by the sidebar nav guard. Silently persists any
+   * in-memory About edits and marketing-flag edits before navigation so the
+   * user never loses a one-shot change (e.g. a freshly-toggled switch within
+   * the 1s autosave debounce window).
+   */
+  const flushAllAutosaves = useCallback(async (): Promise<boolean> => {
+    if (hasAboutLocalEdits) {
+      const ok = await flushAutosave();
+      if (!ok) return false;
+    }
+    if (hasFFLocalEdits) {
+      const ok = await flushFFAutosave();
+      if (!ok) return false;
+    }
+    return true;
+  }, [flushAutosave, flushFFAutosave, hasAboutLocalEdits, hasFFLocalEdits]);
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "about",
+    sectionLabel: "the About page",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: mergedPublishedAt,
+    publishedByLabel,
+    busy,
+    autosaveStatus: combinedAutosaveStatus,
+    inlineError,
+    previewHref: "/preview/about",
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAllAutosaves,
+  });
+
   // The wrapping `<div>` needs a *stable* ref callback. An inline arrow is a
   // new function on every render, which makes React detach (call old ref with
   // `null`) and reattach (call new ref with the element) every time. The
@@ -687,8 +785,9 @@ function AboutForm() {
     (el: HTMLDivElement | null) => {
       autosaveOnUnmount(el);
       ffOnUnmount(el);
+      editorRef(el);
     },
-    [autosaveOnUnmount, ffOnUnmount],
+    [autosaveOnUnmount, ffOnUnmount, editorRef],
   );
 
   if (section === undefined || featureFlagsLoading) {
@@ -704,9 +803,6 @@ function AboutForm() {
       </p>
     );
   }
-
-  const publishedByLabel =
-    section.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
 
   const seoTitleValue = base.seoTitle ?? "";
   const seoDescriptionValue = base.seoDescription ?? "";
@@ -906,67 +1002,7 @@ function AboutForm() {
             bodyDirty={bodyDirty}
           />
       </div>
-
-      <CmsPublishToolbar
-        section="about"
-        sectionLabel="the About page"
-        hasDraftOnServer={hasDraftOnServer}
-        hasLocalEdits={hasLocalEdits}
-        publishedAt={mergedPublishedAt}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        inlineError={inlineError}
-        autosaveStatus={combinedAutosaveStatus}
-        previewHref="/preview/about"
-        onPublish={() => {
-          const liveBody = bodyDirty
-            ? (bodyRef.current?.getHTML() ?? "")
-            : (base.bodyHtml ?? "");
-          const publishSnapshot: AboutContent = {
-            ...base,
-            bodyHtml: liveBody,
-            body: [],
-          };
-          const publishIssues = collectAboutIssues(publishSnapshot);
-          if (publishIssues.length > 0) {
-            setInlineError("Fix the blocking issues above before publishing.");
-            return;
-          }
-          void (async () => {
-            cancelAutosaveRef.current();
-            cancelFFAutosave();
-            if (hasAboutLocalEdits) {
-              const flushed = await flushAutosave();
-              if (!flushed) return;
-            }
-            if (hasFFLocalEdits) {
-              const flushed = await flushFFAutosave();
-              if (!flushed) return;
-            }
-            setInlineError(null);
-            setBusy("Publishing…");
-            const aboutOutcome = await runAdminEffect(
-              convexMutationEffect(() => publish({ section: "about" })),
-              { onErrorMessage: setInlineError },
-            );
-            if (aboutOutcome === undefined) {
-              setBusy(null);
-              return;
-            }
-            setLocalDraft(null);
-            clearLocalBodyUiState();
-            const ffOutcome = await runAdminEffect(runPublishFF(), {
-              onErrorMessage: setInlineError,
-            });
-            setBusy(null);
-            if (ffOutcome !== undefined) {
-              clearFFLocal();
-              toast.success("Changes published.");
-            }
-          })();
-        }}
-        onDiscardConfirm={handleDiscardConfirm}
-      />
+      {toolbarPortal}
     </div>
   );
 }

--- a/src/app/admin/audio/audio-admin.tsx
+++ b/src/app/admin/audio/audio-admin.tsx
@@ -8,7 +8,7 @@ import {
 import { useUser } from "@clerk/nextjs";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { Switch } from "@/components/ui/switch";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { useMarketingFeatureFlagsAdmin } from "@/lib/use-marketing-feature-flags-admin";
@@ -72,6 +72,64 @@ function AudioAdminForm() {
     return true;
   }, [hasFFDraftOnServer, runDiscardFF, clearFFLocal, cancelFFAutosave]);
 
+  const handlePublish = useCallback(() => {
+    void (async () => {
+      cancelFFAutosave();
+      if (hasFFLocalEdits) {
+        const flushed = await flushFFAutosave();
+        if (!flushed) return;
+      }
+      setInlineError(null);
+      setBusy("Publishing…");
+      const outcome = await runAdminEffect(runPublishFF(), {
+        onErrorMessage: setInlineError,
+      });
+      setBusy(null);
+      if (outcome !== undefined) {
+        clearFFLocal();
+        toast.success("Changes published.");
+      }
+    })();
+  }, [cancelFFAutosave, clearFFLocal, flushFFAutosave, hasFFLocalEdits, runPublishFF]);
+
+  const flushAllAutosaves = useCallback(async (): Promise<boolean> => {
+    if (hasFFLocalEdits) {
+      const ok = await flushFFAutosave();
+      if (!ok) return false;
+    }
+    return true;
+  }, [flushFFAutosave, hasFFLocalEdits]);
+
+  const publishedByLabel =
+    featureFlagsCms?.publishedBy && user?.id === featureFlagsCms.publishedBy
+      ? "You"
+      : undefined;
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "marketingFeatureFlags",
+    sectionLabel: "Recordings visibility",
+    hasDraftOnServer: hasFFDraftOnServer,
+    hasLocalEdits: hasFFLocalEdits,
+    publishedAt: featureFlagsCms?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    autosaveStatus: ffAutosaveStatus,
+    inlineError,
+    previewHref: "/preview",
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAllAutosaves,
+  });
+
+  // Stable ref callback — see the matching comment in `about-editor.tsx`.
+  const handleEditorRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      ffOnUnmount(el);
+      editorRef(el);
+    },
+    [ffOnUnmount, editorRef],
+  );
+
   if (isLoading) {
     return (
       <p className="body-text text-muted-foreground">Loading site visibility…</p>
@@ -86,13 +144,8 @@ function AudioAdminForm() {
     );
   }
 
-  const publishedByLabel =
-    featureFlagsCms?.publishedBy && user?.id === featureFlagsCms.publishedBy
-      ? "You"
-      : undefined;
-
   return (
-    <div className="space-y-8 pb-24" ref={ffOnUnmount}>
+    <div className="space-y-8 pb-24" ref={handleEditorRef}>
       <div className="rounded-lg border border-border bg-muted/50 p-6 text-center">
         <p className="body-text text-muted-foreground">
           Audio sample management coming soon.
@@ -120,39 +173,7 @@ function AudioAdminForm() {
           </div>
         </div>
       </fieldset>
-
-      <CmsPublishToolbar
-        section="marketingFeatureFlags"
-        sectionLabel="Recordings visibility"
-        hasDraftOnServer={hasFFDraftOnServer}
-        hasLocalEdits={hasFFLocalEdits}
-        publishedAt={featureFlagsCms?.publishedAt ?? null}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        onPublish={() => {
-          void (async () => {
-            cancelFFAutosave();
-            if (hasFFLocalEdits) {
-              const flushed = await flushFFAutosave();
-              if (!flushed) return;
-            }
-            setInlineError(null);
-            setBusy("Publishing…");
-            const outcome = await runAdminEffect(runPublishFF(), {
-              onErrorMessage: setInlineError,
-            });
-            setBusy(null);
-            if (outcome !== undefined) {
-              clearFFLocal();
-              toast.success("Changes published.");
-            }
-          })();
-        }}
-        onDiscardConfirm={handleDiscardConfirm}
-        previewHref="/preview"
-        inlineError={inlineError}
-        autosaveStatus={ffAutosaveStatus}
-      />
+      {toolbarPortal}
     </div>
   );
 }

--- a/src/app/admin/gear/gear-editor.tsx
+++ b/src/app/admin/gear/gear-editor.tsx
@@ -50,7 +50,7 @@ import {
 import { cn } from "@/lib/utils";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 
 /** Client-side limits (Convex schema is structural only). */
 const MAX_NAME_LEN = 500;
@@ -513,6 +513,32 @@ function GearEditorForm() {
 
   const publishProgram = convexMutationEffect(() => publishGear({}));
 
+  const handleToolbarPublish = useCallback(() => {
+    void (async () => {
+      const ok = await runAction("Publishing…", publishProgram);
+      if (ok !== undefined) {
+        toast.success("Gear published.");
+      }
+    })();
+  }, [publishProgram, runAction]);
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "gear",
+    sectionLabel: "gear",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: data?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    inlineError,
+    previewHref: "/preview#equipment-specs",
+    onPublish: handleToolbarPublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    // No `flush` — gear edits are persisted server-side per-row so
+    // `hasLocalEdits` is always false; the nav guard never needs to
+    // intervene.
+  });
+
   if (data === undefined) {
     return (
       <p className="body-text text-foreground/80">Loading gear…</p>
@@ -520,7 +546,7 @@ function GearEditorForm() {
   }
 
   return (
-    <div className="space-y-8 pb-24">
+    <div className="space-y-8 pb-24" ref={editorRef}>
       <div className="space-y-6">
         <div className="space-y-2">
           <h2 className="font-heading text-xl font-semibold text-foreground">
@@ -727,26 +753,7 @@ function GearEditorForm() {
         </div>
       )}
 
-      <CmsPublishToolbar
-        section="gear"
-        sectionLabel="gear"
-        hasDraftOnServer={hasDraftOnServer}
-        hasLocalEdits={hasLocalEdits}
-        publishedAt={data.publishedAt ?? null}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        inlineError={inlineError}
-        previewHref="/preview#equipment-specs"
-        onPublish={() => {
-          void (async () => {
-            const ok = await runAction("Publishing…", publishProgram);
-            if (ok !== undefined) {
-              toast.success("Gear published.");
-            }
-          })();
-        }}
-        onDiscardConfirm={handleDiscardConfirm}
-      />
+      {toolbarPortal}
 
       <Sheet
         open={categorySheet !== null}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,6 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AdminSidebar } from "@/components/admin/admin-sidebar";
 import {
+  CmsWorkspaceProvider,
+  CmsPersistentToolbarHost,
+} from "@/components/admin/cms-workspace";
+import {
   getDefaultSidebarOpenFromCookie,
   SIDEBAR_COOKIE_NAME,
 } from "@/lib/sidebar-cookie";
@@ -36,10 +40,13 @@ export default async function AdminLayout({
         resizableWidth
         sidebarWidthStorageKey="admin_sidebar_width_px"
       >
-        <AdminSidebar />
-        <SidebarInset className="text-foreground">
-          {children}
-        </SidebarInset>
+        <CmsWorkspaceProvider>
+          <AdminSidebar />
+          <SidebarInset className="text-foreground">
+            {children}
+            <CmsPersistentToolbarHost />
+          </SidebarInset>
+        </CmsWorkspaceProvider>
       </SidebarProvider>
     </TooltipProvider>
   );

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -44,7 +44,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { cn } from "@/lib/utils";
@@ -836,6 +836,27 @@ function PhotosEditorForm() {
     }
   }, [publishPhotos, runAction, savePendingEdits]);
 
+  const handleToolbarPublish = useCallback(() => {
+    void handlePublish();
+  }, [handlePublish]);
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "photos",
+    sectionLabel: "Studio gallery",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: data?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    autosaveStatus: "idle",
+    inlineError,
+    previewHref: "/preview#the-space",
+    onPublish: handleToolbarPublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    // No `flush` — dirty local edits trigger the nav-guard confirm dialog
+    // (they're manual-save pending metadata tweaks, not autosavable).
+  });
+
   if (data === undefined) {
     return <p className="body-text text-foreground/80">Loading photos…</p>;
   }
@@ -846,6 +867,7 @@ function PhotosEditorForm() {
 
   return (
     <div
+      ref={editorRef}
       className={cn(
         "relative space-y-8 pb-24 transition",
         isDraggingOver &&
@@ -1205,20 +1227,7 @@ function PhotosEditorForm() {
         </div>
       )}
 
-      <CmsPublishToolbar
-        section="photos"
-        sectionLabel="Studio gallery"
-        hasDraftOnServer={hasDraftOnServer}
-        hasLocalEdits={hasLocalEdits}
-        publishedAt={data.publishedAt}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        onPublish={() => void handlePublish()}
-        onDiscardConfirm={handleDiscardConfirm}
-        previewHref="/preview#the-space"
-        inlineError={inlineError}
-        autosaveStatus="idle"
-      />
+      {toolbarPortal}
 
       <AlertDialog
         open={deleteStableId !== null}

--- a/src/app/admin/pricing/pricing-editor.tsx
+++ b/src/app/admin/pricing/pricing-editor.tsx
@@ -26,7 +26,7 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { convexMutationEffect } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { useAutosaveDraft } from "@/lib/use-autosave-draft";
 import {
   mergeAutosaveStatus,
@@ -427,6 +427,84 @@ function PricingForm() {
     ffAutosaveStatus,
   );
 
+  const publishedByLabel =
+    pricing?.publishedBy && user?.id === pricing.publishedBy ? "You" : undefined;
+
+  const handlePublish = useCallback(() => {
+    void (async () => {
+      cancelAutosaveRef.current();
+      cancelFFAutosave();
+      if (hasPricingLocalEdits) {
+        const flushed = await flushAutosave();
+        if (!flushed) return;
+      }
+      if (hasFFLocalEdits) {
+        const flushed = await flushFFAutosave();
+        if (!flushed) return;
+      }
+      setInlineError(null);
+      setBusy("Publishing…");
+      const priceOutcome = await runAdminEffect(
+        convexMutationEffect(() => publish({})),
+        { onErrorMessage: setInlineError },
+      );
+      if (priceOutcome === undefined) {
+        setBusy(null);
+        return;
+      }
+      setLocalDraft(null);
+      const ffOutcome = await runAdminEffect(runPublishFF(), {
+        onErrorMessage: setInlineError,
+      });
+      setBusy(null);
+      if (ffOutcome !== undefined) {
+        clearFFLocal();
+        toast.success("Changes published.");
+      }
+    })();
+  }, [
+    cancelFFAutosave,
+    clearFFLocal,
+    flushAutosave,
+    flushFFAutosave,
+    hasFFLocalEdits,
+    hasPricingLocalEdits,
+    publish,
+    runPublishFF,
+  ]);
+
+  /**
+   * Composite flush awaited by the sidebar nav guard — see the matching
+   * helper in `about-editor.tsx`.
+   */
+  const flushAllAutosaves = useCallback(async (): Promise<boolean> => {
+    if (hasPricingLocalEdits) {
+      const ok = await flushAutosave();
+      if (!ok) return false;
+    }
+    if (hasFFLocalEdits) {
+      const ok = await flushFFAutosave();
+      if (!ok) return false;
+    }
+    return true;
+  }, [flushAutosave, flushFFAutosave, hasPricingLocalEdits, hasFFLocalEdits]);
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "pricing",
+    sectionLabel: "pricing",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: mergedPublishedAt,
+    publishedByLabel,
+    busy,
+    autosaveStatus: combinedAutosaveStatus,
+    inlineError,
+    previewHref: "/preview#services-pricing",
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAllAutosaves,
+  });
+
   // Stable ref callback so React only runs `dispose()` (which clears the
   // pending autosave timer) when this editor truly unmounts. An inline arrow
   // would be a new function each render, causing React to detach + reattach
@@ -436,8 +514,9 @@ function PricingForm() {
     (el: HTMLDivElement | null) => {
       autosaveOnUnmount(el);
       ffOnUnmount(el);
+      editorRef(el);
     },
-    [autosaveOnUnmount, ffOnUnmount],
+    [autosaveOnUnmount, ffOnUnmount, editorRef],
   );
 
   if (pricing === undefined || featureFlagsLoading) {
@@ -451,9 +530,6 @@ function PricingForm() {
       </p>
     );
   }
-
-  const publishedByLabel =
-    pricing.publishedBy && user?.id === pricing.publishedBy ? "You" : undefined;
 
   return (
     <div className="space-y-10 pb-24" ref={handleEditorRef}>
@@ -755,52 +831,7 @@ function PricingForm() {
         )}
       </section>
 
-      <CmsPublishToolbar
-        section="pricing"
-        sectionLabel="pricing"
-        hasDraftOnServer={hasDraftOnServer}
-        hasLocalEdits={hasLocalEdits}
-        publishedAt={mergedPublishedAt}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        inlineError={inlineError}
-        autosaveStatus={combinedAutosaveStatus}
-        previewHref="/preview#services-pricing"
-        onPublish={() => {
-          void (async () => {
-            cancelAutosaveRef.current();
-            cancelFFAutosave();
-            if (hasPricingLocalEdits) {
-              const flushed = await flushAutosave();
-              if (!flushed) return;
-            }
-            if (hasFFLocalEdits) {
-              const flushed = await flushFFAutosave();
-              if (!flushed) return;
-            }
-            setInlineError(null);
-            setBusy("Publishing…");
-            const priceOutcome = await runAdminEffect(
-              convexMutationEffect(() => publish({})),
-              { onErrorMessage: setInlineError },
-            );
-            if (priceOutcome === undefined) {
-              setBusy(null);
-              return;
-            }
-            setLocalDraft(null);
-            const ffOutcome = await runAdminEffect(runPublishFF(), {
-              onErrorMessage: setInlineError,
-            });
-            setBusy(null);
-            if (ffOutcome !== undefined) {
-              clearFFLocal();
-              toast.success("Changes published.");
-            }
-          })();
-        }}
-        onDiscardConfirm={handleDiscardConfirm}
-      />
+      {toolbarPortal}
     </div>
   );
 }

--- a/src/app/admin/settings/settings-editor.tsx
+++ b/src/app/admin/settings/settings-editor.tsx
@@ -14,7 +14,7 @@ import { Effect } from "effect";
 import { toast } from "sonner";
 import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { useAutosaveDraft } from "@/lib/use-autosave-draft";
 
 type SettingsContent = {
@@ -163,6 +163,48 @@ function SettingsForm() {
     return true;
   }, [discard, hasDraftOnServer]);
 
+  const handlePublish = useCallback(() => {
+    const publishOnce = convexMutationEffect(() =>
+      publish({ section: "settings" }),
+    );
+    void (async () => {
+      if (hasLocalEdits) {
+        const flushed = await flushAutosave();
+        if (!flushed) return;
+      }
+      await runAction("Publishing…", publishOnce);
+    })();
+  }, [flushAutosave, hasLocalEdits, publish, runAction]);
+
+  const publishedByLabel =
+    section?.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "settings",
+    sectionLabel: "site settings",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: section?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    autosaveStatus,
+    inlineError,
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAutosave,
+  });
+
+  // Stable ref callback — see the matching comment in `about-editor.tsx`.
+  // An inline arrow would be a new identity each render, causing React to
+  // detach/reattach every render and kill the pending autosave debounce.
+  const handleEditorRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      autosaveOnUnmount(el);
+      editorRef(el);
+    },
+    [autosaveOnUnmount, editorRef],
+  );
+
   if (section === undefined) {
     return <p className="body-text text-muted-foreground">Loading settings…</p>;
   }
@@ -173,11 +215,8 @@ function SettingsForm() {
     );
   }
 
-  const publishedByLabel =
-    section.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
-
   return (
-    <div className="space-y-8 pb-24" ref={autosaveOnUnmount}>
+    <div className="space-y-8 pb-24" ref={handleEditorRef}>
       <fieldset className="space-y-3">
         <legend className="label-text text-muted-foreground">Site Metadata</legend>
         <label className="block space-y-1">
@@ -209,31 +248,7 @@ function SettingsForm() {
           />
         </label>
       </fieldset>
-
-      <CmsPublishToolbar
-        section="settings"
-        sectionLabel="site settings"
-        hasDraftOnServer={hasDraftOnServer}
-        hasLocalEdits={hasLocalEdits}
-        publishedAt={section.publishedAt ?? null}
-        publishedByLabel={publishedByLabel}
-        busy={busy}
-        inlineError={inlineError}
-        autosaveStatus={autosaveStatus}
-        onPublish={() => {
-          const publishOnce = convexMutationEffect(() =>
-            publish({ section: "settings" }),
-          );
-          void (async () => {
-            if (hasLocalEdits) {
-              const flushed = await flushAutosave();
-              if (!flushed) return;
-            }
-            await runAction("Publishing…", publishOnce);
-          })();
-        }}
-        onDiscardConfirm={handleDiscardConfirm}
-      />
+      {toolbarPortal}
     </div>
   );
 }

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -23,7 +23,8 @@ import {
   useRoutePrewarmIntent,
 } from "@/lib/route-prewarm";
 import { useCmsNavGuard } from "@/components/admin/cms-workspace";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import { usePendingDraftSections } from "@/components/admin/use-pending-drafts";
+import { useMemo, type MouseEvent as ReactMouseEvent } from "react";
 
 const navItems = [
   { title: "Dashboard", href: "/admin", icon: LayoutDashboard },
@@ -33,9 +34,11 @@ const navItems = [
 function AdminNavLinkItem({
   item,
   pathname,
+  hasPendingChanges,
 }: {
   item: (typeof navItems)[number];
   pathname: string;
+  hasPendingChanges: boolean;
 }) {
   const convex = useConvex();
   const router = useRouter();
@@ -68,11 +71,15 @@ function AdminNavLinkItem({
     if (ok) router.push(item.href);
   }
 
+  const tooltipLabel = hasPendingChanges
+    ? `${item.title} · unpublished changes`
+    : item.title;
+
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
         isActive={isActive(item.href)}
-        tooltip={item.title}
+        tooltip={tooltipLabel}
         render={
           <Link
             href={item.href}
@@ -82,8 +89,19 @@ function AdminNavLinkItem({
           />
         }
       >
-        <item.icon className="size-4" />
+        <span className="relative inline-flex shrink-0 items-center justify-center">
+          <item.icon className="size-4" />
+          {hasPendingChanges ? (
+            <span
+              aria-hidden
+              className="pointer-events-none absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-amber-500 ring-2 ring-sidebar"
+            />
+          ) : null}
+        </span>
         <span>{item.title}</span>
+        {hasPendingChanges ? (
+          <span className="sr-only"> (unpublished changes)</span>
+        ) : null}
       </SidebarMenuButton>
     </SidebarMenuItem>
   );
@@ -124,6 +142,11 @@ function BackToSiteLink() {
 
 export function AdminSidebar() {
   const pathname = usePathname();
+  const pending = usePendingDraftSections();
+  const pendingHrefs = useMemo(
+    () => new Set(pending.map((section) => section.href)),
+    [pending],
+  );
 
   return (
     <Sidebar
@@ -168,6 +191,7 @@ export function AdminSidebar() {
                   key={item.href}
                   item={item}
                   pathname={pathname}
+                  hasPendingChanges={pendingHrefs.has(item.href)}
                 />
               ))}
             </SidebarMenu>

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useConvex } from "convex/react";
 import { LayoutDashboard, ArrowLeft } from "lucide-react";
 import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
@@ -22,6 +22,8 @@ import {
   prewarmAdminNavigation,
   useRoutePrewarmIntent,
 } from "@/lib/route-prewarm";
+import { useCmsNavGuard } from "@/components/admin/cms-workspace";
+import type { MouseEvent as ReactMouseEvent } from "react";
 
 const navItems = [
   { title: "Dashboard", href: "/admin", icon: LayoutDashboard },
@@ -36,6 +38,8 @@ function AdminNavLinkItem({
   pathname: string;
 }) {
   const convex = useConvex();
+  const router = useRouter();
+  const { attemptNavigate } = useCmsNavGuard();
   const { handlers: prewarmHandlers, intentRootRef } = useRoutePrewarmIntent(
     () => prewarmAdminNavigation(convex, item.href),
   );
@@ -45,19 +49,76 @@ function AdminNavLinkItem({
     return pathname.startsWith(href);
   }
 
+  async function handleClick(event: ReactMouseEvent<HTMLAnchorElement>) {
+    if (isActive(item.href)) return;
+    // Skip the guard on modifier clicks so the user can still open the
+    // destination in a new tab / window / background tab.
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const ok = await attemptNavigate();
+    if (ok) router.push(item.href);
+  }
+
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
         isActive={isActive(item.href)}
         tooltip={item.title}
         render={
-          <Link href={item.href} ref={intentRootRef} {...prewarmHandlers} />
+          <Link
+            href={item.href}
+            ref={intentRootRef}
+            onClick={handleClick}
+            {...prewarmHandlers}
+          />
         }
       >
         <item.icon className="size-4" />
         <span>{item.title}</span>
       </SidebarMenuButton>
     </SidebarMenuItem>
+  );
+}
+
+function BackToSiteLink() {
+  const router = useRouter();
+  const { attemptNavigate } = useCmsNavGuard();
+
+  async function handleClick(event: ReactMouseEvent<HTMLAnchorElement>) {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const ok = await attemptNavigate();
+    if (ok) router.push("/");
+  }
+
+  return (
+    <SidebarMenuButton
+      tooltip="Back to site"
+      render={<Link href="/" onClick={handleClick} />}
+    >
+      <ArrowLeft className="size-4" />
+      <span className="body-text-small text-sidebar-foreground">
+        Back to site
+      </span>
+    </SidebarMenuButton>
   );
 }
 
@@ -117,15 +178,7 @@ export function AdminSidebar() {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton
-              tooltip="Back to site"
-              render={<Link href="/" />}
-            >
-              <ArrowLeft className="size-4" />
-              <span className="body-text-small text-sidebar-foreground">
-                Back to site
-              </span>
-            </SidebarMenuButton>
+            <BackToSiteLink />
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/src/components/admin/before-unload-guard.tsx
+++ b/src/components/admin/before-unload-guard.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import { useCmsNavStateRef } from "@/components/admin/cms-workspace";
+
+/**
+ * Warns the browser (and the user) when they try to reload, close the tab,
+ * or navigate externally while an admin editor reports unsaved local edits.
+ *
+ * The listener is attached via a ref callback — matching the project's
+ * ref-callback-instead-of-useEffect convention used in
+ * `src/hooks/use-scroll-and-reveal.ts` — and reads the latest dirty flag
+ * straight from the workspace nav-state ref so the handler always has
+ * fresh data without being re-installed.
+ *
+ * Sidebar / in-app nav is handled separately via the nav guard; this
+ * guard only exists for browser-level lifecycle events.
+ */
+export function BeforeUnloadGuard() {
+  const navStateRef = useCmsNavStateRef();
+
+  const refCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (!el) return;
+      function onBeforeUnload(event: BeforeUnloadEvent) {
+        if (!navStateRef.current.hasLocalEdits) return;
+        event.preventDefault();
+        event.returnValue = "";
+      }
+      window.addEventListener("beforeunload", onBeforeUnload);
+      return () => {
+        window.removeEventListener("beforeunload", onBeforeUnload);
+      };
+    },
+    [navStateRef],
+  );
+
+  return <div ref={refCallback} hidden aria-hidden="true" />;
+}

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -65,6 +65,8 @@ interface CmsWorkspaceContextValue {
   readonly hostNode: HTMLDivElement | null;
   readonly registerHostNode: (el: HTMLDivElement | null) => void;
   readonly navStateRef: MutableRefObject<CmsNavState>;
+  /** Which editor last wrote `navStateRef` (avoids stale unmount clearing a successor's state). */
+  readonly activeEditorMountRef: MutableRefObject<unknown>;
   readonly attemptNavigate: () => Promise<boolean>;
   readonly openConfirm: () => Promise<ConfirmResult>;
 }
@@ -83,6 +85,7 @@ const CmsWorkspaceContext = createContext<CmsWorkspaceContextValue | null>(
 export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
   const [hostNode, setHostNode] = useState<HTMLDivElement | null>(null);
   const navStateRef = useRef<CmsNavState>({ hasLocalEdits: false });
+  const activeEditorMountRef = useRef<unknown>(null);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
   const confirmResolverRef = useRef<((r: ConfirmResult) => void) | null>(null);
@@ -126,6 +129,7 @@ export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
       hostNode,
       registerHostNode,
       navStateRef,
+      activeEditorMountRef,
       attemptNavigate,
       openConfirm,
     }),
@@ -209,20 +213,27 @@ export interface RegisteredCmsEditor {
 export function useRegisterCmsEditor(
   state: CmsEditorState,
 ): RegisteredCmsEditor {
-  const { hostNode, navStateRef } = useCmsWorkspace();
+  const { hostNode, navStateRef, activeEditorMountRef } = useCmsWorkspace();
+  const mountIdRef = useRef<object | null>(null);
+  if (mountIdRef.current === null) {
+    mountIdRef.current = {};
+  }
 
   navStateRef.current = {
     hasLocalEdits: state.hasLocalEdits,
     flush: state.flush,
   };
+  activeEditorMountRef.current = mountIdRef.current;
 
   const editorRef = useCallback(
     (el: HTMLElement | null) => {
       if (!el) {
-        navStateRef.current = { hasLocalEdits: false };
+        if (activeEditorMountRef.current === mountIdRef.current) {
+          navStateRef.current = { hasLocalEdits: false };
+        }
       }
     },
-    [navStateRef],
+    [navStateRef, activeEditorMountRef],
   );
 
   const toolbarPortal: ReactNode = hostNode

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { toast } from "sonner";
+import type { AutosaveStatus } from "@/components/admin/cms-publish-toolbar";
+import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { UnsavedChangesDialog } from "@/components/admin/unsaved-changes-dialog";
+import { BeforeUnloadGuard } from "@/components/admin/before-unload-guard";
+
+/**
+ * Props passed by the active editor into the persistent toolbar host. All
+ * values are live — they're sourced directly from the editor's render, so
+ * the toolbar mirrors busy/autosaveStatus/inlineError without any external
+ * store or cross-component subscription.
+ */
+export interface CmsEditorState {
+  readonly section: string;
+  readonly sectionLabel: string;
+  readonly hasDraftOnServer: boolean;
+  readonly hasLocalEdits: boolean;
+  readonly publishedAt: number | null;
+  readonly publishedByLabel?: string;
+  readonly busy: string | null;
+  readonly autosaveStatus?: AutosaveStatus;
+  readonly inlineError?: string | null;
+  readonly previewHref?: string;
+  readonly onPublish: () => void;
+  readonly onDiscardConfirm: () => Promise<boolean>;
+  /**
+   * Optional silent flush for editors that autosave. When defined, the nav
+   * guard awaits this before navigating away so no in-memory edit is lost.
+   * Returns `true` on success and `false` on failure (editor is expected to
+   * surface its own error messaging).
+   */
+  readonly flush?: () => Promise<boolean>;
+}
+
+type ConfirmResult = "leave" | "stay";
+
+/**
+ * Minimal snapshot the sidebar's nav guard needs when the user clicks a
+ * link. Updated synchronously from the editor's render body via a ref so
+ * no cross-component setState is ever required.
+ */
+interface CmsNavState {
+  readonly hasLocalEdits: boolean;
+  readonly flush?: () => Promise<boolean>;
+}
+
+interface CmsWorkspaceContextValue {
+  readonly hostNode: HTMLDivElement | null;
+  readonly registerHostNode: (el: HTMLDivElement | null) => void;
+  readonly navStateRef: MutableRefObject<CmsNavState>;
+  readonly attemptNavigate: () => Promise<boolean>;
+  readonly openConfirm: () => Promise<ConfirmResult>;
+}
+
+const CmsWorkspaceContext = createContext<CmsWorkspaceContextValue | null>(
+  null,
+);
+
+/**
+ * Provides the shared toolbar host + nav-guard plumbing used by every admin
+ * editor. Publishing state from an editor to the toolbar is done via a
+ * React portal (see {@link useRegisterCmsEditor}) rather than an external
+ * store, which avoids the "update during render" warning that would fire
+ * if we notified subscribers from the editor's render body.
+ */
+export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
+  const [hostNode, setHostNode] = useState<HTMLDivElement | null>(null);
+  const navStateRef = useRef<CmsNavState>({ hasLocalEdits: false });
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const confirmResolverRef = useRef<((r: ConfirmResult) => void) | null>(null);
+
+  const registerHostNode = useCallback((el: HTMLDivElement | null) => {
+    setHostNode(el);
+  }, []);
+
+  const openConfirm = useCallback(() => {
+    return new Promise<ConfirmResult>((resolve) => {
+      confirmResolverRef.current = resolve;
+      setConfirmOpen(true);
+    });
+  }, []);
+
+  const handleConfirmResult = useCallback((result: ConfirmResult) => {
+    setConfirmOpen(false);
+    const resolver = confirmResolverRef.current;
+    confirmResolverRef.current = null;
+    resolver?.(result);
+  }, []);
+
+  const attemptNavigate = useCallback(async (): Promise<boolean> => {
+    const nav = navStateRef.current;
+    if (!nav.hasLocalEdits) return true;
+    if (nav.flush) {
+      const ok = await nav.flush();
+      if (!ok) {
+        toast.error(
+          "Couldn't save your draft before navigating. Fix the error, then try again.",
+        );
+      }
+      return ok;
+    }
+    const result = await openConfirm();
+    return result === "leave";
+  }, [openConfirm]);
+
+  const value = useMemo<CmsWorkspaceContextValue>(
+    () => ({
+      hostNode,
+      registerHostNode,
+      navStateRef,
+      attemptNavigate,
+      openConfirm,
+    }),
+    [hostNode, registerHostNode, attemptNavigate, openConfirm],
+  );
+
+  return (
+    <CmsWorkspaceContext.Provider value={value}>
+      {children}
+      <BeforeUnloadGuard />
+      <UnsavedChangesDialog
+        open={confirmOpen}
+        onLeave={() => handleConfirmResult("leave")}
+        onStay={() => handleConfirmResult("stay")}
+      />
+    </CmsWorkspaceContext.Provider>
+  );
+}
+
+function useCmsWorkspace(): CmsWorkspaceContextValue {
+  const v = useContext(CmsWorkspaceContext);
+  if (!v) {
+    throw new Error(
+      "useCmsWorkspace must be used inside <CmsWorkspaceProvider>",
+    );
+  }
+  return v;
+}
+
+/**
+ * Used by the sidebar + "Back to site" link. Resolves `true` when the UI
+ * may proceed with navigation (no dirty edits, pending autosaves flushed
+ * successfully, or the user explicitly chose "Leave").
+ */
+export function useCmsNavGuard(): {
+  readonly attemptNavigate: () => Promise<boolean>;
+} {
+  const { attemptNavigate } = useCmsWorkspace();
+  return { attemptNavigate };
+}
+
+/**
+ * Internal: exposes the nav-state ref so the beforeunload guard can read
+ * the current dirty flag at event time without subscribing.
+ */
+export function useCmsNavStateRef(): MutableRefObject<CmsNavState> {
+  const { navStateRef } = useCmsWorkspace();
+  return navStateRef;
+}
+
+/**
+ * Result of {@link useRegisterCmsEditor}.
+ *
+ * - `toolbarPortal` must be rendered somewhere in the editor's JSX (it
+ *   teleports into the admin layout host, so its actual location in the
+ *   editor tree doesn't matter).
+ * - `editorRef` must be attached to the editor root `<div>`, merged with
+ *   any other ref callbacks (e.g. autosave unmount refs) through a single
+ *   stable `useCallback` wrapper.
+ */
+export interface RegisteredCmsEditor {
+  readonly toolbarPortal: ReactNode;
+  readonly editorRef: (el: HTMLElement | null) => void;
+}
+
+/**
+ * Register the calling editor as the active CMS editor.
+ *
+ * The toolbar is rendered as a React portal targeting the layout-level
+ * host element, so it shares the editor's render cycle — updates to
+ * `busy`, `autosaveStatus`, or `hasLocalEdits` flow through naturally
+ * without any cross-component store.
+ *
+ * Nav-guard state (`hasLocalEdits`, `flush`) is written to a ref on
+ * every render. The sidebar reads the ref in its click handler, which
+ * keeps all updates out of React's render phase.
+ *
+ * The returned `editorRef` clears the nav-guard ref on unmount so stale
+ * dirty state can never block a sidebar click after leaving a section.
+ */
+export function useRegisterCmsEditor(
+  state: CmsEditorState,
+): RegisteredCmsEditor {
+  const { hostNode, navStateRef } = useCmsWorkspace();
+
+  navStateRef.current = {
+    hasLocalEdits: state.hasLocalEdits,
+    flush: state.flush,
+  };
+
+  const editorRef = useCallback(
+    (el: HTMLElement | null) => {
+      if (!el) {
+        navStateRef.current = { hasLocalEdits: false };
+      }
+    },
+    [navStateRef],
+  );
+
+  const toolbarPortal: ReactNode = hostNode
+    ? createPortal(
+        <CmsPublishToolbar
+          sticky={false}
+          section={state.section}
+          sectionLabel={state.sectionLabel}
+          hasDraftOnServer={state.hasDraftOnServer}
+          hasLocalEdits={state.hasLocalEdits}
+          publishedAt={state.publishedAt}
+          publishedByLabel={state.publishedByLabel}
+          busy={state.busy}
+          inlineError={state.inlineError ?? null}
+          autosaveStatus={state.autosaveStatus ?? "idle"}
+          previewHref={state.previewHref}
+          onPublish={state.onPublish}
+          onDiscardConfirm={state.onDiscardConfirm}
+        />,
+        hostNode,
+      )
+    : null;
+
+  return { toolbarPortal, editorRef };
+}
+
+/**
+ * Persistent toolbar host. Rendered once from the admin layout inside
+ * `<SidebarInset>` so its sticky-bottom positioning resolves against the
+ * admin scroll container. Editors portal their `<CmsPublishToolbar>`
+ * into this element via {@link useRegisterCmsEditor}. When no editor is
+ * mounted (e.g. the admin dashboard or `/admin/videos`) the host is
+ * still present but empty, so the sticky bar simply doesn't show.
+ *
+ * The host carries the sticky/border/padding that was previously baked
+ * into each editor's local toolbar mount (where `-mx-6 px-6`
+ * compensated for the page's inner `max-w-3xl` container). Sitting at
+ * the `SidebarInset` level instead, we apply horizontal padding directly
+ * and render the toolbar itself in its inline variant.
+ */
+export function CmsPersistentToolbarHost() {
+  const { registerHostNode, hostNode } = useCmsWorkspace();
+  return (
+    <div
+      ref={registerHostNode}
+      data-cms-toolbar-host
+      className="sticky bottom-0 z-20 border-t border-border/70 bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 empty:hidden"
+      // `empty:hidden` keeps the sticky bar out of the flow when no
+      // editor is mounted, so non-CMS admin pages don't get a leftover
+      // border bar. `hostNode` is read only to participate in the
+      // provider re-render that occurs when the host element attaches.
+      data-has-node={hostNode ? "true" : "false"}
+    />
+  );
+}

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -11,11 +11,15 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { usePathname } from "next/navigation";
 import { toast } from "sonner";
 import type { AutosaveStatus } from "@/components/admin/cms-publish-toolbar";
 import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
+import { CrossSectionPendingBanner } from "@/components/admin/cross-section-pending-banner";
 import { UnsavedChangesDialog } from "@/components/admin/unsaved-changes-dialog";
 import { BeforeUnloadGuard } from "@/components/admin/before-unload-guard";
+import { usePendingDraftSections } from "@/components/admin/use-pending-drafts";
+import { cn } from "@/lib/utils";
 
 /**
  * Props passed by the active editor into the persistent toolbar host. All
@@ -248,29 +252,60 @@ export function useRegisterCmsEditor(
 /**
  * Persistent toolbar host. Rendered once from the admin layout inside
  * `<SidebarInset>` so its sticky-bottom positioning resolves against the
- * admin scroll container. Editors portal their `<CmsPublishToolbar>`
- * into this element via {@link useRegisterCmsEditor}. When no editor is
- * mounted (e.g. the admin dashboard or `/admin/videos`) the host is
- * still present but empty, so the sticky bar simply doesn't show.
+ * admin scroll container.
  *
- * The host carries the sticky/border/padding that was previously baked
- * into each editor's local toolbar mount (where `-mx-6 px-6`
- * compensated for the page's inner `max-w-3xl` container). Sitting at
- * the `SidebarInset` level instead, we apply horizontal padding directly
- * and render the toolbar itself in its inline variant.
+ * Two surfaces live here:
+ *
+ * 1. A banner listing **other sections** that currently have pending
+ *    drafts. Always rendered from the layout so the indicator reaches
+ *    editor-less admin pages (dashboard, `/admin/videos`) too. The
+ *    current section is filtered out by pathname so its state isn't
+ *    double-shown (it already owns the publish toolbar below).
+ * 2. The active editor's `<CmsPublishToolbar>`, portaled in via
+ *    {@link useRegisterCmsEditor}. When no editor is mounted the
+ *    portal target is empty and `empty:hidden` collapses it.
+ *
+ * The outer sticky container hides itself whenever both children are
+ * empty, so non-CMS admin routes without pending drafts don't get a
+ * leftover border bar.
  */
 export function CmsPersistentToolbarHost() {
   const { registerHostNode, hostNode } = useCmsWorkspace();
+  const pathname = usePathname() ?? "";
+  const pending = usePendingDraftSections();
+
+  const othersPending = useMemo(() => {
+    return pending.filter((section) => {
+      if (section.href === pathname) return false;
+      return !pathname.startsWith(`${section.href}/`);
+    });
+  }, [pending, pathname]);
+
+  const hasBanner = othersPending.length > 0;
+
   return (
     <div
-      ref={registerHostNode}
-      data-cms-toolbar-host
-      className="sticky bottom-0 z-20 border-t border-border/70 bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 empty:hidden"
-      // `empty:hidden` keeps the sticky bar out of the flow when no
-      // editor is mounted, so non-CMS admin pages don't get a leftover
-      // border bar. `hostNode` is read only to participate in the
-      // provider re-render that occurs when the host element attaches.
-      data-has-node={hostNode ? "true" : "false"}
-    />
+      data-cms-toolbar-host-wrapper
+      data-has-banner={hasBanner ? "true" : "false"}
+      className={cn(
+        "sticky bottom-0 z-20 border-t border-border/70 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+        // When neither the banner nor the portal has content, the
+        // `:has()` check below collapses the whole bar. Tailwind v4's
+        // `has-[]` variant compiles this to a native CSS selector so
+        // there's no runtime observation needed.
+        !hasBanner &&
+          "has-[[data-cms-toolbar-host]:empty]:hidden",
+      )}
+    >
+      {hasBanner ? (
+        <CrossSectionPendingBanner sections={othersPending} />
+      ) : null}
+      <div
+        ref={registerHostNode}
+        data-cms-toolbar-host
+        data-has-node={hostNode ? "true" : "false"}
+        className="px-6 py-3 empty:hidden"
+      />
+    </div>
   );
 }

--- a/src/components/admin/cross-section-pending-banner.tsx
+++ b/src/components/admin/cross-section-pending-banner.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { AlertCircle, ChevronRight } from "lucide-react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { useCmsNavGuard } from "@/components/admin/cms-workspace";
+import type { PendingDraftSection } from "@/components/admin/use-pending-drafts";
+
+export interface CrossSectionPendingBannerProps {
+  readonly sections: readonly PendingDraftSection[];
+}
+
+/**
+ * Row rendered above the persistent publish toolbar that surfaces draft state
+ * owned by OTHER CMS sections. Each chip deep-links into the owning section
+ * via the shared CMS nav guard so any unsaved local edit on the current
+ * section gets a chance to autosave before navigation.
+ *
+ * Hidden by the parent when the list is empty (e.g. the current section is
+ * the only place with pending edits).
+ */
+export function CrossSectionPendingBanner({
+  sections,
+}: CrossSectionPendingBannerProps) {
+  const router = useRouter();
+  const { attemptNavigate } = useCmsNavGuard();
+
+  if (sections.length === 0) return null;
+
+  async function handleClick(
+    event: ReactMouseEvent<HTMLAnchorElement>,
+    href: string,
+  ) {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const ok = await attemptNavigate();
+    if (ok) router.push(href);
+  }
+
+  const label =
+    sections.length === 1
+      ? "Unpublished changes in another section:"
+      : `Unpublished changes in ${sections.length} other sections:`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-cms-pending-banner
+      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-900 dark:bg-amber-500/15 dark:text-amber-100"
+    >
+      <span className="inline-flex items-center gap-1.5 font-medium">
+        <AlertCircle
+          className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+          aria-hidden
+        />
+        {label}
+      </span>
+      <ul className="flex flex-wrap items-center gap-1.5">
+        {sections.map((section) => (
+          <li key={section.key}>
+            <Link
+              href={section.href}
+              onClick={(event) => void handleClick(event, section.href)}
+              className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/15 px-2.5 py-0.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-500/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:ring-offset-1 dark:text-amber-100"
+            >
+              {section.label}
+              <ChevronRight className="size-3 opacity-70" aria-hidden />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/admin/unsaved-changes-dialog.tsx
+++ b/src/components/admin/unsaved-changes-dialog.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+export interface UnsavedChangesDialogProps {
+  readonly open: boolean;
+  readonly onLeave: () => void;
+  readonly onStay: () => void;
+}
+
+/**
+ * Confirmation shown when the user clicks a sidebar link with unsaved local
+ * edits that cannot be silently flushed (e.g. the manual-save Photos editor).
+ */
+export function UnsavedChangesDialog({
+  open,
+  onLeave,
+  onStay,
+}: UnsavedChangesDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onStay();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave with unsaved changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You have unsaved edits on this page. Navigating away now will
+            discard them — the live site is not affected.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button type="button" variant="outline" onClick={() => onStay()}>
+            Stay on this page
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => onLeave()}
+          >
+            Leave without saving
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/admin/use-pending-drafts.ts
+++ b/src/components/admin/use-pending-drafts.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import {
+  PENDING_SECTION_NAV,
+  PENDING_SECTION_ORDER,
+  type PendingDraftKey,
+} from "@/lib/admin-nav";
+
+export interface PendingDraftSection {
+  readonly key: PendingDraftKey;
+  readonly href: string;
+  readonly label: string;
+}
+
+/**
+ * Live list of CMS surfaces that currently have a pending draft. Reads
+ * `api.cms.listPendingDrafts` so the result stays in sync whenever any admin
+ * editor saves / publishes / discards a draft elsewhere in the app.
+ *
+ * Ordering is stable across re-renders (see `PENDING_SECTION_ORDER`) so chips
+ * and sidebar dots don't reshuffle while Convex subscriptions refresh.
+ */
+export function usePendingDraftSections(): PendingDraftSection[] {
+  const data = useQuery(api.cms.listPendingDrafts);
+  return useMemo<PendingDraftSection[]>(() => {
+    if (!data) return [];
+    const set = new Set<PendingDraftKey>(data.sections as PendingDraftKey[]);
+    return PENDING_SECTION_ORDER.filter((k) => set.has(k)).map((key) => ({
+      key,
+      ...PENDING_SECTION_NAV[key],
+    }));
+  }, [data]);
+}

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -59,3 +59,42 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Site configuration",
   },
 ];
+
+/**
+ * Keys returned from `api.cms.listPendingDrafts`. Aggregates every CMS
+ * surface that tracks its own draft state (`cmsSections` + the two singleton
+ * meta tables).
+ */
+export type PendingDraftKey =
+  | "settings"
+  | "pricing"
+  | "about"
+  | "recordings"
+  | "gear"
+  | "photos";
+
+/**
+ * Nav target + user-facing label for each pending-draft key. `recordings` is
+ * flag-only and is managed from the Audio admin page, so it links there.
+ */
+export const PENDING_SECTION_NAV: Record<
+  PendingDraftKey,
+  { readonly href: string; readonly label: string }
+> = {
+  settings: { href: "/admin/settings", label: "Settings" },
+  pricing: { href: "/admin/pricing", label: "Pricing" },
+  about: { href: "/admin/about", label: "About" },
+  recordings: { href: "/admin/audio", label: "Audio" },
+  gear: { href: "/admin/gear", label: "Gear" },
+  photos: { href: "/admin/photos", label: "Photos" },
+};
+
+/** Stable display order for pending-draft chips / dots. */
+export const PENDING_SECTION_ORDER: readonly PendingDraftKey[] = [
+  "settings",
+  "pricing",
+  "about",
+  "gear",
+  "photos",
+  "recordings",
+];


### PR DESCRIPTION
## Summary

- Hoists the publish/discard/preview toolbar into the admin layout via a React portal host so it persists across CMS tab changes and stays in sync with whichever editor is mounted.
- Intercepts sidebar navigation: autosave editors (`settings`, `about`, `pricing`, `audio` feature flags) silently flush pending drafts before routing; manual-save editors (`photos`, `gear`) prompt the user via an unsaved-changes dialog. Also warns via `beforeunload` on tab close/reload while dirty.
- Adds `api.cms.listPendingDrafts` that aggregates draft state across `cmsSections`, `gearMeta`, and `galleryPhotoMeta`. Surfaces pending-draft indicators in the sidebar and a cross-section banner so owners can see from any admin page which sections still have unpublished edits and jump to them directly.
- Lifecycle wiring uses ref callbacks (no new `useEffect`), matching the project convention in [AGENTS.md](AGENTS.md).

## Files

- New: `src/components/admin/cms-workspace.tsx`, `before-unload-guard.tsx`, `unsaved-changes-dialog.tsx`, `cross-section-pending-banner.tsx`, `use-pending-drafts.ts`
- Modified: `src/app/admin/layout.tsx`, every admin editor (`settings`, `about`, `pricing`, `audio`, `photos`, `gear`), `admin-sidebar.tsx`, `lib/admin-nav.ts`, `convex/cms.ts`

## Test plan

- [ ] Edit a field on /admin/pricing then immediately click a sidebar link — draft is flushed, value persists on return.
- [ ] Edit photo alt text (manual save), click a sidebar link — confirm dialog appears; Stay keeps edits, Leave discards.
- [ ] Reload the tab while an autosave editor is dirty — browser shows native unsaved-changes prompt.
- [ ] Create a draft on one section (e.g. about), navigate to another — sidebar shows a pending indicator on the dirty section; banner on the current page links back to it.
- [ ] Toolbar shows correct busy / autosaveStatus / published metadata for the active section and hides on non-CMS admin pages (`/admin`, `/admin/videos`).
- [ ] `bun run lint` and `bun run build` both clean; no React "update during render" warnings in dev console.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new cross-page navigation/unsaved-changes flow and a new Convex query that runs on most admin pages; regressions could block navigation or misreport draft state, but changes are scoped to admin UX.
> 
> **Overview**
> Adds a layout-scoped **CMS workspace** that portals each editor’s `CmsPublishToolbar` into a single persistent host and shows a banner for *other sections* with unpublished drafts.
> 
> Sidebar (and “Back to site”) navigation is now guarded: autosave-based editors silently `flush` before routing, while manual-save editors trigger a new `UnsavedChangesDialog`; browser reload/close is also protected via a `beforeunload` guard.
> 
> Introduces `api.cms.listPendingDrafts` to aggregate draft state across `cmsSections`, `gearMeta`, and `galleryPhotoMeta`, and uses it to drive sidebar dot/tooltip indicators and cross-section deep links (with stable ordering via new `PendingDraftKey` mappings in `admin-nav`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4204bf7f152621b5d6125cd663ff85b75506f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->