### PR TITLE
ci: add GitHub Actions workflow to run tests and build on each commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["**"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    name: Test and build
+    runs-on: ubuntu-latest
+
+    env:
+      CI: "true"
+      SENTRY_ENABLED: "false"
+      NEXT_PUBLIC_CONVEX_URL: "https://ci-placeholder.convex.cloud"
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_Y2ktcGxhY2Vob2xkZXIkY2k"
+      CLERK_SECRET_KEY: "sk_test_ci-placeholder"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Trust required postinstall scripts
+        run: bun pm trust @tailwindcss/oxide @vercel/speed-insights unrs-resolver
+
+      - name: Run tests
+        run: bun test
+
+      - name: Build
+        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Trust required postinstall scripts
-        run: bun pm trust @tailwindcss/oxide @vercel/speed-insights unrs-resolver
-
       - name: Run tests
         run: bun test
 


### PR DESCRIPTION
Runs bun test and bun run build on every push and PR using Bun, with dummy inline env vars so no repo secrets are required for the first green run.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI workflow only, with no runtime or production code changes; main risk is CI flakiness/misconfiguration due to placeholder env vars and using `bun-version: latest`.
> 
> **Overview**
> **Adds GitHub Actions CI** via a new `.github/workflows/ci.yml` that runs on every push, PR, or manual dispatch.
> 
> The job sets basic placeholder env vars (disabling Sentry and providing dummy Convex/Clerk keys), installs deps with Bun (with cache), runs `bun test`, then runs `bun run build`, with concurrency configured to cancel in-progress runs on the same ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c190472fd4c223826fe7f38221226c561dbc82b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->