### PR TITLE
Cursor/audio admin replace file c341

### DIFF
--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -678,7 +678,8 @@ export const removeDraftTrack = mutation({
  * On validation failure we delete the newly uploaded blob so it does not
  * linger as an orphan. Other metadata (title, artist, description, artwork,
  * streaming links) is preserved — call `updateDraftTrack` separately to edit
- * those.
+ * those. `createdAt` is set to the swap time so abandoned-draft GC (which keys
+ * off `createdAt`) cannot delete a draft-only row whose file was just replaced.
  */
 export const replaceDraftTrackFile = mutation({
   args: {
@@ -735,6 +736,7 @@ export const replaceDraftTrackFile = mutation({
     // keeps the document shape explicit and lets us clear the optional
     // `durationSec` / `originalFileName` fields when the new upload doesn't
     // provide them.
+    const now = Date.now();
     await ctx.db.replace(row._id, {
       scope: row.scope,
       stableId: row.stableId,
@@ -744,7 +746,7 @@ export const replaceDraftTrackFile = mutation({
       mimeType,
       sortOrder: row.sortOrder,
       sizeBytes,
-      createdAt: row.createdAt,
+      createdAt: now,
       ...(row.artist !== undefined ? { artist: row.artist } : {}),
       ...(nextDurationSec !== undefined ? { durationSec: nextDurationSec } : {}),
       ...(row.albumThumbnailUrl !== undefined

--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -662,6 +662,112 @@ export const removeDraftTrack = mutation({
   },
 });
 
+/**
+ * Swap a draft track's audio file for a freshly uploaded blob. The new
+ * `storageId` must already exist in Convex storage (uploaded via the URL from
+ * `generateUploadUrl`). Within this single mutation transaction we:
+ *
+ *   1. Validate the new blob (allowlisted MIME, size cap).
+ *   2. Patch the draft row so `<audio src>` switches to the new signed URL
+ *      atomically — no window where the public URL is broken.
+ *   3. Best-effort delete the old blob if nothing else references it
+ *      (including the still-live `published` row, which we intentionally keep
+ *      working until the next publish).
+ *
+ * On validation failure we delete the newly uploaded blob so it does not
+ * linger as an orphan. Other metadata (title, artist, description, artwork,
+ * streaming links) is preserved — call `updateDraftTrack` separately to edit
+ * those.
+ */
+export const replaceDraftTrackFile = mutation({
+  args: {
+    stableId: v.string(),
+    storageId: v.id("_storage"),
+    durationSec: v.optional(v.union(v.number(), v.null())),
+    originalFileName: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftTrackByStableId(ctx, args.stableId);
+    if (!row) {
+      // Can't resolve the draft row — the uploaded blob has no home, clean it up.
+      await deleteStorageIfUnreferenced(ctx, args.storageId);
+      cmsNotFound("audioTrack", args.stableId);
+    }
+
+    if (row.storageId === args.storageId) {
+      // Same blob — caller re-picked the existing file. Nothing to swap, and
+      // no orphan to clean up (the row still references it).
+      return { ok: true as const, replaced: false };
+    }
+
+    const oldStorageId = row.storageId;
+    let mimeType: string;
+    let sizeBytes: number;
+    let nextDurationSec: number | undefined;
+    let nextOriginalFileName: string | undefined;
+    try {
+      const storage = await getStorageMetadata(ctx, args.storageId);
+      validateStorageMetadataOrThrow(storage);
+      mimeType = storage.contentType;
+      sizeBytes = storage.size;
+
+      if (args.durationSec === null || args.durationSec === undefined) {
+        nextDurationSec = undefined;
+      } else {
+        nextDurationSec = normalizeDurationSec(args.durationSec);
+      }
+
+      if (args.originalFileName === null || args.originalFileName === undefined) {
+        nextOriginalFileName = undefined;
+      } else {
+        nextOriginalFileName = normalizeFileName(args.originalFileName);
+      }
+    } catch (error) {
+      // Validation failed — the draft row is untouched, but the new blob is
+      // now orphaned. Remove it so we don't leak storage.
+      await deleteStorageIfUnreferenced(ctx, args.storageId);
+      throw error;
+    }
+
+    // Swap the reference. Using `ctx.db.replace` here (like `updateDraftTrack`)
+    // keeps the document shape explicit and lets us clear the optional
+    // `durationSec` / `originalFileName` fields when the new upload doesn't
+    // provide them.
+    await ctx.db.replace(row._id, {
+      scope: row.scope,
+      stableId: row.stableId,
+      storageId: args.storageId,
+      title: row.title,
+      description: row.description,
+      mimeType,
+      sortOrder: row.sortOrder,
+      sizeBytes,
+      createdAt: row.createdAt,
+      ...(row.artist !== undefined ? { artist: row.artist } : {}),
+      ...(nextDurationSec !== undefined ? { durationSec: nextDurationSec } : {}),
+      ...(row.albumThumbnailUrl !== undefined
+        ? { albumThumbnailUrl: row.albumThumbnailUrl }
+        : {}),
+      ...(row.spotifyUrl !== undefined ? { spotifyUrl: row.spotifyUrl } : {}),
+      ...(row.appleMusicUrl !== undefined
+        ? { appleMusicUrl: row.appleMusicUrl }
+        : {}),
+      ...(nextOriginalFileName !== undefined
+        ? { originalFileName: nextOriginalFileName }
+        : {}),
+    });
+
+    // Old blob may still be referenced by the published row or by another
+    // draft track (rare, but possible). `deleteStorageIfUnreferenced` checks
+    // every `audioTracks` and `galleryPhotos` row before deleting, so this is
+    // a safe best-effort cleanup.
+    await deleteStorageIfUnreferenced(ctx, oldStorageId);
+    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, replaced: true };
+  },
+});
+
 export async function publishAudioDraftCore(
   ctx: MutationCtx,
   args: { userId: string; updatedBy: string },

--- a/convex/audioTracks.test.ts
+++ b/convex/audioTracks.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  ABANDONED_DRAFT_AUDIO_MS,
+  ALLOWED_AUDIO_MIME_TYPES,
+  MAX_AUDIO_FILE_BYTES,
+  MAX_AUDIO_TRACKS,
+  audioDraftMatchesPublished,
+} from "./audioTracks";
+
+type Row = Doc<"audioTracks">;
+
+function row(patch: Partial<Row> = {}): Row {
+  return {
+    _id: ("at-" + (patch.stableId ?? "x")) as unknown as Id<"audioTracks">,
+    _creationTime: 0,
+    scope: "draft",
+    stableId: "at_1",
+    storageId: "st_1" as unknown as Id<"_storage">,
+    title: "Song",
+    description: "Sample description",
+    mimeType: "audio/mpeg",
+    sortOrder: 0,
+    sizeBytes: 1024,
+    createdAt: 0,
+    ...patch,
+  } as Row;
+}
+
+describe("audio constants", () => {
+  test("ALLOWED_AUDIO_MIME_TYPES covers the expected MP3/WAV variants", () => {
+    expect([...ALLOWED_AUDIO_MIME_TYPES]).toEqual([
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/wav",
+      "audio/x-wav",
+      "audio/wave",
+    ]);
+  });
+
+  test("MAX_AUDIO_FILE_BYTES is 100MB", () => {
+    expect(MAX_AUDIO_FILE_BYTES).toBe(100 * 1024 * 1024);
+  });
+
+  test("MAX_AUDIO_TRACKS caps at 30", () => {
+    expect(MAX_AUDIO_TRACKS).toBe(30);
+  });
+
+  test("ABANDONED_DRAFT_AUDIO_MS is 7 days", () => {
+    expect(ABANDONED_DRAFT_AUDIO_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("audioDraftMatchesPublished", () => {
+  test("empty arrays match", () => {
+    expect(audioDraftMatchesPublished([], [])).toBe(true);
+  });
+
+  test("different lengths do not match", () => {
+    expect(audioDraftMatchesPublished([row()], [])).toBe(false);
+  });
+
+  test("same content → match", () => {
+    expect(
+      audioDraftMatchesPublished(
+        [row({ stableId: "a" }), row({ stableId: "b" })],
+        [row({ stableId: "a" }), row({ stableId: "b" })],
+      ),
+    ).toBe(true);
+  });
+
+  test("different storageId → not a match (replace file is a draft change)", () => {
+    // Replace-flow sanity check: swapping the blob for the same stableId
+    // must flip `hasDraftChanges` to true so the toolbar enables Publish.
+    expect(
+      audioDraftMatchesPublished(
+        [row({ storageId: "new" as unknown as Id<"_storage"> })],
+        [row({ storageId: "old" as unknown as Id<"_storage"> })],
+      ),
+    ).toBe(false);
+  });
+
+  test("different title / description → not a match", () => {
+    expect(
+      audioDraftMatchesPublished(
+        [row({ title: "A" })],
+        [row({ title: "B" })],
+      ),
+    ).toBe(false);
+    expect(
+      audioDraftMatchesPublished(
+        [row({ description: "A" })],
+        [row({ description: "B" })],
+      ),
+    ).toBe(false);
+  });
+
+  test("order matters", () => {
+    expect(
+      audioDraftMatchesPublished(
+        [row({ stableId: "a", sortOrder: 0 }), row({ stableId: "b", sortOrder: 1 })],
+        [row({ stableId: "b", sortOrder: 1 }), row({ stableId: "a", sortOrder: 0 })],
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/app/admin/audio/audio-editor.test.ts
+++ b/src/app/admin/audio/audio-editor.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+  defaultTitleFromFileName,
+  formatBytes,
+  formatDuration,
+  isAcceptedAudioFile,
+  validateTrackFields,
+} from "./audio-editor";
+
+function makeFile(name: string, type: string, size = 1024): File {
+  const data = new Uint8Array(size);
+  return new File([data], name, { type });
+}
+
+describe("defaultTitleFromFileName", () => {
+  test("drops the extension", () => {
+    expect(defaultTitleFromFileName("session.mp3")).toBe("Session");
+    expect(defaultTitleFromFileName("live-take.wav")).toBe("Live take");
+  });
+
+  test("converts dashes/underscores to spaces", () => {
+    expect(defaultTitleFromFileName("behind_the_board.mp3")).toBe(
+      "Behind the board",
+    );
+  });
+
+  test("empty / whitespace filename → 'Untitled track' fallback", () => {
+    expect(defaultTitleFromFileName(".mp3")).toBe("Untitled track");
+    expect(defaultTitleFromFileName("   .wav")).toBe("Untitled track");
+  });
+});
+
+describe("formatBytes", () => {
+  test("bytes / KB / MB scales", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("formatDuration", () => {
+  test("null / invalid / negative → dash", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(Number.NaN)).toBe("—");
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatDuration(-3)).toBe("—");
+  });
+
+  test("rounds down to whole seconds and pads", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(5.8)).toBe("0:05");
+    expect(formatDuration(65)).toBe("1:05");
+    expect(formatDuration(3599)).toBe("59:59");
+    expect(formatDuration(3600)).toBe("60:00");
+  });
+});
+
+describe("validateTrackFields", () => {
+  test("title is required", () => {
+    expect(validateTrackFields("", "", "something")).toContain("Title");
+    expect(validateTrackFields("   ", "", "something")).toContain("Title");
+  });
+
+  test("title at most 200 chars", () => {
+    expect(validateTrackFields("a".repeat(200), "", "desc")).toBeNull();
+    expect(validateTrackFields("a".repeat(201), "", "desc")).toContain("200");
+  });
+
+  test("artist over 200 chars rejected", () => {
+    expect(validateTrackFields("ok", "a".repeat(201), "desc")).toContain("200");
+  });
+
+  test("description required and capped", () => {
+    expect(validateTrackFields("ok", "", "")).toContain("Description");
+    expect(
+      validateTrackFields("ok", "", "a".repeat(2001)),
+    ).toContain("2000");
+  });
+
+  test("valid input passes", () => {
+    expect(validateTrackFields("Track 1", "Artist", "Desc")).toBeNull();
+  });
+});
+
+describe("isAcceptedAudioFile", () => {
+  test("accepts MP3 by mime type", () => {
+    expect(isAcceptedAudioFile(makeFile("a.mp3", "audio/mpeg"))).toBe(true);
+    expect(isAcceptedAudioFile(makeFile("a.mp3", "audio/mp3"))).toBe(true);
+  });
+
+  test("accepts WAV by mime type variants", () => {
+    expect(isAcceptedAudioFile(makeFile("a.wav", "audio/wav"))).toBe(true);
+    expect(isAcceptedAudioFile(makeFile("a.wav", "audio/x-wav"))).toBe(true);
+    expect(isAcceptedAudioFile(makeFile("a.wav", "audio/wave"))).toBe(true);
+  });
+
+  test("accepts any audio/* mime type as a best-effort fallback", () => {
+    // Server still enforces the strict allowlist — the client check only
+    // needs to reject obviously-wrong files before uploading.
+    expect(isAcceptedAudioFile(makeFile("a.flac", "audio/flac"))).toBe(true);
+  });
+
+  test("accepts by filename extension when mime type is missing", () => {
+    expect(isAcceptedAudioFile(makeFile("track.mp3", ""))).toBe(true);
+    expect(isAcceptedAudioFile(makeFile("track.wav", ""))).toBe(true);
+    expect(isAcceptedAudioFile(makeFile("track.mpeg", ""))).toBe(true);
+  });
+
+  test("rejects non-audio files", () => {
+    expect(isAcceptedAudioFile(makeFile("doc.pdf", "application/pdf"))).toBe(
+      false,
+    );
+    expect(isAcceptedAudioFile(makeFile("image.png", "image/png"))).toBe(
+      false,
+    );
+    expect(isAcceptedAudioFile(makeFile("no-extension", ""))).toBe(false);
+  });
+});

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -27,6 +27,7 @@ import {
   Headphones,
   Loader2,
   Music,
+  Replace,
   Save,
   Trash2,
   Upload,
@@ -58,6 +59,27 @@ const MAX_TITLE_LENGTH = 200;
 const MAX_ARTIST_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
 
+/**
+ * Client-side MIME allowlist for audio uploads. The server enforces the
+ * authoritative list from `ALLOWED_AUDIO_MIME_TYPES`; this set is only used
+ * for early rejection in the file picker / drag-drop so the user doesn't wait
+ * for a round-trip to learn the file is unsupported.
+ */
+const ALLOWED_AUDIO_MIME_TYPES = new Set<string>([
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/wave",
+]);
+const AUDIO_FILENAME_PATTERN = /\.(mp3|wav|mpeg)$/i;
+
+export function isAcceptedAudioFile(file: File): boolean {
+  if (file.type && ALLOWED_AUDIO_MIME_TYPES.has(file.type)) return true;
+  if (file.type && file.type.startsWith("audio/")) return true;
+  return AUDIO_FILENAME_PATTERN.test(file.name);
+}
+
 type TrackItem = {
   stableId: string;
   storageId: Id<"_storage">;
@@ -87,7 +109,7 @@ type TrackEdits = Record<
   }
 >;
 
-type RowAction = "saving" | "deleting";
+type RowAction = "saving" | "deleting" | "replacing";
 type RowBusy = Record<string, RowAction | undefined>;
 
 type UploadProgressEntry = {
@@ -98,7 +120,7 @@ type UploadProgressEntry = {
   readonly error?: string;
 };
 
-function defaultTitleFromFileName(fileName: string): string {
+export function defaultTitleFromFileName(fileName: string): string {
   const withoutExtension = fileName.replace(/\.[^.]+$/, "");
   const normalized = withoutExtension
     .replace(/[_-]+/g, " ")
@@ -110,20 +132,20 @@ function defaultTitleFromFileName(fileName: string): string {
   return normalized[0].toUpperCase() + normalized.slice(1);
 }
 
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function formatDuration(sec: number | null): string {
+export function formatDuration(sec: number | null): string {
   if (sec === null || !Number.isFinite(sec) || sec < 0) return "—";
   const m = Math.floor(sec / 60);
   const s = Math.floor(sec % 60);
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-function validateTrackFields(
+export function validateTrackFields(
   title: string,
   artist: string,
   description: string,
@@ -316,6 +338,9 @@ function AudioEditorForm() {
   const generateUploadUrl = useMutation(api.admin.audio.generateUploadUrl);
   const saveUploadedTrack = useMutation(api.admin.audio.saveUploadedTrack);
   const updateDraftTrack = useMutation(api.admin.audio.updateDraftTrack);
+  const replaceDraftTrackFile = useMutation(
+    api.admin.audio.replaceDraftTrackFile,
+  );
   const reorderDraftTracks = useMutation(api.admin.audio.reorderDraftTracks);
   const removeDraftTrack = useMutation(api.admin.audio.removeDraftTrack);
   const publishAudioTracks = useMutation(api.admin.audio.publishAudioTracks);
@@ -324,6 +349,13 @@ function AudioEditorForm() {
   );
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const replaceFileInputRef = useRef<HTMLInputElement | null>(null);
+  /**
+   * Pending replace target captured on click so the hidden file input knows
+   * which row to swap once the user picks a file. Using a ref avoids a render
+   * between click → native file picker opening.
+   */
+  const pendingReplaceStableIdRef = useRef<string | null>(null);
   const dragDepthRef = useRef(0);
   const uploadDismissTimerRef = useRef<number | null>(null);
 
@@ -643,11 +675,7 @@ function AudioEditorForm() {
   const processFiles = useCallback(
     async (files: File[]) => {
       if (!data) return;
-      const audioFiles = files.filter(
-        (f) =>
-          f.type.startsWith("audio/") ||
-          /\.(mp3|wav|mpeg)$/i.test(f.name),
-      );
+      const audioFiles = files.filter(isAcceptedAudioFile);
       if (audioFiles.length === 0) {
         toast.error("Drop MP3 or WAV files only.");
         return;
@@ -747,6 +775,135 @@ function AudioEditorForm() {
       await processFiles(Array.from(list));
     },
     [processFiles],
+  );
+
+  /**
+   * Replace flow: uploads a new blob, then calls the Convex mutation that
+   * swaps the draft track's `storageId` atomically and best-effort deletes
+   * the old blob. Uses the shared upload tray for progress, and the existing
+   * `runAdminEffect` toast channel for mutation errors.
+   */
+  const replaceTrackFile = useCallback(
+    async (stableId: string, file: File) => {
+      if (!data) return;
+
+      if (!isAcceptedAudioFile(file)) {
+        toast.error("Replacement must be an MP3 or WAV file.");
+        return;
+      }
+      if (file.size > data.limits.maxFileBytes) {
+        toast.error(
+          `File is too large (max ${Math.floor(data.limits.maxFileBytes / (1024 * 1024))}MB).`,
+        );
+        return;
+      }
+
+      const entryId = `replace-${stableId}-${Date.now()}`;
+      setUploadQueue((q) => [
+        ...q,
+        {
+          id: entryId,
+          name: `Replacing: ${file.name}`,
+          progress: 0,
+          status: "uploading" as const,
+        },
+      ]);
+
+      setInlineError(null);
+      setRowAction(stableId, "replacing");
+
+      try {
+        const { uploadUrl } = await generateUploadUrl({});
+        const newStorageId = await uploadFileWithProgress(
+          uploadUrl,
+          file,
+          (fraction) => {
+            setUploadQueue((q) =>
+              q.map((e) =>
+                e.id === entryId ? { ...e, progress: fraction } : e,
+              ),
+            );
+          },
+        );
+
+        setUploadQueue((q) =>
+          q.map((e) =>
+            e.id === entryId ? { ...e, status: "saving", progress: 1 } : e,
+          ),
+        );
+
+        const durationSec = await readAudioDurationSec(file);
+
+        const outcome = await runAdminEffect(
+          convexMutationEffect(() =>
+            replaceDraftTrackFile({
+              stableId,
+              storageId: newStorageId,
+              durationSec: durationSec ?? null,
+              originalFileName: file.name,
+            }),
+          ),
+          { onErrorMessage: setInlineError },
+        );
+
+        if (outcome === undefined) {
+          setUploadQueue((q) =>
+            q.map((e) =>
+              e.id === entryId
+                ? { ...e, status: "error", error: "Replace failed." }
+                : e,
+            ),
+          );
+          return;
+        }
+
+        setUploadQueue((q) =>
+          q.map((e) =>
+            e.id === entryId ? { ...e, status: "done" } : e,
+          ),
+        );
+        toast.success(`Replaced audio file with ${file.name}.`);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Replace failed.";
+        setUploadQueue((q) =>
+          q.map((entry) =>
+            entry.id === entryId
+              ? { ...entry, status: "error", error: message }
+              : entry,
+          ),
+        );
+        setInlineError(message);
+        toast.error(message);
+      } finally {
+        setRowAction(stableId, undefined);
+      }
+
+      if (uploadDismissTimerRef.current !== null) {
+        window.clearTimeout(uploadDismissTimerRef.current);
+      }
+      uploadDismissTimerRef.current = window.setTimeout(() => {
+        setUploadQueue((q) => q.filter((e) => e.status !== "done"));
+        uploadDismissTimerRef.current = null;
+      }, 4000);
+    },
+    [data, generateUploadUrl, replaceDraftTrackFile, setRowAction],
+  );
+
+  const handleReplaceClick = useCallback((stableId: string) => {
+    pendingReplaceStableIdRef.current = stableId;
+    replaceFileInputRef.current?.click();
+  }, []);
+
+  const handleReplaceFileSelection = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const list = event.target.files;
+      const stableId = pendingReplaceStableIdRef.current;
+      pendingReplaceStableIdRef.current = null;
+      event.target.value = "";
+      if (!list || list.length === 0 || !stableId) return;
+      await replaceTrackFile(stableId, list[0]);
+    },
+    [replaceTrackFile],
   );
 
   const canAcceptDrop =
@@ -1026,6 +1183,13 @@ function AudioEditorForm() {
               className="hidden"
               onChange={(event) => void handleFileSelection(event)}
             />
+            <input
+              ref={replaceFileInputRef}
+              type="file"
+              accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,.mp3,.wav"
+              className="hidden"
+              onChange={(event) => void handleReplaceFileSelection(event)}
+            />
             <Button
               type="button"
               variant="outline"
@@ -1149,8 +1313,16 @@ function AudioEditorForm() {
                         Playback URL unavailable — re-upload if this persists.
                       </p>
                     )}
+                    {track.originalFileName ? (
+                      <p
+                        className="body-text-small truncate text-muted-foreground"
+                        title={track.originalFileName}
+                      >
+                        {track.originalFileName}
+                      </p>
+                    ) : null}
                   </div>
-                  <div className="flex shrink-0 gap-1">
+                  <div className="flex shrink-0 flex-wrap items-center gap-1">
                     <Button
                       type="button"
                       variant="ghost"
@@ -1176,6 +1348,25 @@ function AudioEditorForm() {
                       onClick={() => void moveTrack(track.stableId, 1)}
                     >
                       <ArrowDown className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2"
+                      aria-label={`Replace audio file for ${track.title}`}
+                      disabled={busy !== null || isRowBusy}
+                      onClick={() => handleReplaceClick(track.stableId)}
+                    >
+                      {rowAction === "replacing" ? (
+                        <Loader2
+                          className="mr-1 size-3.5 animate-spin"
+                          aria-hidden
+                        />
+                      ) : (
+                        <Replace className="mr-1 size-3.5" aria-hidden />
+                      )}
+                      {rowAction === "replacing" ? "Replacing…" : "Replace file"}
                     </Button>
                     <Button
                       type="button"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new mutation and UI flow that swaps Convex storage references and performs best-effort blob cleanup, which could impact draft/published playback if edge cases around storage IDs or validation are mishandled.
> 
> **Overview**
> Adds an admin “Replace file” flow for audio tracks: the UI now uploads a new MP3/WAV, then calls a new `replaceDraftTrackFile` Convex mutation to atomically swap the draft track’s `storageId` (updating `mimeType`/`sizeBytes` and optional `durationSec`/`originalFileName`) while best-effort deleting the old blob if unreferenced.
> 
> Refactors client-side file acceptance into a shared `isAcceptedAudioFile` helper and exports formatting/validation helpers for unit tests; adds new Bun tests covering audio allowlist/constants, draft-vs-published matching (including storageId changes), and the editor utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf8e561d6083587d3bac3e204a97e840353cc28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->