### PR TITLE
Add atomic replace-file flow for admin audio tracks

### DIFF
--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -1,5 +1,10 @@
 import { v } from "convex/values";
-import { internalMutation, mutation, query, type MutationCtx } from "../_generated/server";
+import {
+  internalMutation,
+  mutation,
+  query,
+  type MutationCtx,
+} from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import {
   ABANDONED_DRAFT_AUDIO_MS,
@@ -21,7 +26,11 @@ import {
   ALLOWED_GALLERY_IMAGE_TYPES,
   MAX_GALLERY_IMAGE_BYTES,
 } from "../galleryPhotos";
-import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
+import {
+  cmsNotFound,
+  cmsPublishValidationFailed,
+  cmsValidationError,
+} from "../errors";
 import { requireCmsOwner } from "../lib/auth";
 
 const MAX_TITLE_LENGTH = 200;
@@ -203,7 +212,10 @@ function validateStorageMetadataOrThrow(
   }
 
   if (!isAllowedAudioMimeType(storage.contentType)) {
-    cmsValidationError("Only MP3 and WAV audio files are allowed.", "storageId");
+    cmsValidationError(
+      "Only MP3 and WAV audio files are allowed.",
+      "storageId",
+    );
   }
 
   if (storage.size > MAX_AUDIO_FILE_BYTES) {
@@ -250,7 +262,10 @@ function validateAlbumArtStorageMetadataOrThrow(
 
 function collectTrackIssues(
   rows: AudioTrackDoc[],
-  storageById: Map<Id<"_storage">, Awaited<ReturnType<typeof getStorageMetadata>>>,
+  storageById: Map<
+    Id<"_storage">,
+    Awaited<ReturnType<typeof getStorageMetadata>>
+  >,
 ): AudioPublishIssue[] {
   const issues: AudioPublishIssue[] = [];
   const stableIds = new Set<string>();
@@ -465,10 +480,10 @@ export async function validateDraftAudioForPublish(
             : [row.storageId],
         ),
       ),
-    ).map(async (storageId) => [
-      storageId,
-      await getStorageMetadata(ctx, storageId),
-    ] as const),
+    ).map(
+      async (storageId) =>
+        [storageId, await getStorageMetadata(ctx, storageId)] as const,
+    ),
   );
   return collectTrackIssues(rows, new Map(storageRecords));
 }
@@ -527,6 +542,12 @@ export const saveUploadedTrack = mutation({
     const draft = await loadAudioTracks(ctx, "draft");
     if (draft.length >= MAX_AUDIO_TRACKS) {
       await deleteStorageIfUnreferenced(ctx, args.storageId);
+      if (
+        args.albumThumbnailStorageId !== null &&
+        args.albumThumbnailStorageId !== undefined
+      ) {
+        await deleteStorageIfUnreferenced(ctx, args.albumThumbnailStorageId);
+      }
       cmsValidationError(
         `Audio portfolio supports up to ${MAX_AUDIO_TRACKS} tracks.`,
         "storageId",
@@ -549,7 +570,10 @@ export const saveUploadedTrack = mutation({
         "albumThumbnailUrl",
       );
       let albumThumbnailStorageId: Id<"_storage"> | undefined;
-      if (args.albumThumbnailStorageId !== null && args.albumThumbnailStorageId !== undefined) {
+      if (
+        args.albumThumbnailStorageId !== null &&
+        args.albumThumbnailStorageId !== undefined
+      ) {
         const albumArtStorage = await getStorageMetadata(
           ctx,
           args.albumThumbnailStorageId,
@@ -557,7 +581,10 @@ export const saveUploadedTrack = mutation({
         validateAlbumArtStorageMetadataOrThrow(albumArtStorage);
         albumThumbnailStorageId = args.albumThumbnailStorageId;
       }
-      const spotifyUrl = normalizeOptionalExternalUrl(args.spotifyUrl, "spotifyUrl");
+      const spotifyUrl = normalizeOptionalExternalUrl(
+        args.spotifyUrl,
+        "spotifyUrl",
+      );
       const appleMusicUrl = normalizeOptionalExternalUrl(
         args.appleMusicUrl,
         "appleMusicUrl",
@@ -577,9 +604,7 @@ export const saveUploadedTrack = mutation({
         description,
         mimeType,
         ...(durationSec !== undefined ? { durationSec } : {}),
-        ...(albumThumbnailUrl !== undefined
-          ? { albumThumbnailUrl }
-          : {}),
+        ...(albumThumbnailUrl !== undefined ? { albumThumbnailUrl } : {}),
         ...(albumThumbnailStorageId !== undefined
           ? { albumThumbnailStorageId }
           : {}),
@@ -592,7 +617,10 @@ export const saveUploadedTrack = mutation({
       });
     } catch (error) {
       await deleteStorageIfUnreferenced(ctx, args.storageId);
-      if (args.albumThumbnailStorageId !== null && args.albumThumbnailStorageId !== undefined) {
+      if (
+        args.albumThumbnailStorageId !== null &&
+        args.albumThumbnailStorageId !== undefined
+      ) {
         await deleteStorageIfUnreferenced(ctx, args.albumThumbnailStorageId);
       }
       throw error;
@@ -622,105 +650,127 @@ export const updateDraftTrack = mutation({
       cmsNotFound("audioTrack", args.stableId);
     }
 
-    const title = normalizeTitle(args.title);
-    const description = normalizeDescription(args.description);
+    let draftRowReplaced = false;
+    try {
+      const title = normalizeTitle(args.title);
+      const description = normalizeDescription(args.description);
 
-    let nextArtist: string | undefined;
-    if (args.artist === null) {
-      nextArtist = undefined;
-    } else if (args.artist !== undefined) {
-      nextArtist = normalizeArtist(args.artist);
-    } else {
-      nextArtist = row.artist;
+      let nextArtist: string | undefined;
+      if (args.artist === null) {
+        nextArtist = undefined;
+      } else if (args.artist !== undefined) {
+        nextArtist = normalizeArtist(args.artist);
+      } else {
+        nextArtist = row.artist;
+      }
+
+      let durationSec: number | undefined;
+      if (args.durationSec === null) {
+        durationSec = undefined;
+      } else if (args.durationSec !== undefined) {
+        durationSec = normalizeDurationSec(args.durationSec);
+      } else {
+        durationSec = row.durationSec;
+      }
+
+      let nextAlbumThumbnailUrl: string | undefined;
+      if (args.albumThumbnailUrl === null) {
+        nextAlbumThumbnailUrl = undefined;
+      } else if (args.albumThumbnailUrl !== undefined) {
+        nextAlbumThumbnailUrl = normalizeOptionalExternalUrl(
+          args.albumThumbnailUrl,
+          "albumThumbnailUrl",
+        );
+      } else {
+        nextAlbumThumbnailUrl = row.albumThumbnailUrl;
+      }
+
+      let nextAlbumThumbnailStorageId: Id<"_storage"> | undefined;
+      if (args.albumThumbnailStorageId === null) {
+        nextAlbumThumbnailStorageId = undefined;
+      } else if (args.albumThumbnailStorageId !== undefined) {
+        const storage = await getStorageMetadata(
+          ctx,
+          args.albumThumbnailStorageId,
+        );
+        validateAlbumArtStorageMetadataOrThrow(storage);
+        nextAlbumThumbnailStorageId = args.albumThumbnailStorageId;
+      } else {
+        nextAlbumThumbnailStorageId = row.albumThumbnailStorageId;
+      }
+
+      let nextSpotifyUrl: string | undefined;
+      if (args.spotifyUrl === null) {
+        nextSpotifyUrl = undefined;
+      } else if (args.spotifyUrl !== undefined) {
+        nextSpotifyUrl = normalizeOptionalExternalUrl(
+          args.spotifyUrl,
+          "spotifyUrl",
+        );
+      } else {
+        nextSpotifyUrl = row.spotifyUrl;
+      }
+
+      let nextAppleMusicUrl: string | undefined;
+      if (args.appleMusicUrl === null) {
+        nextAppleMusicUrl = undefined;
+      } else if (args.appleMusicUrl !== undefined) {
+        nextAppleMusicUrl = normalizeOptionalExternalUrl(
+          args.appleMusicUrl,
+          "appleMusicUrl",
+        );
+      } else {
+        nextAppleMusicUrl = row.appleMusicUrl;
+      }
+
+      await ctx.db.replace(row._id, {
+        scope: row.scope,
+        stableId: row.stableId,
+        storageId: row.storageId,
+        title,
+        description,
+        mimeType: row.mimeType,
+        sortOrder: row.sortOrder,
+        sizeBytes: row.sizeBytes,
+        createdAt: row.createdAt,
+        ...(nextArtist !== undefined ? { artist: nextArtist } : {}),
+        ...(durationSec !== undefined ? { durationSec } : {}),
+        ...(nextAlbumThumbnailUrl !== undefined
+          ? { albumThumbnailUrl: nextAlbumThumbnailUrl }
+          : {}),
+        ...(nextAlbumThumbnailStorageId !== undefined
+          ? { albumThumbnailStorageId: nextAlbumThumbnailStorageId }
+          : {}),
+        ...(nextSpotifyUrl !== undefined ? { spotifyUrl: nextSpotifyUrl } : {}),
+        ...(nextAppleMusicUrl !== undefined
+          ? { appleMusicUrl: nextAppleMusicUrl }
+          : {}),
+        ...(row.originalFileName !== undefined
+          ? { originalFileName: row.originalFileName }
+          : {}),
+      });
+      draftRowReplaced = true;
+
+      if (
+        row.albumThumbnailStorageId !== undefined &&
+        row.albumThumbnailStorageId !== nextAlbumThumbnailStorageId
+      ) {
+        await deleteStorageIfUnreferenced(ctx, row.albumThumbnailStorageId);
+      }
+
+      await patchAudioMetaAfterDraftChange(ctx, updatedBy);
+      return { ok: true as const };
+    } catch (error) {
+      if (
+        !draftRowReplaced &&
+        args.albumThumbnailStorageId !== null &&
+        args.albumThumbnailStorageId !== undefined &&
+        args.albumThumbnailStorageId !== row.albumThumbnailStorageId
+      ) {
+        await deleteStorageIfUnreferenced(ctx, args.albumThumbnailStorageId);
+      }
+      throw error;
     }
-
-    let durationSec: number | undefined;
-    if (args.durationSec === null) {
-      durationSec = undefined;
-    } else if (args.durationSec !== undefined) {
-      durationSec = normalizeDurationSec(args.durationSec);
-    } else {
-      durationSec = row.durationSec;
-    }
-
-    let nextAlbumThumbnailUrl: string | undefined;
-    if (args.albumThumbnailUrl === null) {
-      nextAlbumThumbnailUrl = undefined;
-    } else if (args.albumThumbnailUrl !== undefined) {
-      nextAlbumThumbnailUrl = normalizeOptionalExternalUrl(
-        args.albumThumbnailUrl,
-        "albumThumbnailUrl",
-      );
-    } else {
-      nextAlbumThumbnailUrl = row.albumThumbnailUrl;
-    }
-
-    let nextAlbumThumbnailStorageId: Id<"_storage"> | undefined;
-    if (args.albumThumbnailStorageId === null) {
-      nextAlbumThumbnailStorageId = undefined;
-    } else if (args.albumThumbnailStorageId !== undefined) {
-      const storage = await getStorageMetadata(ctx, args.albumThumbnailStorageId);
-      validateAlbumArtStorageMetadataOrThrow(storage);
-      nextAlbumThumbnailStorageId = args.albumThumbnailStorageId;
-    } else {
-      nextAlbumThumbnailStorageId = row.albumThumbnailStorageId;
-    }
-
-    let nextSpotifyUrl: string | undefined;
-    if (args.spotifyUrl === null) {
-      nextSpotifyUrl = undefined;
-    } else if (args.spotifyUrl !== undefined) {
-      nextSpotifyUrl = normalizeOptionalExternalUrl(args.spotifyUrl, "spotifyUrl");
-    } else {
-      nextSpotifyUrl = row.spotifyUrl;
-    }
-
-    let nextAppleMusicUrl: string | undefined;
-    if (args.appleMusicUrl === null) {
-      nextAppleMusicUrl = undefined;
-    } else if (args.appleMusicUrl !== undefined) {
-      nextAppleMusicUrl = normalizeOptionalExternalUrl(
-        args.appleMusicUrl,
-        "appleMusicUrl",
-      );
-    } else {
-      nextAppleMusicUrl = row.appleMusicUrl;
-    }
-
-    await ctx.db.replace(row._id, {
-      scope: row.scope,
-      stableId: row.stableId,
-      storageId: row.storageId,
-      title,
-      description,
-      mimeType: row.mimeType,
-      sortOrder: row.sortOrder,
-      sizeBytes: row.sizeBytes,
-      createdAt: row.createdAt,
-      ...(nextArtist !== undefined ? { artist: nextArtist } : {}),
-      ...(durationSec !== undefined ? { durationSec } : {}),
-      ...(nextAlbumThumbnailUrl !== undefined
-        ? { albumThumbnailUrl: nextAlbumThumbnailUrl }
-        : {}),
-      ...(nextAlbumThumbnailStorageId !== undefined
-        ? { albumThumbnailStorageId: nextAlbumThumbnailStorageId }
-        : {}),
-      ...(nextSpotifyUrl !== undefined ? { spotifyUrl: nextSpotifyUrl } : {}),
-      ...(nextAppleMusicUrl !== undefined
-        ? { appleMusicUrl: nextAppleMusicUrl }
-        : {}),
-      ...(row.originalFileName !== undefined ? { originalFileName: row.originalFileName } : {}),
-    });
-
-    if (
-      row.albumThumbnailStorageId !== undefined &&
-      row.albumThumbnailStorageId !== nextAlbumThumbnailStorageId
-    ) {
-      await deleteStorageIfUnreferenced(ctx, row.albumThumbnailStorageId);
-    }
-
-    await patchAudioMetaAfterDraftChange(ctx, updatedBy);
-    return { ok: true as const };
   },
 });
 
@@ -841,7 +891,10 @@ export const replaceDraftTrackFile = mutation({
         nextDurationSec = normalizeDurationSec(args.durationSec);
       }
 
-      if (args.originalFileName === null || args.originalFileName === undefined) {
+      if (
+        args.originalFileName === null ||
+        args.originalFileName === undefined
+      ) {
         nextOriginalFileName = undefined;
       } else {
         nextOriginalFileName = normalizeFileName(args.originalFileName);
@@ -868,7 +921,9 @@ export const replaceDraftTrackFile = mutation({
       sizeBytes,
       createdAt: row.createdAt,
       ...(row.artist !== undefined ? { artist: row.artist } : {}),
-      ...(nextDurationSec !== undefined ? { durationSec: nextDurationSec } : {}),
+      ...(nextDurationSec !== undefined
+        ? { durationSec: nextDurationSec }
+        : {}),
       ...(row.albumThumbnailUrl !== undefined
         ? { albumThumbnailUrl: row.albumThumbnailUrl }
         : {}),
@@ -907,11 +962,7 @@ export async function publishAudioDraftCore(
   const draft = await loadAudioTracks(ctx, "draft");
   const issues = await validateDraftAudioForPublish(ctx, draft);
   if (issues.length > 0) {
-    cmsPublishValidationFailed(
-      "audio",
-      "Publish validation failed.",
-      issues,
-    );
+    cmsPublishValidationFailed("audio", "Publish validation failed.", issues);
   }
 
   await replaceAudioScope(ctx, "draft", "published");

--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -17,6 +17,10 @@ import {
   patchAudioMetaAfterDraftChange,
   replaceAudioScope,
 } from "../audioTracks";
+import {
+  ALLOWED_GALLERY_IMAGE_TYPES,
+  MAX_GALLERY_IMAGE_BYTES,
+} from "../galleryPhotos";
 import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
 import { requireCmsOwner } from "../lib/auth";
 
@@ -91,6 +95,14 @@ function isAllowedAudioMimeType(
   contentType: string,
 ): contentType is (typeof ALLOWED_AUDIO_MIME_TYPES)[number] {
   return (ALLOWED_AUDIO_MIME_TYPES as readonly string[]).includes(contentType);
+}
+
+function isAllowedAlbumArtMimeType(
+  contentType: string,
+): contentType is (typeof ALLOWED_GALLERY_IMAGE_TYPES)[number] {
+  return (ALLOWED_GALLERY_IMAGE_TYPES as readonly string[]).includes(
+    contentType,
+  );
 }
 
 function generateTrackStableId(): string {
@@ -202,6 +214,40 @@ function validateStorageMetadataOrThrow(
   }
 }
 
+function validateAlbumArtStorageMetadataOrThrow(
+  storage: Awaited<ReturnType<typeof getStorageMetadata>>,
+): asserts storage is NonNullable<
+  Awaited<ReturnType<typeof getStorageMetadata>>
+> & { contentType: string } {
+  if (!storage) {
+    cmsValidationError(
+      "Uploaded album art was not found in storage.",
+      "albumThumbnailStorageId",
+    );
+  }
+
+  if (!storage.contentType) {
+    cmsValidationError(
+      "Uploaded album art is missing a content type. Upload JPEG, PNG, or WebP only.",
+      "albumThumbnailStorageId",
+    );
+  }
+
+  if (!isAllowedAlbumArtMimeType(storage.contentType)) {
+    cmsValidationError(
+      "Only JPEG, PNG, and WebP album art images are allowed.",
+      "albumThumbnailStorageId",
+    );
+  }
+
+  if (storage.size > MAX_GALLERY_IMAGE_BYTES) {
+    cmsValidationError(
+      `Album art images must be ${Math.floor(MAX_GALLERY_IMAGE_BYTES / (1024 * 1024))}MB or smaller.`,
+      "albumThumbnailStorageId",
+    );
+  }
+}
+
 function collectTrackIssues(
   rows: AudioTrackDoc[],
   storageById: Map<Id<"_storage">, Awaited<ReturnType<typeof getStorageMetadata>>>,
@@ -264,6 +310,33 @@ function collectTrackIssues(
         issues.push({
           path: `${base}.albumThumbnailUrl`,
           message: "Album thumbnail must be a valid https:// URL.",
+        });
+      }
+    }
+
+    if (row.albumThumbnailStorageId !== undefined) {
+      const storage = storageById.get(row.albumThumbnailStorageId) ?? null;
+      if (!storage) {
+        issues.push({
+          path: `${base}.albumThumbnailStorageId`,
+          message: "Uploaded album art is missing. Try uploading again.",
+        });
+      } else if (!storage.contentType) {
+        issues.push({
+          path: `${base}.albumThumbnailStorageId`,
+          message: "Uploaded album art is missing a content type.",
+        });
+      } else if (!isAllowedAlbumArtMimeType(storage.contentType)) {
+        issues.push({
+          path: `${base}.albumThumbnailStorageId`,
+          message: `Unsupported album art content type: ${storage.contentType}`,
+        });
+      } else if (storage.size > MAX_GALLERY_IMAGE_BYTES) {
+        issues.push({
+          path: `${base}.albumThumbnailStorageId`,
+          message: `Album art must be ${Math.floor(
+            MAX_GALLERY_IMAGE_BYTES / (1024 * 1024),
+          )}MB or smaller.`,
         });
       }
     }
@@ -384,7 +457,15 @@ export async function validateDraftAudioForPublish(
   rows: AudioTrackDoc[],
 ): Promise<AudioPublishIssue[]> {
   const storageRecords = await Promise.all(
-    Array.from(new Set(rows.map((row) => row.storageId))).map(async (storageId) => [
+    Array.from(
+      new Set(
+        rows.flatMap((row) =>
+          row.albumThumbnailStorageId !== undefined
+            ? [row.storageId, row.albumThumbnailStorageId]
+            : [row.storageId],
+        ),
+      ),
+    ).map(async (storageId) => [
       storageId,
       await getStorageMetadata(ctx, storageId),
     ] as const),
@@ -435,6 +516,7 @@ export const saveUploadedTrack = mutation({
     durationSec: v.optional(v.union(v.number(), v.null())),
     originalFileName: v.optional(v.union(v.string(), v.null())),
     albumThumbnailUrl: v.optional(v.union(v.string(), v.null())),
+    albumThumbnailStorageId: v.optional(v.union(v.id("_storage"), v.null())),
     spotifyUrl: v.optional(v.union(v.string(), v.null())),
     appleMusicUrl: v.optional(v.union(v.string(), v.null())),
   },
@@ -466,6 +548,15 @@ export const saveUploadedTrack = mutation({
         args.albumThumbnailUrl,
         "albumThumbnailUrl",
       );
+      let albumThumbnailStorageId: Id<"_storage"> | undefined;
+      if (args.albumThumbnailStorageId !== null && args.albumThumbnailStorageId !== undefined) {
+        const albumArtStorage = await getStorageMetadata(
+          ctx,
+          args.albumThumbnailStorageId,
+        );
+        validateAlbumArtStorageMetadataOrThrow(albumArtStorage);
+        albumThumbnailStorageId = args.albumThumbnailStorageId;
+      }
       const spotifyUrl = normalizeOptionalExternalUrl(args.spotifyUrl, "spotifyUrl");
       const appleMusicUrl = normalizeOptionalExternalUrl(
         args.appleMusicUrl,
@@ -489,6 +580,9 @@ export const saveUploadedTrack = mutation({
         ...(albumThumbnailUrl !== undefined
           ? { albumThumbnailUrl }
           : {}),
+        ...(albumThumbnailStorageId !== undefined
+          ? { albumThumbnailStorageId }
+          : {}),
         ...(spotifyUrl !== undefined ? { spotifyUrl } : {}),
         ...(appleMusicUrl !== undefined ? { appleMusicUrl } : {}),
         sortOrder,
@@ -498,6 +592,9 @@ export const saveUploadedTrack = mutation({
       });
     } catch (error) {
       await deleteStorageIfUnreferenced(ctx, args.storageId);
+      if (args.albumThumbnailStorageId !== null && args.albumThumbnailStorageId !== undefined) {
+        await deleteStorageIfUnreferenced(ctx, args.albumThumbnailStorageId);
+      }
       throw error;
     }
 
@@ -514,6 +611,7 @@ export const updateDraftTrack = mutation({
     description: v.string(),
     durationSec: v.optional(v.union(v.number(), v.null())),
     albumThumbnailUrl: v.optional(v.union(v.string(), v.null())),
+    albumThumbnailStorageId: v.optional(v.union(v.id("_storage"), v.null())),
     spotifyUrl: v.optional(v.union(v.string(), v.null())),
     appleMusicUrl: v.optional(v.union(v.string(), v.null())),
   },
@@ -557,6 +655,17 @@ export const updateDraftTrack = mutation({
       nextAlbumThumbnailUrl = row.albumThumbnailUrl;
     }
 
+    let nextAlbumThumbnailStorageId: Id<"_storage"> | undefined;
+    if (args.albumThumbnailStorageId === null) {
+      nextAlbumThumbnailStorageId = undefined;
+    } else if (args.albumThumbnailStorageId !== undefined) {
+      const storage = await getStorageMetadata(ctx, args.albumThumbnailStorageId);
+      validateAlbumArtStorageMetadataOrThrow(storage);
+      nextAlbumThumbnailStorageId = args.albumThumbnailStorageId;
+    } else {
+      nextAlbumThumbnailStorageId = row.albumThumbnailStorageId;
+    }
+
     let nextSpotifyUrl: string | undefined;
     if (args.spotifyUrl === null) {
       nextSpotifyUrl = undefined;
@@ -593,12 +702,22 @@ export const updateDraftTrack = mutation({
       ...(nextAlbumThumbnailUrl !== undefined
         ? { albumThumbnailUrl: nextAlbumThumbnailUrl }
         : {}),
+      ...(nextAlbumThumbnailStorageId !== undefined
+        ? { albumThumbnailStorageId: nextAlbumThumbnailStorageId }
+        : {}),
       ...(nextSpotifyUrl !== undefined ? { spotifyUrl: nextSpotifyUrl } : {}),
       ...(nextAppleMusicUrl !== undefined
         ? { appleMusicUrl: nextAppleMusicUrl }
         : {}),
       ...(row.originalFileName !== undefined ? { originalFileName: row.originalFileName } : {}),
     });
+
+    if (
+      row.albumThumbnailStorageId !== undefined &&
+      row.albumThumbnailStorageId !== nextAlbumThumbnailStorageId
+    ) {
+      await deleteStorageIfUnreferenced(ctx, row.albumThumbnailStorageId);
+    }
 
     await patchAudioMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const };
@@ -658,6 +777,9 @@ export const removeDraftTrack = mutation({
     await ctx.db.delete(row._id);
     await resequenceDraftTracks(ctx);
     await deleteStorageIfUnreferenced(ctx, row.storageId);
+    if (row.albumThumbnailStorageId !== undefined) {
+      await deleteStorageIfUnreferenced(ctx, row.albumThumbnailStorageId);
+    }
     await patchAudioMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const, removed: true };
   },
@@ -749,6 +871,9 @@ export const replaceDraftTrackFile = mutation({
       ...(nextDurationSec !== undefined ? { durationSec: nextDurationSec } : {}),
       ...(row.albumThumbnailUrl !== undefined
         ? { albumThumbnailUrl: row.albumThumbnailUrl }
+        : {}),
+      ...(row.albumThumbnailStorageId !== undefined
+        ? { albumThumbnailStorageId: row.albumThumbnailStorageId }
         : {}),
       ...(row.spotifyUrl !== undefined ? { spotifyUrl: row.spotifyUrl } : {}),
       ...(row.appleMusicUrl !== undefined
@@ -864,6 +989,9 @@ export const garbageCollectAbandonedDraftAudio = internalMutation({
       }
       await ctx.db.delete(row._id);
       await deleteStorageIfUnreferenced(ctx, row.storageId);
+      if (row.albumThumbnailStorageId !== undefined) {
+        await deleteStorageIfUnreferenced(ctx, row.albumThumbnailStorageId);
+      }
       removedRows += 1;
     }
 

--- a/convex/audioTracks.ts
+++ b/convex/audioTracks.ts
@@ -41,6 +41,7 @@ function comparableTrack(row: AudioTrackDoc) {
     mimeType: row.mimeType,
     durationSec: row.durationSec ?? null,
     albumThumbnailUrl: row.albumThumbnailUrl ?? null,
+    albumThumbnailStorageId: row.albumThumbnailStorageId ?? null,
     spotifyUrl: row.spotifyUrl ?? null,
     appleMusicUrl: row.appleMusicUrl ?? null,
     sortOrder: row.sortOrder,
@@ -113,11 +114,21 @@ export async function replaceAudioScope(
     loadAudioTracks(ctx, toScope),
   ]);
 
-  const sourceStorageIds = new Set(source.map((row) => row.storageId));
+  const sourceStorageIds = new Set(
+    source.flatMap((row) =>
+      row.albumThumbnailStorageId !== undefined
+        ? [row.storageId, row.albumThumbnailStorageId]
+        : [row.storageId],
+    ),
+  );
   const targetOnlyStorageIds = Array.from(
     new Set(
       target
-        .map((row) => row.storageId)
+        .flatMap((row) =>
+          row.albumThumbnailStorageId !== undefined
+            ? [row.storageId, row.albumThumbnailStorageId]
+            : [row.storageId],
+        )
         .filter((storageId) => !sourceStorageIds.has(storageId)),
     ),
   );
@@ -138,6 +149,9 @@ export async function replaceAudioScope(
       ...(row.durationSec !== undefined ? { durationSec: row.durationSec } : {}),
       ...(row.albumThumbnailUrl !== undefined
         ? { albumThumbnailUrl: row.albumThumbnailUrl }
+        : {}),
+      ...(row.albumThumbnailStorageId !== undefined
+        ? { albumThumbnailStorageId: row.albumThumbnailStorageId }
         : {}),
       ...(row.spotifyUrl !== undefined ? { spotifyUrl: row.spotifyUrl } : {}),
       ...(row.appleMusicUrl !== undefined
@@ -191,26 +205,40 @@ export async function materializeAudioTracks(
     sizeBytes: number;
     originalFileName: string | null;
     albumThumbnailUrl: string | null;
+    albumThumbnailStorageId: Id<"_storage"> | null;
+    albumThumbnailStorageUrl: string | null;
+    albumThumbnailDisplayUrl: string | null;
     spotifyUrl: string | null;
     appleMusicUrl: string | null;
   }>
 > {
   return await Promise.all(
-    rows.map(async (row) => ({
-      stableId: row.stableId,
-      storageId: row.storageId,
-      url: await ctx.storage.getUrl(row.storageId),
-      title: row.title,
-      artist: row.artist ?? null,
-      description: row.description,
-      mimeType: row.mimeType,
-      durationSec: row.durationSec ?? null,
-      sortOrder: row.sortOrder,
-      sizeBytes: row.sizeBytes,
-      originalFileName: row.originalFileName ?? null,
-      albumThumbnailUrl: row.albumThumbnailUrl ?? null,
-      spotifyUrl: row.spotifyUrl ?? null,
-      appleMusicUrl: row.appleMusicUrl ?? null,
-    })),
+    rows.map(async (row) => {
+      const albumThumbnailStorageUrl =
+        row.albumThumbnailStorageId !== undefined
+          ? await ctx.storage.getUrl(row.albumThumbnailStorageId)
+          : null;
+
+      return {
+        stableId: row.stableId,
+        storageId: row.storageId,
+        url: await ctx.storage.getUrl(row.storageId),
+        title: row.title,
+        artist: row.artist ?? null,
+        description: row.description,
+        mimeType: row.mimeType,
+        durationSec: row.durationSec ?? null,
+        sortOrder: row.sortOrder,
+        sizeBytes: row.sizeBytes,
+        originalFileName: row.originalFileName ?? null,
+        albumThumbnailUrl: row.albumThumbnailUrl ?? null,
+        albumThumbnailStorageId: row.albumThumbnailStorageId ?? null,
+        albumThumbnailStorageUrl,
+        albumThumbnailDisplayUrl:
+          albumThumbnailStorageUrl ?? row.albumThumbnailUrl ?? null,
+        spotifyUrl: row.spotifyUrl ?? null,
+        appleMusicUrl: row.appleMusicUrl ?? null,
+      };
+    }),
   );
 }

--- a/convex/mediaStorage.ts
+++ b/convex/mediaStorage.ts
@@ -23,7 +23,7 @@ export async function deleteStorageIfUnreferenced(
   ctx: MutationCtx,
   storageId: Id<"_storage">,
 ): Promise<boolean> {
-  const [galleryRefs, audioRefs] = await Promise.all([
+  const [galleryRefs, audioRefs, audioArtRefs] = await Promise.all([
     ctx.db
       .query("galleryPhotos")
       .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
@@ -32,8 +32,18 @@ export async function deleteStorageIfUnreferenced(
       .query("audioTracks")
       .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
       .take(1),
+    ctx.db
+      .query("audioTracks")
+      .withIndex("by_albumThumbnailStorageId", (q) =>
+        q.eq("albumThumbnailStorageId", storageId),
+      )
+      .take(1),
   ]);
-  if (galleryRefs.length > 0 || audioRefs.length > 0) {
+  if (
+    galleryRefs.length > 0 ||
+    audioRefs.length > 0 ||
+    audioArtRefs.length > 0
+  ) {
     return false;
   }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -157,6 +157,8 @@ export default defineSchema({
     durationSec: v.optional(v.number()),
     /** HTTPS URL to album/track artwork (e.g. CDN). */
     albumThumbnailUrl: v.optional(v.string()),
+    /** Uploaded album/track artwork stored in Convex file storage. */
+    albumThumbnailStorageId: v.optional(v.id("_storage")),
     /** Public Spotify page for this release or track. */
     spotifyUrl: v.optional(v.string()),
     /** Public Apple Music page for this release or track. */
@@ -170,5 +172,6 @@ export default defineSchema({
     .index("by_scope_and_sort", ["scope", "sortOrder"])
     .index("by_scope_and_stableId", ["scope", "stableId"])
     .index("by_storageId", ["storageId"])
+    .index("by_albumThumbnailStorageId", ["albumThumbnailStorageId"])
     .index("by_scope_and_createdAt", ["scope", "createdAt"]),
 });

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -1340,35 +1340,13 @@ function AudioEditorForm() {
 
             return (
               <Card key={track.stableId} className="space-y-4 p-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1 space-y-1">
-                    <p className="body-text-small text-muted-foreground">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <p className="body-text-small min-w-0 flex-1 text-muted-foreground">
                       {formatBytes(track.sizeBytes)} · {track.mimeType}
                       {" · "}
                       {formatDuration(track.durationSec)}
                     </p>
-                    {track.url ? (
-                      <audio
-                        controls
-                        className="h-9 w-full max-w-md"
-                        src={track.url}
-                        crossOrigin="anonymous"
-                        preload="metadata"
-                      />
-                    ) : (
-                      <p className="text-sm text-destructive">
-                        Playback URL unavailable — re-upload if this persists.
-                      </p>
-                    )}
-                    {track.originalFileName ? (
-                      <p
-                        className="body-text-small truncate text-muted-foreground"
-                        title={track.originalFileName}
-                      >
-                        {track.originalFileName}
-                      </p>
-                    ) : null}
-                  </div>
                   <div className="flex shrink-0 flex-wrap items-center gap-1">
                     <Button
                       type="button"
@@ -1427,6 +1405,28 @@ function AudioEditorForm() {
                       <Trash2 className="size-4" />
                     </Button>
                   </div>
+                  </div>
+                  {track.url ? (
+                    <audio
+                      controls
+                      className="h-9 w-full"
+                      src={track.url}
+                      crossOrigin="anonymous"
+                      preload="metadata"
+                    />
+                  ) : (
+                    <p className="text-sm text-destructive">
+                      Playback URL unavailable — re-upload if this persists.
+                    </p>
+                  )}
+                  {track.originalFileName ? (
+                    <p
+                      className="body-text-small truncate text-muted-foreground"
+                      title={track.originalFileName}
+                    >
+                      {track.originalFileName}
+                    </p>
+                  ) : null}
                 </div>
 
                 <div className="space-y-3">

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -58,6 +58,7 @@ import { cn } from "@/lib/utils";
 const MAX_TITLE_LENGTH = 200;
 const MAX_ARTIST_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
+const ALBUM_ART_ACCEPT = "image/jpeg,image/png,image/webp";
 
 /**
  * Filename fallback for audio files when the browser doesn't surface a usable
@@ -99,6 +100,9 @@ type TrackItem = {
   sizeBytes: number;
   originalFileName: string | null;
   albumThumbnailUrl: string | null;
+  albumThumbnailStorageId: Id<"_storage"> | null;
+  albumThumbnailStorageUrl: string | null;
+  albumThumbnailDisplayUrl: string | null;
   spotifyUrl: string | null;
   appleMusicUrl: string | null;
 };
@@ -110,12 +114,15 @@ type TrackEdits = Record<
     artist: string;
     description: string;
     albumThumbnailUrl: string;
+    albumThumbnailStorageId: Id<"_storage"> | null;
+    albumThumbnailStorageUrl: string | null;
+    albumThumbnailDisplayUrl: string | null;
     spotifyUrl: string;
     appleMusicUrl: string;
   }
 >;
 
-type RowAction = "saving" | "deleting" | "replacing";
+type RowAction = "saving" | "deleting" | "replacing" | "art";
 type RowBusy = Record<string, RowAction | undefined>;
 
 type UploadProgressEntry = {
@@ -246,6 +253,10 @@ function httpsImagePreviewUrl(raw: string): string | null {
   }
 }
 
+function isAcceptedAlbumArtFile(file: File): boolean {
+  return ["image/jpeg", "image/png", "image/webp"].includes(file.type);
+}
+
 function sequentialEffects(
   effects: Array<Effect.Effect<unknown, CmsAppError>>,
 ): Effect.Effect<void, CmsAppError> {
@@ -359,12 +370,14 @@ function AudioEditorForm() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const replaceFileInputRef = useRef<HTMLInputElement | null>(null);
+  const albumArtFileInputRef = useRef<HTMLInputElement | null>(null);
   /**
    * Pending replace target captured on click so the hidden file input knows
    * which row to swap once the user picks a file. Using a ref avoids a render
    * between click → native file picker opening.
    */
   const pendingReplaceStableIdRef = useRef<string | null>(null);
+  const pendingAlbumArtStableIdRef = useRef<string | null>(null);
   const dragDepthRef = useRef(0);
   const uploadDismissTimerRef = useRef<number | null>(null);
 
@@ -456,6 +469,15 @@ function AudioEditorForm() {
       albumThumbnailUrl:
         edits[track.stableId]?.albumThumbnailUrl ??
         (track.albumThumbnailUrl ?? ""),
+      albumThumbnailStorageId:
+        edits[track.stableId]?.albumThumbnailStorageId ??
+        track.albumThumbnailStorageId,
+      albumThumbnailStorageUrl:
+        edits[track.stableId]?.albumThumbnailStorageUrl ??
+        track.albumThumbnailStorageUrl,
+      albumThumbnailDisplayUrl:
+        edits[track.stableId]?.albumThumbnailDisplayUrl ??
+        track.albumThumbnailDisplayUrl,
       spotifyUrl: edits[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
       appleMusicUrl:
         edits[track.stableId]?.appleMusicUrl ?? (track.appleMusicUrl ?? ""),
@@ -473,6 +495,9 @@ function AudioEditorForm() {
         albumThumbnailUrl: string;
         spotifyUrl: string;
         appleMusicUrl: string;
+        albumThumbnailStorageId: Id<"_storage"> | null;
+        albumThumbnailStorageUrl: string | null;
+        albumThumbnailDisplayUrl: string | null;
       }>,
     ) => {
       setEdits((current) => {
@@ -483,6 +508,15 @@ function AudioEditorForm() {
           albumThumbnailUrl:
             current[track.stableId]?.albumThumbnailUrl ??
             (track.albumThumbnailUrl ?? ""),
+          albumThumbnailStorageId:
+            current[track.stableId]?.albumThumbnailStorageId ??
+            track.albumThumbnailStorageId,
+          albumThumbnailStorageUrl:
+            current[track.stableId]?.albumThumbnailStorageUrl ??
+            track.albumThumbnailStorageUrl,
+          albumThumbnailDisplayUrl:
+            current[track.stableId]?.albumThumbnailDisplayUrl ??
+            track.albumThumbnailDisplayUrl,
           spotifyUrl:
             current[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
           appleMusicUrl:
@@ -493,6 +527,18 @@ function AudioEditorForm() {
           artist: patch.artist ?? base.artist,
           description: patch.description ?? base.description,
           albumThumbnailUrl: patch.albumThumbnailUrl ?? base.albumThumbnailUrl,
+          albumThumbnailStorageId:
+            "albumThumbnailStorageId" in patch
+              ? (patch.albumThumbnailStorageId ?? null)
+              : base.albumThumbnailStorageId,
+          albumThumbnailStorageUrl:
+            "albumThumbnailStorageUrl" in patch
+              ? (patch.albumThumbnailStorageUrl ?? null)
+              : base.albumThumbnailStorageUrl,
+          albumThumbnailDisplayUrl:
+            "albumThumbnailDisplayUrl" in patch
+              ? (patch.albumThumbnailDisplayUrl ?? null)
+              : base.albumThumbnailDisplayUrl,
           spotifyUrl: patch.spotifyUrl ?? base.spotifyUrl,
           appleMusicUrl: patch.appleMusicUrl ?? base.appleMusicUrl,
         };
@@ -501,6 +547,9 @@ function AudioEditorForm() {
           next.artist === (track.artist ?? "") &&
           next.description === track.description &&
           next.albumThumbnailUrl === (track.albumThumbnailUrl ?? "") &&
+          next.albumThumbnailStorageId === track.albumThumbnailStorageId &&
+          next.albumThumbnailStorageUrl === track.albumThumbnailStorageUrl &&
+          next.albumThumbnailDisplayUrl === track.albumThumbnailDisplayUrl &&
           next.spotifyUrl === (track.spotifyUrl ?? "") &&
           next.appleMusicUrl === (track.appleMusicUrl ?? "")
         ) {
@@ -560,6 +609,7 @@ function AudioEditorForm() {
               fields.albumThumbnailUrl.trim().length > 0
                 ? fields.albumThumbnailUrl.trim()
                 : null,
+            albumThumbnailStorageId: fields.albumThumbnailStorageId,
             spotifyUrl:
               fields.spotifyUrl.trim().length > 0
                 ? fields.spotifyUrl.trim()
@@ -628,6 +678,7 @@ function AudioEditorForm() {
             fields.albumThumbnailUrl.trim().length > 0
               ? fields.albumThumbnailUrl.trim()
               : null,
+          albumThumbnailStorageId: fields.albumThumbnailStorageId,
           spotifyUrl:
             fields.spotifyUrl.trim().length > 0
               ? fields.spotifyUrl.trim()
@@ -779,10 +830,10 @@ function AudioEditorForm() {
 
   const handleFileSelection = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const list = event.target.files;
-      event.target.value = "";
-      if (!list || list.length === 0) return;
-      await processFiles(Array.from(list));
+      const files = Array.from(event.currentTarget.files ?? []);
+      event.currentTarget.value = "";
+      if (files.length === 0) return;
+      await processFiles(files);
     },
     [processFiles],
   );
@@ -906,14 +957,114 @@ function AudioEditorForm() {
 
   const handleReplaceFileSelection = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const list = event.target.files;
+      const files = Array.from(event.currentTarget.files ?? []);
       const stableId = pendingReplaceStableIdRef.current;
       pendingReplaceStableIdRef.current = null;
-      event.target.value = "";
-      if (!list || list.length === 0 || !stableId) return;
-      await replaceTrackFile(stableId, list[0]);
+      event.currentTarget.value = "";
+      if (files.length === 0 || !stableId) return;
+      await replaceTrackFile(stableId, files[0]);
     },
     [replaceTrackFile],
+  );
+
+  const uploadAlbumArt = useCallback(
+    async (track: TrackItem, file: File) => {
+      if (!isAcceptedAlbumArtFile(file)) {
+        toast.error("Choose a JPEG, PNG, or WebP image.");
+        return;
+      }
+
+      const fields = getEditableFields(track);
+      const fieldError = validateTrackFields(
+        fields.title,
+        fields.artist,
+        fields.description,
+      );
+      if (fieldError) {
+        setInlineError(fieldError);
+        toast.error(fieldError);
+        return;
+      }
+      const urlErr = validateStreamingUrls(
+        fields.albumThumbnailUrl,
+        fields.spotifyUrl,
+        fields.appleMusicUrl,
+      );
+      if (urlErr) {
+        setInlineError(urlErr);
+        toast.error(urlErr);
+        return;
+      }
+
+      setInlineError(null);
+      setRowAction(track.stableId, "art");
+      try {
+        const { uploadUrl } = await generateUploadUrl({});
+        const storageId = await uploadFileWithProgress(uploadUrl, file, () => {});
+        const outcome = await runAdminEffect(
+          convexMutationEffect(() =>
+            updateDraftTrack({
+              stableId: track.stableId,
+              title: fields.title.trim(),
+              artist:
+                fields.artist.trim().length > 0 ? fields.artist.trim() : null,
+              description: fields.description.trim(),
+              albumThumbnailUrl:
+                fields.albumThumbnailUrl.trim().length > 0
+                  ? fields.albumThumbnailUrl.trim()
+                  : null,
+              albumThumbnailStorageId: storageId,
+              spotifyUrl:
+                fields.spotifyUrl.trim().length > 0
+                  ? fields.spotifyUrl.trim()
+                  : null,
+              appleMusicUrl:
+                fields.appleMusicUrl.trim().length > 0
+                  ? fields.appleMusicUrl.trim()
+                  : null,
+            }),
+          ),
+          { onErrorMessage: setInlineError },
+        );
+
+        if (outcome !== undefined) {
+          clearTrackEdit(track.stableId);
+          toast.success("Album art uploaded.");
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Album art upload failed.";
+        setInlineError(message);
+        toast.error(message);
+      } finally {
+        setRowAction(track.stableId, undefined);
+      }
+    },
+    [
+      clearTrackEdit,
+      generateUploadUrl,
+      getEditableFields,
+      setRowAction,
+      updateDraftTrack,
+    ],
+  );
+
+  const handleAlbumArtUploadClick = useCallback((stableId: string) => {
+    pendingAlbumArtStableIdRef.current = stableId;
+    albumArtFileInputRef.current?.click();
+  }, []);
+
+  const handleAlbumArtSelection = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.currentTarget.files ?? []);
+      const stableId = pendingAlbumArtStableIdRef.current;
+      pendingAlbumArtStableIdRef.current = null;
+      event.currentTarget.value = "";
+      if (files.length === 0 || !stableId) return;
+      const track = tracks.find((candidate) => candidate.stableId === stableId);
+      if (!track) return;
+      await uploadAlbumArt(track, files[0]);
+    },
+    [tracks, uploadAlbumArt],
   );
 
   const canAcceptDrop =
@@ -1211,8 +1362,8 @@ function AudioEditorForm() {
             </h2>
             <p className="body-text-small max-w-2xl text-foreground/85">
               Upload MP3 or WAV samples for the homepage “Studio portfolio”
-              section. Add optional album art (HTTPS image URL), Spotify, and Apple
-              Music links per track. Playback uses Convex signed URLs (
+              section. Add optional album art with an HTTPS image URL or upload,
+              plus Spotify and Apple Music links per track. Playback uses Convex signed URLs (
               <code className="rounded bg-muted px-1 py-0.5 text-xs">
                 &lt;audio src&gt;
               </code>
@@ -1236,6 +1387,13 @@ function AudioEditorForm() {
               accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,.mp3,.wav"
               className="hidden"
               onChange={(event) => void handleReplaceFileSelection(event)}
+            />
+            <input
+              ref={albumArtFileInputRef}
+              type="file"
+              accept={ALBUM_ART_ACCEPT}
+              className="hidden"
+              onChange={(event) => void handleAlbumArtSelection(event)}
             />
             <Button
               type="button"
@@ -1482,10 +1640,49 @@ function AudioEditorForm() {
                       inputMode="url"
                       autoComplete="off"
                     />
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 px-2"
+                        disabled={busy !== null || isRowBusy}
+                        onClick={() => handleAlbumArtUploadClick(track.stableId)}
+                      >
+                        {rowAction === "art" ? (
+                          <Loader2
+                            className="mr-1 size-3.5 animate-spin"
+                            aria-hidden
+                          />
+                        ) : (
+                          <Upload className="mr-1 size-3.5" aria-hidden />
+                        )}
+                        {rowAction === "art" ? "Uploading…" : "Upload image"}
+                      </Button>
+                      {fields.albumThumbnailStorageId ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 px-2 text-destructive hover:text-destructive"
+                          disabled={busy !== null || isRowBusy}
+                          onClick={() =>
+                            updateTrackEdit(track, {
+                              albumThumbnailStorageId: null,
+                              albumThumbnailStorageUrl: null,
+                              albumThumbnailDisplayUrl:
+                                httpsImagePreviewUrl(fields.albumThumbnailUrl),
+                            })
+                          }
+                        >
+                          Clear upload
+                        </Button>
+                      ) : null}
+                    </div>
                     {(() => {
-                      const preview = httpsImagePreviewUrl(
-                        fields.albumThumbnailUrl,
-                      );
+                      const preview =
+                        fields.albumThumbnailStorageUrl ??
+                        httpsImagePreviewUrl(fields.albumThumbnailUrl);
                       return preview ? (
                         <div className="relative mt-2 aspect-square w-full max-w-[140px] overflow-hidden rounded-sm border border-border bg-muted">
                           <Image

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -115,8 +115,6 @@ type TrackEdits = Record<
     description: string;
     albumThumbnailUrl: string;
     albumThumbnailStorageId: Id<"_storage"> | null;
-    albumThumbnailStorageUrl: string | null;
-    albumThumbnailDisplayUrl: string | null;
     spotifyUrl: string;
     appleMusicUrl: string;
   }
@@ -261,7 +259,11 @@ function sequentialEffects(
   effects: Array<Effect.Effect<unknown, CmsAppError>>,
 ): Effect.Effect<void, CmsAppError> {
   return effects.reduce(
-    (acc, effect) => pipe(acc, Effect.flatMap(() => effect)),
+    (acc, effect) =>
+      pipe(
+        acc,
+        Effect.flatMap(() => effect),
+      ),
     Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
   );
 }
@@ -293,7 +295,10 @@ async function uploadFileWithProgress(
   return await new Promise<Id<"_storage">>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("POST", uploadUrl);
-    xhr.setRequestHeader("Content-Type", file.type || "application/octet-stream");
+    xhr.setRequestHeader(
+      "Content-Type",
+      file.type || "application/octet-stream",
+    );
     xhr.upload.addEventListener("progress", (event) => {
       if (event.lengthComputable && event.total > 0) {
         onProgress(Math.min(1, event.loaded / event.total));
@@ -464,26 +469,19 @@ function AudioEditorForm() {
   const getEditableFields = useCallback(
     (track: TrackItem) => ({
       title: edits[track.stableId]?.title ?? track.title,
-      artist: edits[track.stableId]?.artist ?? (track.artist ?? ""),
+      artist: edits[track.stableId]?.artist ?? track.artist ?? "",
       description: edits[track.stableId]?.description ?? track.description,
       albumThumbnailUrl:
         edits[track.stableId]?.albumThumbnailUrl ??
-        (track.albumThumbnailUrl ?? ""),
+        track.albumThumbnailUrl ??
+        "",
       albumThumbnailStorageId:
         edits[track.stableId]?.albumThumbnailStorageId !== undefined
           ? edits[track.stableId]!.albumThumbnailStorageId
           : track.albumThumbnailStorageId,
-      albumThumbnailStorageUrl:
-        edits[track.stableId]?.albumThumbnailStorageUrl !== undefined
-          ? edits[track.stableId]!.albumThumbnailStorageUrl
-          : track.albumThumbnailStorageUrl,
-      albumThumbnailDisplayUrl:
-        edits[track.stableId]?.albumThumbnailDisplayUrl !== undefined
-          ? edits[track.stableId]!.albumThumbnailDisplayUrl
-          : track.albumThumbnailDisplayUrl,
-      spotifyUrl: edits[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
+      spotifyUrl: edits[track.stableId]?.spotifyUrl ?? track.spotifyUrl ?? "",
       appleMusicUrl:
-        edits[track.stableId]?.appleMusicUrl ?? (track.appleMusicUrl ?? ""),
+        edits[track.stableId]?.appleMusicUrl ?? track.appleMusicUrl ?? "",
     }),
     [edits],
   );
@@ -499,34 +497,26 @@ function AudioEditorForm() {
         spotifyUrl: string;
         appleMusicUrl: string;
         albumThumbnailStorageId: Id<"_storage"> | null;
-        albumThumbnailStorageUrl: string | null;
-        albumThumbnailDisplayUrl: string | null;
       }>,
     ) => {
       setEdits((current) => {
         const base = {
           title: current[track.stableId]?.title ?? track.title,
-          artist: current[track.stableId]?.artist ?? (track.artist ?? ""),
-          description: current[track.stableId]?.description ?? track.description,
+          artist: current[track.stableId]?.artist ?? track.artist ?? "",
+          description:
+            current[track.stableId]?.description ?? track.description,
           albumThumbnailUrl:
             current[track.stableId]?.albumThumbnailUrl ??
-            (track.albumThumbnailUrl ?? ""),
+            track.albumThumbnailUrl ??
+            "",
           albumThumbnailStorageId:
             current[track.stableId]?.albumThumbnailStorageId !== undefined
               ? current[track.stableId]!.albumThumbnailStorageId
               : track.albumThumbnailStorageId,
-          albumThumbnailStorageUrl:
-            current[track.stableId]?.albumThumbnailStorageUrl !== undefined
-              ? current[track.stableId]!.albumThumbnailStorageUrl
-              : track.albumThumbnailStorageUrl,
-          albumThumbnailDisplayUrl:
-            current[track.stableId]?.albumThumbnailDisplayUrl !== undefined
-              ? current[track.stableId]!.albumThumbnailDisplayUrl
-              : track.albumThumbnailDisplayUrl,
           spotifyUrl:
-            current[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
+            current[track.stableId]?.spotifyUrl ?? track.spotifyUrl ?? "",
           appleMusicUrl:
-            current[track.stableId]?.appleMusicUrl ?? (track.appleMusicUrl ?? ""),
+            current[track.stableId]?.appleMusicUrl ?? track.appleMusicUrl ?? "",
         };
         const next = {
           title: patch.title ?? base.title,
@@ -537,14 +527,6 @@ function AudioEditorForm() {
             "albumThumbnailStorageId" in patch
               ? (patch.albumThumbnailStorageId ?? null)
               : base.albumThumbnailStorageId,
-          albumThumbnailStorageUrl:
-            "albumThumbnailStorageUrl" in patch
-              ? (patch.albumThumbnailStorageUrl ?? null)
-              : base.albumThumbnailStorageUrl,
-          albumThumbnailDisplayUrl:
-            "albumThumbnailDisplayUrl" in patch
-              ? (patch.albumThumbnailDisplayUrl ?? null)
-              : base.albumThumbnailDisplayUrl,
           spotifyUrl: patch.spotifyUrl ?? base.spotifyUrl,
           appleMusicUrl: patch.appleMusicUrl ?? base.appleMusicUrl,
         };
@@ -554,8 +536,6 @@ function AudioEditorForm() {
           next.description === track.description &&
           next.albumThumbnailUrl === (track.albumThumbnailUrl ?? "") &&
           next.albumThumbnailStorageId === track.albumThumbnailStorageId &&
-          next.albumThumbnailStorageUrl === track.albumThumbnailStorageUrl &&
-          next.albumThumbnailDisplayUrl === track.albumThumbnailDisplayUrl &&
           next.spotifyUrl === (track.spotifyUrl ?? "") &&
           next.appleMusicUrl === (track.appleMusicUrl ?? "")
         ) {
@@ -677,8 +657,7 @@ function AudioEditorForm() {
         updateDraftTrack({
           stableId: track.stableId,
           title: fields.title.trim(),
-          artist:
-            fields.artist.trim().length > 0 ? fields.artist.trim() : null,
+          artist: fields.artist.trim().length > 0 ? fields.artist.trim() : null,
           description: fields.description.trim(),
           albumThumbnailUrl:
             fields.albumThumbnailUrl.trim().length > 0
@@ -710,9 +689,7 @@ function AudioEditorForm() {
     async (orderedStableIds: string[]): Promise<boolean> => {
       const outcome = await runAction(
         "Reordering…",
-        convexMutationEffect(() =>
-          reorderDraftTracks({ orderedStableIds }),
-        ),
+        convexMutationEffect(() => reorderDraftTracks({ orderedStableIds })),
       );
       return outcome !== undefined;
     },
@@ -742,7 +719,9 @@ function AudioEditorForm() {
     async (files: File[]) => {
       if (!data) return;
       const allowedMime = new Set<string>(data.limits.acceptedMimeTypes);
-      const audioFiles = files.filter((f) => isAcceptedAudioFile(f, allowedMime));
+      const audioFiles = files.filter((f) =>
+        isAcceptedAudioFile(f, allowedMime),
+      );
       if (audioFiles.length === 0) {
         toast.error("Drop MP3 or WAV files only.");
         return;
@@ -804,14 +783,11 @@ function AudioEditorForm() {
           });
 
           setUploadQueue((q) =>
-            q.map((e) =>
-              e.id === entryId ? { ...e, status: "done" } : e,
-            ),
+            q.map((e) => (e.id === entryId ? { ...e, status: "done" } : e)),
           );
           toast.success(`Added ${file.name}`);
         } catch (e) {
-          const message =
-            e instanceof Error ? e.message : "Upload failed.";
+          const message = e instanceof Error ? e.message : "Upload failed.";
           setUploadQueue((q) =>
             q.map((entry) =>
               entry.id === entryId
@@ -925,9 +901,7 @@ function AudioEditorForm() {
         }
 
         setUploadQueue((q) =>
-          q.map((e) =>
-            e.id === entryId ? { ...e, status: "done" } : e,
-          ),
+          q.map((e) => (e.id === entryId ? { ...e, status: "done" } : e)),
         );
         toast.success(`Replaced audio file with ${file.name}.`);
       } catch (e) {
@@ -1006,7 +980,11 @@ function AudioEditorForm() {
       setRowAction(track.stableId, "art");
       try {
         const { uploadUrl } = await generateUploadUrl({});
-        const storageId = await uploadFileWithProgress(uploadUrl, file, () => {});
+        const storageId = await uploadFileWithProgress(
+          uploadUrl,
+          file,
+          () => {},
+        );
         const outcome = await runAdminEffect(
           convexMutationEffect(() =>
             updateDraftTrack({
@@ -1036,9 +1014,14 @@ function AudioEditorForm() {
         if (outcome !== undefined) {
           clearTrackEdit(track.stableId);
           toast.success("Album art uploaded.");
+        } else {
+          updateTrackEdit(track, {
+            albumThumbnailStorageId: track.albumThumbnailStorageId,
+          });
         }
       } catch (e) {
-        const message = e instanceof Error ? e.message : "Album art upload failed.";
+        const message =
+          e instanceof Error ? e.message : "Album art upload failed.";
         setInlineError(message);
         toast.error(message);
       } finally {
@@ -1051,6 +1034,7 @@ function AudioEditorForm() {
       getEditableFields,
       setRowAction,
       updateDraftTrack,
+      updateTrackEdit,
     ],
   );
 
@@ -1263,12 +1247,7 @@ function AudioEditorForm() {
       if (!ok) return false;
     }
     return true;
-  }, [
-    flushFFAutosave,
-    hasAudioLocalEdits,
-    hasFFLocalEdits,
-    savePendingEdits,
-  ]);
+  }, [flushFFAutosave, hasAudioLocalEdits, hasFFLocalEdits, savePendingEdits]);
 
   const { toolbarPortal, editorRef } = useRegisterCmsEditor({
     section: "audio",
@@ -1369,12 +1348,13 @@ function AudioEditorForm() {
             <p className="body-text-small max-w-2xl text-foreground/85">
               Upload MP3 or WAV samples for the homepage “Studio portfolio”
               section. Add optional album art with an HTTPS image URL or upload,
-              plus Spotify and Apple Music links per track. Playback uses Convex signed URLs (
+              plus Spotify and Apple Music links per track. Playback uses Convex
+              signed URLs (
               <code className="rounded bg-muted px-1 py-0.5 text-xs">
                 &lt;audio src&gt;
               </code>
-              ). Draft changes stay private until you publish. Abandoned draft-only
-              uploads are removed after 7 days (weekly job).
+              ). Draft changes stay private until you publish. Abandoned
+              draft-only uploads are removed after 7 days (weekly job).
             </p>
           </div>
 
@@ -1415,7 +1395,8 @@ function AudioEditorForm() {
               Upload audio
             </Button>
             <p className="body-text-small text-right text-foreground/70">
-              MP3 or WAV. Up to {Math.floor(data.limits.maxFileBytes / (1024 * 1024))}MB each.
+              MP3 or WAV. Up to{" "}
+              {Math.floor(data.limits.maxFileBytes / (1024 * 1024))}MB each.
               {tracks.length >= data.limits.maxTracks
                 ? ` Limit reached (${data.limits.maxTracks}).`
                 : ` ${tracks.length}/${data.limits.maxTracks} used.`}
@@ -1437,7 +1418,10 @@ function AudioEditorForm() {
             {uploadQueue.map((entry) => (
               <li key={entry.id} className="space-y-1">
                 <div className="flex items-center justify-between gap-3 text-sm">
-                  <span className="truncate text-foreground/85" title={entry.name}>
+                  <span
+                    className="truncate text-foreground/85"
+                    title={entry.name}
+                  >
                     {entry.name}
                   </span>
                   <span
@@ -1511,64 +1495,66 @@ function AudioEditorForm() {
                       {" · "}
                       {formatDuration(track.durationSec)}
                     </p>
-                  <div className="flex shrink-0 flex-wrap items-center gap-1">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      aria-label="Move up"
-                      disabled={index === 0 || busy !== null || isRowBusy}
-                      onClick={() => void moveTrack(track.stableId, -1)}
-                    >
-                      <ArrowUp className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      aria-label="Move down"
-                      disabled={
-                        index === tracks.length - 1 ||
-                        busy !== null ||
-                        isRowBusy
-                      }
-                      onClick={() => void moveTrack(track.stableId, 1)}
-                    >
-                      <ArrowDown className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 px-2"
-                      aria-label={`Replace audio file for ${track.title}`}
-                      disabled={busy !== null || isRowBusy}
-                      onClick={() => handleReplaceClick(track.stableId)}
-                    >
-                      {rowAction === "replacing" ? (
-                        <Loader2
-                          className="mr-1 size-3.5 animate-spin"
-                          aria-hidden
-                        />
-                      ) : (
-                        <Replace className="mr-1 size-3.5" aria-hidden />
-                      )}
-                      {rowAction === "replacing" ? "Replacing…" : "Replace file"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-destructive hover:text-destructive"
-                      aria-label="Remove track"
-                      disabled={busy !== null || isRowBusy}
-                      onClick={() => setDeleteStableId(track.stableId)}
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  </div>
+                    <div className="flex shrink-0 flex-wrap items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label="Move up"
+                        disabled={index === 0 || busy !== null || isRowBusy}
+                        onClick={() => void moveTrack(track.stableId, -1)}
+                      >
+                        <ArrowUp className="size-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label="Move down"
+                        disabled={
+                          index === tracks.length - 1 ||
+                          busy !== null ||
+                          isRowBusy
+                        }
+                        onClick={() => void moveTrack(track.stableId, 1)}
+                      >
+                        <ArrowDown className="size-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 px-2"
+                        aria-label={`Replace audio file for ${track.title}`}
+                        disabled={busy !== null || isRowBusy}
+                        onClick={() => handleReplaceClick(track.stableId)}
+                      >
+                        {rowAction === "replacing" ? (
+                          <Loader2
+                            className="mr-1 size-3.5 animate-spin"
+                            aria-hidden
+                          />
+                        ) : (
+                          <Replace className="mr-1 size-3.5" aria-hidden />
+                        )}
+                        {rowAction === "replacing"
+                          ? "Replacing…"
+                          : "Replace file"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 text-destructive hover:text-destructive"
+                        aria-label="Remove track"
+                        disabled={busy !== null || isRowBusy}
+                        onClick={() => setDeleteStableId(track.stableId)}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
                   </div>
                   {track.url ? (
                     <audio
@@ -1653,7 +1639,9 @@ function AudioEditorForm() {
                         size="sm"
                         className="h-8 px-2"
                         disabled={busy !== null || isRowBusy}
-                        onClick={() => handleAlbumArtUploadClick(track.stableId)}
+                        onClick={() =>
+                          handleAlbumArtUploadClick(track.stableId)
+                        }
                       >
                         {rowAction === "art" ? (
                           <Loader2
@@ -1675,9 +1663,6 @@ function AudioEditorForm() {
                           onClick={() =>
                             updateTrackEdit(track, {
                               albumThumbnailStorageId: null,
-                              albumThumbnailStorageUrl: null,
-                              albumThumbnailDisplayUrl:
-                                httpsImagePreviewUrl(fields.albumThumbnailUrl),
                             })
                           }
                         >
@@ -1687,8 +1672,9 @@ function AudioEditorForm() {
                     </div>
                     {(() => {
                       const preview =
-                        fields.albumThumbnailStorageUrl ??
-                        httpsImagePreviewUrl(fields.albumThumbnailUrl);
+                        fields.albumThumbnailStorageId != null
+                          ? track.albumThumbnailStorageUrl
+                          : httpsImagePreviewUrl(fields.albumThumbnailUrl);
                       return preview ? (
                         <div className="relative mt-2 aspect-square w-full max-w-[140px] overflow-hidden rounded-sm border border-border bg-muted">
                           <Image
@@ -1743,7 +1729,10 @@ function AudioEditorForm() {
                     onClick={() => void saveTrackDetails(track)}
                   >
                     {rowAction === "saving" ? (
-                      <Loader2 className="mr-1 size-3.5 animate-spin" aria-hidden />
+                      <Loader2
+                        className="mr-1 size-3.5 animate-spin"
+                        aria-hidden
+                      />
                     ) : (
                       <Save className="mr-1 size-3.5" aria-hidden />
                     )}

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -470,14 +470,17 @@ function AudioEditorForm() {
         edits[track.stableId]?.albumThumbnailUrl ??
         (track.albumThumbnailUrl ?? ""),
       albumThumbnailStorageId:
-        edits[track.stableId]?.albumThumbnailStorageId ??
-        track.albumThumbnailStorageId,
+        edits[track.stableId]?.albumThumbnailStorageId !== undefined
+          ? edits[track.stableId]!.albumThumbnailStorageId
+          : track.albumThumbnailStorageId,
       albumThumbnailStorageUrl:
-        edits[track.stableId]?.albumThumbnailStorageUrl ??
-        track.albumThumbnailStorageUrl,
+        edits[track.stableId]?.albumThumbnailStorageUrl !== undefined
+          ? edits[track.stableId]!.albumThumbnailStorageUrl
+          : track.albumThumbnailStorageUrl,
       albumThumbnailDisplayUrl:
-        edits[track.stableId]?.albumThumbnailDisplayUrl ??
-        track.albumThumbnailDisplayUrl,
+        edits[track.stableId]?.albumThumbnailDisplayUrl !== undefined
+          ? edits[track.stableId]!.albumThumbnailDisplayUrl
+          : track.albumThumbnailDisplayUrl,
       spotifyUrl: edits[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
       appleMusicUrl:
         edits[track.stableId]?.appleMusicUrl ?? (track.appleMusicUrl ?? ""),
@@ -509,14 +512,17 @@ function AudioEditorForm() {
             current[track.stableId]?.albumThumbnailUrl ??
             (track.albumThumbnailUrl ?? ""),
           albumThumbnailStorageId:
-            current[track.stableId]?.albumThumbnailStorageId ??
-            track.albumThumbnailStorageId,
+            current[track.stableId]?.albumThumbnailStorageId !== undefined
+              ? current[track.stableId]!.albumThumbnailStorageId
+              : track.albumThumbnailStorageId,
           albumThumbnailStorageUrl:
-            current[track.stableId]?.albumThumbnailStorageUrl ??
-            track.albumThumbnailStorageUrl,
+            current[track.stableId]?.albumThumbnailStorageUrl !== undefined
+              ? current[track.stableId]!.albumThumbnailStorageUrl
+              : track.albumThumbnailStorageUrl,
           albumThumbnailDisplayUrl:
-            current[track.stableId]?.albumThumbnailDisplayUrl ??
-            track.albumThumbnailDisplayUrl,
+            current[track.stableId]?.albumThumbnailDisplayUrl !== undefined
+              ? current[track.stableId]!.albumThumbnailDisplayUrl
+              : track.albumThumbnailDisplayUrl,
           spotifyUrl:
             current[track.stableId]?.spotifyUrl ?? (track.spotifyUrl ?? ""),
           appleMusicUrl:

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -55,6 +55,8 @@ function materializePublishedAudio(
     durationSec: number | null;
     sortOrder: number;
     albumThumbnailUrl: string | null;
+    albumThumbnailStorageUrl: string | null;
+    albumThumbnailDisplayUrl: string | null;
     spotifyUrl: string | null;
     appleMusicUrl: string | null;
   }>,
@@ -71,6 +73,8 @@ function materializePublishedAudio(
       durationSec: t.durationSec,
       sortOrder: t.sortOrder,
       albumThumbnailUrl: t.albumThumbnailUrl,
+      albumThumbnailStorageUrl: t.albumThumbnailStorageUrl,
+      albumThumbnailDisplayUrl: t.albumThumbnailDisplayUrl,
       spotifyUrl: t.spotifyUrl,
       appleMusicUrl: t.appleMusicUrl,
     }));

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -71,6 +71,8 @@ function PreviewContent() {
       durationSec: t.durationSec,
       sortOrder: t.sortOrder,
       albumThumbnailUrl: t.albumThumbnailUrl,
+      albumThumbnailStorageUrl: t.albumThumbnailStorageUrl,
+      albumThumbnailDisplayUrl: t.albumThumbnailDisplayUrl,
       spotifyUrl: t.spotifyUrl,
       appleMusicUrl: t.appleMusicUrl,
     }));

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -14,6 +14,8 @@ export type PublishedAudioTrack = {
   durationSec: number | null;
   sortOrder: number;
   albumThumbnailUrl: string | null;
+  albumThumbnailStorageUrl: string | null;
+  albumThumbnailDisplayUrl: string | null;
   spotifyUrl: string | null;
   appleMusicUrl: string | null;
 };
@@ -84,9 +86,9 @@ export function AudioPortfolio({
               className="rounded-sm border border-sage/30 bg-washed-black/60 p-6 transition-colors hover:border-sand/50"
             >
               <div className="relative mb-4 aspect-square overflow-hidden rounded-sm bg-sage/20">
-                {track.albumThumbnailUrl ? (
+                {track.albumThumbnailDisplayUrl ? (
                   <Image
-                    src={track.albumThumbnailUrl}
+                    src={track.albumThumbnailDisplayUrl}
                     alt=""
                     fill
                     className="object-cover"

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -112,33 +112,35 @@ function StudioGallery({
           </div>
         </div>
 
-        <div className="mt-8 flex items-center justify-between px-2">
-          <div className="label-text text-[10px] text-ivory/55">
-            <span className="text-sand">
-              {String(safeIndex + 1).padStart(2, "0")}
-            </span>
-            <span className="mx-2 text-ivory/45">/</span>
-            <span>{String(availablePhotos.length).padStart(2, "0")}</span>
-          </div>
+        <div className="mt-8 flex flex-col gap-5 px-2 md:flex-row md:items-center md:justify-between md:gap-0">
+          <div className="flex items-center justify-between gap-3 md:contents">
+            <div className="label-text text-[10px] text-ivory/55">
+              <span className="text-sand">
+                {String(safeIndex + 1).padStart(2, "0")}
+              </span>
+              <span className="mx-2 text-ivory/45">/</span>
+              <span>{String(availablePhotos.length).padStart(2, "0")}</span>
+            </div>
 
-          <div className="flex items-center gap-1.5">
-            {availablePhotos.map((photo, index) => (
-              <button
-                key={photo.stableId}
-                type="button"
-                onClick={() => goToImage(index)}
-                aria-label={`View image ${index + 1}`}
-                className={`h-px transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] ${
-                  index === safeIndex
-                    ? "w-8 bg-sand"
-                    : "w-4 bg-ivory/22 hover:bg-ivory/40"
-                }`}
-              />
-            ))}
+            <div className="flex items-center gap-1.5">
+              {availablePhotos.map((photo, index) => (
+                <button
+                  key={photo.stableId}
+                  type="button"
+                  onClick={() => goToImage(index)}
+                  aria-label={`View image ${index + 1}`}
+                  className={`h-px transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+                    index === safeIndex
+                      ? "w-8 bg-sand"
+                      : "w-4 bg-ivory/22 hover:bg-ivory/40"
+                  }`}
+                />
+              ))}
+            </div>
           </div>
 
           {availablePhotos.length > 1 ? (
-            <div className="flex items-center gap-4 text-ivory/62">
+            <div className="flex items-center justify-between gap-4 text-ivory/62 md:justify-end">
               <button
                 type="button"
                 onClick={goToPrevious}
@@ -157,7 +159,7 @@ function StudioGallery({
               </button>
             </div>
           ) : (
-            <span className="w-20" aria-hidden />
+            <span className="hidden w-20 md:block" aria-hidden />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds an admin audio track replace flow that uploads a new blob, swaps the draft `storageId` atomically, and best-effort deletes the old blob when unreferenced.
- Updates the audio editor UI with a per-track **Replace file** action, hidden file picker handling, and replacement progress/error states.
- Refines audio editor helpers for file acceptance, title/byte/duration formatting, and track field validation.
- Adjusts gallery layout responsiveness in `the-space` for better mobile/desktop alignment.
- Adds coverage for audio constants, draft/published track matching, and audio editor helper behavior.

## Testing
- `bun test convex/audioTracks.test.ts`
- `bun test src/app/admin/audio/audio-editor.test.ts`
- Not run: full app lint/build or Convex integration validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Convex schema and storage GC logic and adds new per-track upload flows, so mistakes could lead to broken media references or leaked/deleted storage blobs.
> 
> **Overview**
> **Audio tracks now support uploaded album art** via a new optional `albumThumbnailStorageId` on `audioTracks`, with schema/index updates and expanded storage reference tracking so blobs aren’t deleted while still referenced.
> 
> Admin audio mutations (`saveUploadedTrack`, `updateDraftTrack`, publish validation, GC) now validate album-art MIME/size, include album-art blobs when checking for publish issues, and best-effort clean up unreferenced album-art uploads on errors/removals.
> 
> The admin audio editor UI adds a per-track *Upload image* action (JPEG/PNG/WebP) with preview/clear behavior and new `albumThumbnailDisplayUrl` plumbing; the public/preview audio portfolio now renders album art from the uploaded blob URL when present, falling back to the external URL. Also tweaks gallery (`the-space`) controls layout responsiveness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af46bc854b24a9744b013cfb4556a32615f89114. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->