### PR TITLE
[INF-97] Audio portfolio: lazy playback, empty state, accessibility

### DIFF
--- a/convex/admin/audio.ts
+++ b/convex/admin/audio.ts
@@ -35,9 +35,13 @@ import { requireCmsOwner } from "../lib/auth";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_ARTIST_LENGTH = 200;
+const MAX_GENRE_LENGTH = 100;
+const MAX_ROLE_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
 const MAX_FILENAME_LENGTH = 255;
 const MAX_EXTERNAL_URL_LENGTH = 2048;
+const MIN_RECORDING_YEAR = 1800;
+const MAX_RECORDING_YEAR = 3000;
 
 function hostnameOfHttpsUrl(raw: string): string | null {
   try {
@@ -147,6 +151,57 @@ function normalizeArtist(raw?: string | null): string | undefined {
     );
   }
   return value;
+}
+
+function normalizeGenre(raw?: string | null): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  if (value.length > MAX_GENRE_LENGTH) {
+    cmsValidationError(
+      `Genre must be at most ${MAX_GENRE_LENGTH} characters.`,
+      "genre",
+    );
+  }
+  return value;
+}
+
+function normalizeRole(raw?: string | null): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  if (value.length > MAX_ROLE_LENGTH) {
+    cmsValidationError(
+      `Role must be at most ${MAX_ROLE_LENGTH} characters.`,
+      "role",
+    );
+  }
+  return value;
+}
+
+function normalizeYear(raw: number | null | undefined): number | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (
+    !Number.isInteger(raw) ||
+    raw < MIN_RECORDING_YEAR ||
+    raw > MAX_RECORDING_YEAR
+  ) {
+    cmsValidationError(
+      `Year must be a whole number between ${MIN_RECORDING_YEAR} and ${MAX_RECORDING_YEAR}.`,
+      "year",
+    );
+  }
+  return raw;
 }
 
 function normalizeDescription(raw: string): string {
@@ -288,6 +343,29 @@ function collectTrackIssues(
       issues.push({
         path: `${base}.artist`,
         message: `Artist must be at most ${MAX_ARTIST_LENGTH} characters.`,
+      });
+    }
+    if ((row.genre ?? "").length > MAX_GENRE_LENGTH) {
+      issues.push({
+        path: `${base}.genre`,
+        message: `Genre must be at most ${MAX_GENRE_LENGTH} characters.`,
+      });
+    }
+    if (
+      row.year !== undefined &&
+      (!Number.isInteger(row.year) ||
+        row.year < MIN_RECORDING_YEAR ||
+        row.year > MAX_RECORDING_YEAR)
+    ) {
+      issues.push({
+        path: `${base}.year`,
+        message: `Year must be between ${MIN_RECORDING_YEAR} and ${MAX_RECORDING_YEAR}.`,
+      });
+    }
+    if ((row.role ?? "").length > MAX_ROLE_LENGTH) {
+      issues.push({
+        path: `${base}.role`,
+        message: `Role must be at most ${MAX_ROLE_LENGTH} characters.`,
       });
     }
     if (row.description.trim().length === 0) {
@@ -527,6 +605,9 @@ export const saveUploadedTrack = mutation({
     storageId: v.id("_storage"),
     title: v.string(),
     artist: v.optional(v.union(v.string(), v.null())),
+    genre: v.optional(v.union(v.string(), v.null())),
+    year: v.optional(v.union(v.number(), v.null())),
+    role: v.optional(v.union(v.string(), v.null())),
     description: v.string(),
     durationSec: v.optional(v.union(v.number(), v.null())),
     originalFileName: v.optional(v.union(v.string(), v.null())),
@@ -562,6 +643,9 @@ export const saveUploadedTrack = mutation({
 
       const title = normalizeTitle(args.title);
       const artist = normalizeArtist(args.artist);
+      const genre = normalizeGenre(args.genre);
+      const year = normalizeYear(args.year);
+      const role = normalizeRole(args.role);
       const description = normalizeDescription(args.description);
       const durationSec = normalizeDurationSec(args.durationSec ?? undefined);
       const originalFileName = normalizeFileName(args.originalFileName);
@@ -601,6 +685,9 @@ export const saveUploadedTrack = mutation({
         storageId: args.storageId,
         title,
         ...(artist !== undefined ? { artist } : {}),
+        ...(genre !== undefined ? { genre } : {}),
+        ...(year !== undefined ? { year } : {}),
+        ...(role !== undefined ? { role } : {}),
         description,
         mimeType,
         ...(durationSec !== undefined ? { durationSec } : {}),
@@ -636,6 +723,9 @@ export const updateDraftTrack = mutation({
     stableId: v.string(),
     title: v.string(),
     artist: v.optional(v.union(v.string(), v.null())),
+    genre: v.optional(v.union(v.string(), v.null())),
+    year: v.optional(v.union(v.number(), v.null())),
+    role: v.optional(v.union(v.string(), v.null())),
     description: v.string(),
     durationSec: v.optional(v.union(v.number(), v.null())),
     albumThumbnailUrl: v.optional(v.union(v.string(), v.null())),
@@ -662,6 +752,33 @@ export const updateDraftTrack = mutation({
         nextArtist = normalizeArtist(args.artist);
       } else {
         nextArtist = row.artist;
+      }
+
+      let nextGenre: string | undefined;
+      if (args.genre === null) {
+        nextGenre = undefined;
+      } else if (args.genre !== undefined) {
+        nextGenre = normalizeGenre(args.genre);
+      } else {
+        nextGenre = row.genre;
+      }
+
+      let nextYear: number | undefined;
+      if (args.year === null) {
+        nextYear = undefined;
+      } else if (args.year !== undefined) {
+        nextYear = normalizeYear(args.year);
+      } else {
+        nextYear = row.year;
+      }
+
+      let nextRole: string | undefined;
+      if (args.role === null) {
+        nextRole = undefined;
+      } else if (args.role !== undefined) {
+        nextRole = normalizeRole(args.role);
+      } else {
+        nextRole = row.role;
       }
 
       let durationSec: number | undefined;
@@ -734,6 +851,9 @@ export const updateDraftTrack = mutation({
         sizeBytes: row.sizeBytes,
         createdAt: row.createdAt,
         ...(nextArtist !== undefined ? { artist: nextArtist } : {}),
+        ...(nextGenre !== undefined ? { genre: nextGenre } : {}),
+        ...(nextYear !== undefined ? { year: nextYear } : {}),
+        ...(nextRole !== undefined ? { role: nextRole } : {}),
         ...(durationSec !== undefined ? { durationSec } : {}),
         ...(nextAlbumThumbnailUrl !== undefined
           ? { albumThumbnailUrl: nextAlbumThumbnailUrl }
@@ -849,9 +969,10 @@ export const removeDraftTrack = mutation({
  *
  * On validation failure we delete the newly uploaded blob so it does not
  * linger as an orphan. Other metadata (title, artist, description, artwork,
- * streaming links) is preserved — call `updateDraftTrack` separately to edit
- * those. `createdAt` is set to the swap time so abandoned-draft GC (which keys
- * off `createdAt`) cannot delete a draft-only row whose file was just replaced.
+ * genre, year, role, streaming links) is preserved — call `updateDraftTrack`
+ * separately to edit those. `createdAt` is set to the swap time so abandoned-
+ * draft GC (which keys off `createdAt`) cannot delete a draft-only row whose
+ * file was just replaced.
  */
 export const replaceDraftTrackFile = mutation({
   args: {
@@ -923,6 +1044,9 @@ export const replaceDraftTrackFile = mutation({
       sizeBytes,
       createdAt: now,
       ...(row.artist !== undefined ? { artist: row.artist } : {}),
+      ...(row.genre !== undefined ? { genre: row.genre } : {}),
+      ...(row.year !== undefined ? { year: row.year } : {}),
+      ...(row.role !== undefined ? { role: row.role } : {}),
       ...(nextDurationSec !== undefined
         ? { durationSec: nextDurationSec }
         : {}),

--- a/convex/audioTracks.test.ts
+++ b/convex/audioTracks.test.ts
@@ -95,6 +95,24 @@ describe("audioDraftMatchesPublished", () => {
     ).toBe(false);
   });
 
+  test("different public recording metadata → not a match", () => {
+    expect(
+      audioDraftMatchesPublished(
+        [row({ genre: "Americana" })],
+        [row({ genre: "Indie Folk" })],
+      ),
+    ).toBe(false);
+    expect(
+      audioDraftMatchesPublished([row({ year: 2026 })], [row({ year: 2025 })]),
+    ).toBe(false);
+    expect(
+      audioDraftMatchesPublished(
+        [row({ role: "Recorded" })],
+        [row({ role: "Mixed" })],
+      ),
+    ).toBe(false);
+  });
+
   test("order matters", () => {
     expect(
       audioDraftMatchesPublished(

--- a/convex/audioTracks.ts
+++ b/convex/audioTracks.ts
@@ -37,6 +37,9 @@ function comparableTrack(row: AudioTrackDoc) {
     storageId: row.storageId,
     title: row.title,
     artist: row.artist ?? null,
+    genre: row.genre ?? null,
+    year: row.year ?? null,
+    role: row.role ?? null,
     description: row.description,
     mimeType: row.mimeType,
     durationSec: row.durationSec ?? null,
@@ -144,6 +147,9 @@ export async function replaceAudioScope(
       storageId: row.storageId,
       title: row.title,
       ...(row.artist !== undefined ? { artist: row.artist } : {}),
+      ...(row.genre !== undefined ? { genre: row.genre } : {}),
+      ...(row.year !== undefined ? { year: row.year } : {}),
+      ...(row.role !== undefined ? { role: row.role } : {}),
       description: row.description,
       mimeType: row.mimeType,
       ...(row.durationSec !== undefined ? { durationSec: row.durationSec } : {}),
@@ -198,6 +204,9 @@ export async function materializeAudioTracks(
     url: string | null;
     title: string;
     artist: string | null;
+    genre: string | null;
+    year: number | null;
+    role: string | null;
     description: string;
     mimeType: string;
     durationSec: number | null;
@@ -225,6 +234,9 @@ export async function materializeAudioTracks(
         url: await ctx.storage.getUrl(row.storageId),
         title: row.title,
         artist: row.artist ?? null,
+        genre: row.genre ?? null,
+        year: row.year ?? null,
+        role: row.role ?? null,
         description: row.description,
         mimeType: row.mimeType,
         durationSec: row.durationSec ?? null,

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -8,7 +8,7 @@ import { v } from "convex/values";
  * - `settings`   — site metadata (title, description; extend as CMS grows).
  * - `pricing`    — pricing package catalogue that drives the public pricing block.
  * - `about`      — About page hero copy, body block array, optional highlights, SEO meta, optional team headshots.
- * - `recordings` — public recordings page (flag-only; content lives in `src/app/recordings/recordings-data.ts`).
+ * - `recordings` — public recordings page visibility flag; audio content lives in `audioTracks`.
  *
  * Content for each section (when any) lives in dedicated scoped tables using the
  * gear/photos pattern (`scope: "draft" | "published"` column); `cmsSections`
@@ -154,7 +154,7 @@ export const aboutContentValidator = v.object({
 /**
  * The set of sections tracked in `cmsSections`. `recordings` was added when
  * flags moved off the `marketingFeatureFlags` singleton and onto `cmsSections`
- * rows; it has no content table today (flag-only).
+ * rows; its visibility is flag-only while audio content is stored separately.
  */
 export const cmsSectionValidator = v.union(
   v.literal("settings"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,8 +22,8 @@ import {
  *   `pricingPackages`, `settingsContent`) using the same `scope: "draft" | "published"`
  *   pattern as `gearCategories` / `galleryPhotos`. Publish copies the draft
  *   scope onto the published scope in a single mutation.
- * - The `recordings` section is flag-only (no content table); the public page
- *   reads copy from `src/app/recordings/recordings-data.ts`.
+ * - The `recordings` section row is flag-only; recording/audio content is
+ *   authored separately in `audioTracks` and published through the audio CMS.
  */
 export default defineSchema({
   inquiries: defineTable({
@@ -152,6 +152,12 @@ export default defineSchema({
     storageId: v.id("_storage"),
     title: v.string(),
     artist: v.optional(v.string()),
+    /** Displayed on the public recordings table. */
+    genre: v.optional(v.string()),
+    /** Release/recording year displayed on the public recordings table. */
+    year: v.optional(v.number()),
+    /** Optional engineering/production credit for the public recordings row. */
+    role: v.optional(v.string()),
     description: v.string(),
     mimeType: v.string(),
     durationSec: v.optional(v.number()),

--- a/src/app/admin/audio/audio-editor.test.ts
+++ b/src/app/admin/audio/audio-editor.test.ts
@@ -70,28 +70,60 @@ describe("formatDuration", () => {
 
 describe("validateTrackFields", () => {
   test("title is required", () => {
-    expect(validateTrackFields("", "", "something")).toContain("Title");
-    expect(validateTrackFields("   ", "", "something")).toContain("Title");
+    expect(validateTrackFields("", "", "", "", "", "something")).toContain(
+      "Title",
+    );
+    expect(validateTrackFields("   ", "", "", "", "", "something")).toContain(
+      "Title",
+    );
   });
 
   test("title at most 200 chars", () => {
-    expect(validateTrackFields("a".repeat(200), "", "desc")).toBeNull();
-    expect(validateTrackFields("a".repeat(201), "", "desc")).toContain("200");
+    expect(
+      validateTrackFields("a".repeat(200), "", "", "", "", "desc"),
+    ).toBeNull();
+    expect(validateTrackFields("a".repeat(201), "", "", "", "", "desc")).toContain(
+      "200",
+    );
   });
 
   test("artist over 200 chars rejected", () => {
-    expect(validateTrackFields("ok", "a".repeat(201), "desc")).toContain("200");
+    expect(
+      validateTrackFields("ok", "a".repeat(201), "", "", "", "desc"),
+    ).toContain("200");
+  });
+
+  test("recording metadata is capped and year is bounded", () => {
+    expect(validateTrackFields("ok", "", "a".repeat(101), "", "", "desc")).toContain(
+      "100",
+    );
+    expect(validateTrackFields("ok", "", "", "1799", "", "desc")).toContain(
+      "1800",
+    );
+    expect(validateTrackFields("ok", "", "", "2026", "a".repeat(201), "desc"))
+      .toContain("200");
   });
 
   test("description required and capped", () => {
-    expect(validateTrackFields("ok", "", "")).toContain("Description");
+    expect(validateTrackFields("ok", "", "", "", "", "")).toContain(
+      "Description",
+    );
     expect(
-      validateTrackFields("ok", "", "a".repeat(2001)),
+      validateTrackFields("ok", "", "", "", "", "a".repeat(2001)),
     ).toContain("2000");
   });
 
   test("valid input passes", () => {
-    expect(validateTrackFields("Track 1", "Artist", "Desc")).toBeNull();
+    expect(
+      validateTrackFields(
+        "Track 1",
+        "Artist",
+        "Americana",
+        "2026",
+        "Recorded and mixed",
+        "Desc",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -57,8 +57,12 @@ import { cn } from "@/lib/utils";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_ARTIST_LENGTH = 200;
+const MAX_GENRE_LENGTH = 100;
+const MAX_ROLE_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
 const ALBUM_ART_ACCEPT = "image/jpeg,image/png,image/webp";
+const MIN_RECORDING_YEAR = 1800;
+const MAX_RECORDING_YEAR = 3000;
 
 /**
  * Filename fallback for audio files when the browser doesn't surface a usable
@@ -93,6 +97,9 @@ type TrackItem = {
   url: string | null;
   title: string;
   artist: string | null;
+  genre: string | null;
+  year: number | null;
+  role: string | null;
   description: string;
   mimeType: string;
   durationSec: number | null;
@@ -112,6 +119,9 @@ type TrackEdits = Record<
   {
     title: string;
     artist: string;
+    genre: string;
+    year: string;
+    role: string;
     description: string;
     albumThumbnailUrl: string;
     albumThumbnailStorageId: Id<"_storage"> | null;
@@ -159,6 +169,9 @@ export function formatDuration(sec: number | null): string {
 export function validateTrackFields(
   title: string,
   artist: string,
+  genre: string,
+  year: string,
+  role: string,
   description: string,
 ): string | null {
   const t = title.trim();
@@ -169,12 +182,34 @@ export function validateTrackFields(
   if (artist.trim().length > MAX_ARTIST_LENGTH) {
     return `Artist must be at most ${MAX_ARTIST_LENGTH} characters.`;
   }
+  if (genre.trim().length > MAX_GENRE_LENGTH) {
+    return `Genre must be at most ${MAX_GENRE_LENGTH} characters.`;
+  }
+  const y = year.trim();
+  if (y.length > 0) {
+    const n = Number(y);
+    if (
+      !Number.isInteger(n) ||
+      n < MIN_RECORDING_YEAR ||
+      n > MAX_RECORDING_YEAR
+    ) {
+      return `Year must be a whole number between ${MIN_RECORDING_YEAR} and ${MAX_RECORDING_YEAR}.`;
+    }
+  }
+  if (role.trim().length > MAX_ROLE_LENGTH) {
+    return `Role must be at most ${MAX_ROLE_LENGTH} characters.`;
+  }
   const d = description.trim();
   if (d.length === 0) return "Description is required.";
   if (d.length > MAX_DESCRIPTION_LENGTH) {
     return `Description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`;
   }
   return null;
+}
+
+function parseOptionalYear(raw: string): number | null {
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? Number(trimmed) : null;
 }
 
 function validateOptionalHttpsUrl(raw: string, label: string): string | null {
@@ -470,6 +505,11 @@ function AudioEditorForm() {
     (track: TrackItem) => ({
       title: edits[track.stableId]?.title ?? track.title,
       artist: edits[track.stableId]?.artist ?? track.artist ?? "",
+      genre: edits[track.stableId]?.genre ?? track.genre ?? "",
+      year:
+        edits[track.stableId]?.year ??
+        (track.year !== null ? String(track.year) : ""),
+      role: edits[track.stableId]?.role ?? track.role ?? "",
       description: edits[track.stableId]?.description ?? track.description,
       albumThumbnailUrl:
         edits[track.stableId]?.albumThumbnailUrl ??
@@ -492,6 +532,9 @@ function AudioEditorForm() {
       patch: Partial<{
         title: string;
         artist: string;
+        genre: string;
+        year: string;
+        role: string;
         description: string;
         albumThumbnailUrl: string;
         spotifyUrl: string;
@@ -503,6 +546,11 @@ function AudioEditorForm() {
         const base = {
           title: current[track.stableId]?.title ?? track.title,
           artist: current[track.stableId]?.artist ?? track.artist ?? "",
+          genre: current[track.stableId]?.genre ?? track.genre ?? "",
+          year:
+            current[track.stableId]?.year ??
+            (track.year !== null ? String(track.year) : ""),
+          role: current[track.stableId]?.role ?? track.role ?? "",
           description:
             current[track.stableId]?.description ?? track.description,
           albumThumbnailUrl:
@@ -521,6 +569,9 @@ function AudioEditorForm() {
         const next = {
           title: patch.title ?? base.title,
           artist: patch.artist ?? base.artist,
+          genre: patch.genre ?? base.genre,
+          year: patch.year ?? base.year,
+          role: patch.role ?? base.role,
           description: patch.description ?? base.description,
           albumThumbnailUrl: patch.albumThumbnailUrl ?? base.albumThumbnailUrl,
           albumThumbnailStorageId:
@@ -533,6 +584,9 @@ function AudioEditorForm() {
         if (
           next.title === track.title &&
           next.artist === (track.artist ?? "") &&
+          next.genre === (track.genre ?? "") &&
+          next.year === (track.year !== null ? String(track.year) : "") &&
+          next.role === (track.role ?? "") &&
           next.description === track.description &&
           next.albumThumbnailUrl === (track.albumThumbnailUrl ?? "") &&
           next.albumThumbnailStorageId === track.albumThumbnailStorageId &&
@@ -563,6 +617,9 @@ function AudioEditorForm() {
       const validationError = validateTrackFields(
         fields.title,
         fields.artist,
+        fields.genre,
+        fields.year,
+        fields.role,
         fields.description,
       );
       if (validationError) {
@@ -590,6 +647,9 @@ function AudioEditorForm() {
             title: fields.title.trim(),
             artist:
               fields.artist.trim().length > 0 ? fields.artist.trim() : null,
+            genre: fields.genre.trim().length > 0 ? fields.genre.trim() : null,
+            year: parseOptionalYear(fields.year),
+            role: fields.role.trim().length > 0 ? fields.role.trim() : null,
             description: fields.description.trim(),
             albumThumbnailUrl:
               fields.albumThumbnailUrl.trim().length > 0
@@ -632,6 +692,9 @@ function AudioEditorForm() {
       const err = validateTrackFields(
         fields.title,
         fields.artist,
+        fields.genre,
+        fields.year,
+        fields.role,
         fields.description,
       );
       if (err) {
@@ -658,6 +721,9 @@ function AudioEditorForm() {
           stableId: track.stableId,
           title: fields.title.trim(),
           artist: fields.artist.trim().length > 0 ? fields.artist.trim() : null,
+          genre: fields.genre.trim().length > 0 ? fields.genre.trim() : null,
+          year: parseOptionalYear(fields.year),
+          role: fields.role.trim().length > 0 ? fields.role.trim() : null,
           description: fields.description.trim(),
           albumThumbnailUrl:
             fields.albumThumbnailUrl.trim().length > 0
@@ -773,6 +839,9 @@ function AudioEditorForm() {
             storageId,
             title: defaultTitleFromFileName(file.name),
             artist: null,
+            genre: null,
+            year: null,
+            role: null,
             description:
               "Studio recording sample — edit this description before publishing.",
             durationSec: durationSec ?? null,
@@ -958,6 +1027,9 @@ function AudioEditorForm() {
       const fieldError = validateTrackFields(
         fields.title,
         fields.artist,
+        fields.genre,
+        fields.year,
+        fields.role,
         fields.description,
       );
       if (fieldError) {
@@ -992,6 +1064,10 @@ function AudioEditorForm() {
               title: fields.title.trim(),
               artist:
                 fields.artist.trim().length > 0 ? fields.artist.trim() : null,
+              genre:
+                fields.genre.trim().length > 0 ? fields.genre.trim() : null,
+              year: parseOptionalYear(fields.year),
+              role: fields.role.trim().length > 0 ? fields.role.trim() : null,
               description: fields.description.trim(),
               albumThumbnailUrl:
                 fields.albumThumbnailUrl.trim().length > 0
@@ -1602,6 +1678,50 @@ function AudioEditorForm() {
                         updateTrackEdit(track, { artist: e.target.value })
                       }
                       maxLength={MAX_ARTIST_LENGTH + 20}
+                    />
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem]">
+                    <div className="space-y-1">
+                      <label className="body-text-small font-medium text-foreground">
+                        Genre (optional)
+                      </label>
+                      <Input
+                        value={fields.genre}
+                        onChange={(e) =>
+                          updateTrackEdit(track, { genre: e.target.value })
+                        }
+                        maxLength={MAX_GENRE_LENGTH + 20}
+                        placeholder="Americana"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="body-text-small font-medium text-foreground">
+                        Year (optional)
+                      </label>
+                      <Input
+                        value={fields.year}
+                        onChange={(e) =>
+                          updateTrackEdit(track, { year: e.target.value })
+                        }
+                        type="number"
+                        inputMode="numeric"
+                        min={MIN_RECORDING_YEAR}
+                        max={MAX_RECORDING_YEAR}
+                        placeholder="2026"
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="body-text-small font-medium text-foreground">
+                      Role / credit (optional)
+                    </label>
+                    <Input
+                      value={fields.role}
+                      onChange={(e) =>
+                        updateTrackEdit(track, { role: e.target.value })
+                      }
+                      maxLength={MAX_ROLE_LENGTH + 20}
+                      placeholder="Recorded, mixed, and mastered at Lula Lake Sound"
                     />
                   </div>
                   <div className="space-y-1">

--- a/src/app/preview/recordings/page.tsx
+++ b/src/app/preview/recordings/page.tsx
@@ -8,13 +8,14 @@ import {
 } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { RecordingsClient } from "../../recordings/recordings-client";
-import { RECORDINGS } from "../../recordings/recordings-data";
+import { mapPublishedAudioToRecordings } from "../../recordings/recordings-data";
 import { PreviewBanner } from "@/components/preview-banner";
 
 function RecordingsPreviewContent() {
   const marketing = useQuery(api.cms.getPreviewMarketingFeatureFlags);
+  const audioPreview = useQuery(api.audioPreviewDraft.getPreviewAudioTracks);
 
-  if (marketing === undefined) {
+  if (marketing === undefined || audioPreview === undefined) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">Loading preview…</p>
@@ -22,7 +23,7 @@ function RecordingsPreviewContent() {
     );
   }
 
-  if (marketing === null) {
+  if (marketing === null || audioPreview === null) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
         <p className="text-ivory/60">
@@ -49,11 +50,15 @@ function RecordingsPreviewContent() {
     );
   }
 
+  const recordings = mapPublishedAudioToRecordings(audioPreview.tracks);
+  const bannerHasDraft =
+    hasDraftChanges || audioPreview.hasDraftChanges;
+
   return (
     <RecordingsClient
-      recordings={RECORDINGS}
+      recordings={recordings}
       marketing={flags}
-      banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
+      banner={<PreviewBanner hasDraftChanges={bannerHasDraft} />}
     />
   );
 }

--- a/src/app/recordings/page.tsx
+++ b/src/app/recordings/page.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { api } from "../../../convex/_generated/api";
-import { mapPublishedAudioToRecordings } from "./recordings-data";
 import { RecordingsPageClient } from "./recordings-page-client";
 
 /** One preload per request for metadata + page (same render pass). */
@@ -53,15 +52,9 @@ export default async function RecordingsPage() {
     notFound();
   }
 
-  const initialAudio = preloadedQueryResult(preloadedAudio);
-  const initialRecordings = mapPublishedAudioToRecordings(
-    initialAudio ?? [],
-  );
-
   return (
     <RecordingsPageClient
       preloadedAudio={preloadedAudio}
-      initialRecordings={initialRecordings}
       marketing={data}
     />
   );

--- a/src/app/recordings/page.tsx
+++ b/src/app/recordings/page.tsx
@@ -3,12 +3,16 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { api } from "../../../convex/_generated/api";
-import { RecordingsClient } from "./recordings-client";
-import { RECORDINGS } from "./recordings-data";
+import { mapPublishedAudioToRecordings } from "./recordings-data";
+import { RecordingsPageClient } from "./recordings-page-client";
 
 /** One preload per request for metadata + page (same render pass). */
 const preloadMarketingForRecordings = cache(() =>
   preloadQuery(api.public.getPublishedMarketingFeatureFlags),
+);
+
+const preloadAudioForRecordings = cache(() =>
+  preloadQuery(api.public.getPublishedAudioTracks),
 );
 
 /**
@@ -40,13 +44,25 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function RecordingsPage() {
-  const preloaded = await preloadMarketingForRecordings();
+  const [preloaded, preloadedAudio] = await Promise.all([
+    preloadMarketingForRecordings(),
+    preloadAudioForRecordings(),
+  ]);
   const data = preloadedQueryResult(preloaded);
   if (!data.recordingsPage) {
     notFound();
   }
 
+  const initialAudio = preloadedQueryResult(preloadedAudio);
+  const initialRecordings = mapPublishedAudioToRecordings(
+    initialAudio ?? [],
+  );
+
   return (
-    <RecordingsClient recordings={RECORDINGS} marketing={data} />
+    <RecordingsPageClient
+      preloadedAudio={preloadedAudio}
+      initialRecordings={initialRecordings}
+      marketing={data}
+    />
   );
 }

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -113,11 +113,11 @@ function Waveform({ seed, isActive, isPlaying }: WaveformProps) {
               isPlaying && isActive && "recordings-waveform-bar--playing",
             )}
             style={{
-              height: `${Math.min(h, 95)}%`,
+              height: `${Math.min(h, 95).toFixed(2)}%`,
               ...(isPlaying && isActive
                 ? {
-                    animationDuration: `${0.4 + (j % 5) * 0.07 + (seed % 3) * 0.05}s`,
-                    animationDelay: `${-((j * 11 + seed * 3) % 100) / 250}s`,
+                    animationDuration: `${(0.4 + (j % 5) * 0.07 + (seed % 3) * 0.05).toFixed(2)}s`,
+                    animationDelay: `${(-((j * 11 + seed * 3) % 100) / 250).toFixed(3)}s`,
                   }
                 : {}),
             }}
@@ -394,56 +394,61 @@ function TrackRow({
           </div>
         </div>
 
-        {/* Mobile row */}
-        <button
-          type="button"
-          onClick={() => onToggle(track.id)}
-          aria-label={rowLabel}
-          aria-pressed={isPlaying}
-          className="md:hidden flex w-full items-center gap-3 px-3 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold/60"
-        >
-          <span
-            className={cn(
-              "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border transition-all duration-300",
-              isPlaying
-                ? "bg-gold border-gold text-washed-black"
-                : "border-sand/30 text-sand/60",
-            )}
+        {/* Mobile row — play and title-block are siblings (rather than the
+            title-block being nested inside the play button) so streaming
+            anchors can sit inline with the metadata line without nesting
+            interactive elements inside a button. */}
+        <div className="md:hidden flex items-center gap-3 px-3 py-4">
+          <button
+            type="button"
+            onClick={() => onToggle(track.id)}
+            aria-label={rowLabel}
+            aria-pressed={isPlaying}
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold/60"
           >
-            <PlayPauseIcon isActive={isPlaying} className="h-3.5 w-3.5" />
-          </span>
-          <AlbumThumbnail track={track} />
-          <span className="min-w-0 flex-1">
             <span
               className={cn(
-                "headline-secondary block truncate text-base transition-colors",
-                isActive ? "text-gold" : "text-warm-white",
+                "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border transition-all duration-300",
+                isPlaying
+                  ? "bg-gold border-gold text-washed-black"
+                  : "border-sand/30 text-sand/60",
               )}
-              title={track.title}
             >
-              {track.title}
+              <PlayPauseIcon isActive={isPlaying} className="h-3.5 w-3.5" />
             </span>
-            <span
-              className="body-text-small mt-0.5 block truncate text-xs text-ivory/55"
-              title={`${track.artist} — ${recordingGenreLabel(track)} — ${recordingYearLabel(track)}`}
-            >
-              {track.artist} · {recordingGenreLabel(track)} ·{" "}
-              {recordingYearLabel(track)}
+          </button>
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => onToggle(track.id)}
+            aria-label={rowLabel}
+            aria-pressed={isPlaying}
+            className="flex min-w-0 flex-1 items-center gap-3 text-left focus-visible:outline-none"
+          >
+            <AlbumThumbnail track={track} />
+            <span className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  "headline-secondary block truncate text-base transition-colors",
+                  isActive ? "text-gold" : "text-warm-white",
+                )}
+                title={track.title}
+              >
+                {track.title}
+              </span>
+              <span
+                className="body-text-small mt-0.5 block truncate text-xs text-ivory/55"
+                title={`${track.artist} — ${recordingGenreLabel(track)} — ${recordingYearLabel(track)}`}
+              >
+                {track.artist} · {recordingGenreLabel(track)} ·{" "}
+                {recordingYearLabel(track)}
+              </span>
             </span>
-          </span>
-        </button>
-
-        {track.spotifyUrl || track.appleMusicUrl ? (
-          <div className="md:hidden flex items-center gap-3 border-t border-sand/10 px-3 py-3 pl-[7.25rem]">
-            <span className="label-text shrink-0 text-[9px] tracking-[0.2em] text-sand/45">
-              Stream
-            </span>
-            <StreamingLinks
-              track={track}
-              className="justify-start gap-3"
-            />
-          </div>
-        ) : null}
+          </button>
+          {track.spotifyUrl || track.appleMusicUrl ? (
+            <StreamingLinks track={track} className="shrink-0" />
+          ) : null}
+        </div>
 
         {/* In-playback duration UX — elapsed / total + progress bar, shown
             only for the active row so the required duration context is

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -4,7 +4,7 @@ import { Music } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 
 import { Header } from "@/components/header";
 import { SiteFooter } from "@/components/site-footer";
@@ -251,11 +251,37 @@ function TrackRow({
   const progress =
     duration > 0 ? Math.min(1, Math.max(0, currentTime / duration)) : 0;
 
-  function handleProgressClick(e: React.MouseEvent<HTMLDivElement>) {
-    if (!isActive) return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const fraction = (e.clientX - rect.left) / rect.width;
-    onSeekFraction(fraction);
+  const sliderRef = useRef<HTMLDivElement | null>(null);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+
+  function fractionFromClientX(clientX: number): number {
+    const el = sliderRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0) return 0;
+    const fraction = (clientX - rect.left) / rect.width;
+    return Math.max(0, Math.min(1, fraction));
+  }
+
+  function handleSliderPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    if (!isActive || duration <= 0) return;
+    if (e.button !== 0 && e.pointerType === "mouse") return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setIsScrubbing(true);
+    onSeekFraction(fractionFromClientX(e.clientX));
+  }
+
+  function handleSliderPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    if (!isScrubbing) return;
+    onSeekFraction(fractionFromClientX(e.clientX));
+  }
+
+  function handleSliderPointerEnd(e: React.PointerEvent<HTMLDivElement>) {
+    if (!isScrubbing) return;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    setIsScrubbing(false);
   }
 
   const rowLabel = isPlaying
@@ -429,6 +455,7 @@ function TrackRow({
                 {formatTime(currentTime)}
               </span>
               <div
+                ref={sliderRef}
                 role="slider"
                 aria-label={`Seek — ${track.title}`}
                 aria-valuemin={0}
@@ -436,7 +463,10 @@ function TrackRow({
                 aria-valuenow={Math.floor(currentTime)}
                 aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
                 tabIndex={0}
-                onClick={handleProgressClick}
+                onPointerDown={handleSliderPointerDown}
+                onPointerMove={handleSliderPointerMove}
+                onPointerUp={handleSliderPointerEnd}
+                onPointerCancel={handleSliderPointerEnd}
                 onKeyDown={(e) => {
                   if (duration <= 0) return;
                   if (e.key === "ArrowRight") {
@@ -449,17 +479,36 @@ function TrackRow({
                     onSeekFraction(
                       Math.max(0, (currentTime - 5) / duration),
                     );
+                  } else if (e.key === "Home") {
+                    e.preventDefault();
+                    onSeekFraction(0);
+                  } else if (e.key === "End") {
+                    e.preventDefault();
+                    onSeekFraction(1);
                   }
                 }}
-                className="group/bar relative h-1 flex-1 cursor-pointer rounded-full bg-sand/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold/60"
+                className={cn(
+                  "group/bar relative h-1 flex-1 rounded-full bg-sand/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold/60",
+                  isScrubbing ? "cursor-grabbing" : "cursor-pointer",
+                  "touch-none select-none",
+                )}
+                style={{ touchAction: "none" }}
               >
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-gold/85 transition-[width]"
+                  className={cn(
+                    "absolute inset-y-0 left-0 rounded-full bg-gold/85",
+                    isScrubbing ? "" : "transition-[width]",
+                  )}
                   style={{ width: `${progress * 100}%` }}
                 />
                 <div
                   aria-hidden
-                  className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 h-3 w-3 rounded-full bg-gold shadow-[0_0_0_3px_rgba(31,30,28,0.6)] opacity-0 transition-opacity group-hover/bar:opacity-100"
+                  className={cn(
+                    "absolute top-1/2 -translate-y-1/2 -translate-x-1/2 h-3 w-3 rounded-full bg-gold shadow-[0_0_0_3px_rgba(31,30,28,0.6)] transition-opacity",
+                    isScrubbing
+                      ? "opacity-100"
+                      : "opacity-0 group-hover/bar:opacity-100 group-focus-visible/bar:opacity-100",
+                  )}
                   style={{ left: `${progress * 100}%` }}
                 />
               </div>

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -18,6 +18,17 @@ import {
 
 import type { Recording } from "./recordings-data";
 
+function recordingGenreLabel(track: Recording): string {
+  const g = track.genre?.trim();
+  return g ? g : "—";
+}
+
+function recordingYearLabel(track: Recording): string {
+  return track.year !== undefined && track.year > 0
+    ? String(track.year)
+    : "—";
+}
+
 /**
  * Public Recordings page shell (INF-48).
  *
@@ -342,13 +353,13 @@ function TrackRow({
 
             <span
               className="label-text truncate pr-1 text-right text-[10px] tracking-[0.12em] text-ivory/45"
-              title={track.genre}
+              title={recordingGenreLabel(track)}
             >
-              {track.genre}
+              {recordingGenreLabel(track)}
             </span>
 
             <span className="label-text pl-1 text-right text-[10px] tabular-nums tracking-[0.12em] text-ivory/45">
-              {track.year}
+              {recordingYearLabel(track)}
             </span>
           </button>
 
@@ -388,9 +399,10 @@ function TrackRow({
             </span>
             <span
               className="body-text-small mt-0.5 block truncate text-xs text-ivory/55"
-              title={`${track.artist} — ${track.genre} — ${track.year}`}
+              title={`${track.artist} — ${recordingGenreLabel(track)} — ${recordingYearLabel(track)}`}
             >
-              {track.artist} · {track.genre} · {track.year}
+              {track.artist} · {recordingGenreLabel(track)} ·{" "}
+              {recordingYearLabel(track)}
             </span>
           </span>
         </button>
@@ -706,6 +718,8 @@ export function RecordingsClient({
       <audio
         ref={setAudioEl}
         preload="none"
+        playsInline
+        crossOrigin="anonymous"
         onLoadedMetadata={handleLoadedMetadata}
         onTimeUpdate={handleTimeUpdate}
         onPlay={handlePlay}

--- a/src/app/recordings/recordings-data.ts
+++ b/src/app/recordings/recordings-data.ts
@@ -1,21 +1,25 @@
 /**
- * Shape for the public Recordings page (INF-48).
+ * Shape for the public Recordings page (INF-48 / INF-97).
  *
  * Fields are a superset of the four primary columns (`title`, `artist`, `genre`,
  * `year`) plus metadata for Convex / CMS (`id`, `order`, `role`, `audioUrl`,
- * `coverImageUrl`, `spotifyUrl`, `appleMusicUrl`). Extended fields stay optional
- * so the table layout continues to work if entries omit them.
- *
- * `RECORDINGS` is empty until INF-49 (CMS) and INF-50 (media) supply content —
- * or wire this file to a Convex `preloadQuery` from `page.tsx` and pass the
- * list through.
+ * `coverImageUrl`, `spotifyUrl`, `appleMusicUrl`). `genre` and `year` are
+ * optional for CMS-sourced audio (portfolio tracks do not store them yet).
  */
 export interface Recording {
   readonly id: string;
   readonly title: string;
   readonly artist: string;
-  readonly genre: string;
-  readonly year: number;
+  /**
+   * When omitted or blank, the table shows an em dash. Reserved for a future
+   * CMS field.
+   */
+  readonly genre?: string;
+  /**
+   * When omitted or zero, the table shows an em dash. Reserved for a future
+   * CMS field.
+   */
+  readonly year?: number;
   readonly audioUrl: string;
   /** Album / single artwork — shown as a row thumbnail when set. */
   readonly coverImageUrl?: string;
@@ -27,4 +31,50 @@ export interface Recording {
   readonly appleMusicUrl?: string;
 }
 
+/** @deprecated Use {@link mapPublishedAudioToRecordings} with Convex; kept for tests. */
 export const RECORDINGS: readonly Recording[] = [];
+
+/**
+ * One row as returned from `getPublishedAudioTracks` / `getPreviewAudioTracks`
+ * (after `materializeAudioTracks`); `url` may be null for incomplete rows.
+ */
+export type CmsAudioTrackRow = {
+  readonly stableId: string;
+  readonly url: string | null;
+  readonly title: string;
+  readonly artist: string | null;
+  readonly sortOrder: number;
+  readonly albumThumbnailDisplayUrl: string | null;
+  readonly spotifyUrl: string | null;
+  readonly appleMusicUrl: string | null;
+};
+
+/**
+ * Map CMS audio portfolio rows to table rows for {@link RecordingsClient}.
+ * Drops tracks without a playback URL. Preserves `sortOrder` from Convex.
+ */
+export function mapPublishedAudioToRecordings(
+  rows: readonly CmsAudioTrackRow[],
+): Recording[] {
+  return rows
+    .filter(
+      (t): t is CmsAudioTrackRow & { url: string } =>
+        t.url !== null && t.url.length > 0,
+    )
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((t) => {
+      const artist = t.artist?.trim() ? t.artist : "—";
+      return {
+        id: t.stableId,
+        title: t.title,
+        artist,
+        audioUrl: t.url,
+        order: t.sortOrder,
+        ...(t.albumThumbnailDisplayUrl
+          ? { coverImageUrl: t.albumThumbnailDisplayUrl }
+          : {}),
+        ...(t.spotifyUrl ? { spotifyUrl: t.spotifyUrl } : {}),
+        ...(t.appleMusicUrl ? { appleMusicUrl: t.appleMusicUrl } : {}),
+      } satisfies Recording;
+    });
+}

--- a/src/app/recordings/recordings-data.ts
+++ b/src/app/recordings/recordings-data.ts
@@ -3,8 +3,8 @@
  *
  * Fields are a superset of the four primary columns (`title`, `artist`, `genre`,
  * `year`) plus metadata for Convex / CMS (`id`, `order`, `role`, `audioUrl`,
- * `coverImageUrl`, `spotifyUrl`, `appleMusicUrl`). `genre` and `year` are
- * optional for CMS-sourced audio (portfolio tracks do not store them yet).
+ * `coverImageUrl`, `spotifyUrl`, `appleMusicUrl`). `genre`, `year`, and `role`
+ * are optional for rows where that metadata is not authored.
  */
 export interface Recording {
   readonly id: string;
@@ -43,6 +43,9 @@ export type CmsAudioTrackRow = {
   readonly url: string | null;
   readonly title: string;
   readonly artist: string | null;
+  readonly genre: string | null;
+  readonly year: number | null;
+  readonly role: string | null;
   readonly sortOrder: number;
   readonly albumThumbnailDisplayUrl: string | null;
   readonly spotifyUrl: string | null;
@@ -68,6 +71,9 @@ export function mapPublishedAudioToRecordings(
         id: t.stableId,
         title: t.title,
         artist,
+        ...(t.genre?.trim() ? { genre: t.genre } : {}),
+        ...(t.year !== null && t.year > 0 ? { year: t.year } : {}),
+        ...(t.role?.trim() ? { role: t.role } : {}),
         audioUrl: t.url,
         order: t.sortOrder,
         ...(t.albumThumbnailDisplayUrl

--- a/src/app/recordings/recordings-page-client.tsx
+++ b/src/app/recordings/recordings-page-client.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePreloadedQuery, type Preloaded } from "convex/react";
+
+import { api } from "../../../convex/_generated/api";
+import { RecordingsClient } from "./recordings-client";
+import {
+  mapPublishedAudioToRecordings,
+  type Recording,
+} from "./recordings-data";
+import { type MarketingFeatureFlags } from "@/lib/site-settings";
+
+type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks>;
+
+/**
+ * Resolves preloaded published audio and passes table rows to {@link RecordingsClient}.
+ * Subscribes to Convex so storage URLs stay fresh.
+ */
+export function RecordingsPageClient({
+  preloadedAudio,
+  initialRecordings,
+  marketing,
+}: {
+  readonly preloadedAudio: PreloadedAudio;
+  /** From server `preloadedQueryResult` to avoid a hydration flash before live data. */
+  readonly initialRecordings: Recording[];
+  readonly marketing: MarketingFeatureFlags;
+}) {
+  const raw = usePreloadedQuery(preloadedAudio);
+  const recordings = useMemo((): Recording[] => {
+    if (raw === undefined) return initialRecordings;
+    return mapPublishedAudioToRecordings(raw);
+  }, [raw, initialRecordings]);
+
+  return <RecordingsClient recordings={recordings} marketing={marketing} />;
+}

--- a/src/app/recordings/recordings-page-client.tsx
+++ b/src/app/recordings/recordings-page-client.tsx
@@ -19,19 +19,16 @@ type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks>;
  */
 export function RecordingsPageClient({
   preloadedAudio,
-  initialRecordings,
   marketing,
 }: {
   readonly preloadedAudio: PreloadedAudio;
-  /** From server `preloadedQueryResult` to avoid a hydration flash before live data. */
-  readonly initialRecordings: Recording[];
   readonly marketing: MarketingFeatureFlags;
 }) {
   const raw = usePreloadedQuery(preloadedAudio);
-  const recordings = useMemo((): Recording[] => {
-    if (raw === undefined) return initialRecordings;
-    return mapPublishedAudioToRecordings(raw);
-  }, [raw, initialRecordings]);
+  const recordings = useMemo(
+    (): Recording[] => mapPublishedAudioToRecordings(raw),
+    [raw],
+  );
 
   return <RecordingsClient recordings={recordings} marketing={marketing} />;
 }

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -71,6 +71,7 @@ function TrackAudioPlayer({
     }
 
     if (audio.paused) {
+      claimExclusive(audio);
       void audio.play().catch(() => {
         /* Autoplay policy / decode errors — leave paused */
       });
@@ -90,7 +91,6 @@ function TrackAudioPlayer({
         aria-label={trackTitle}
         onPlay={() => {
           setIsPlaying(true);
-          claimExclusive(audioRef.current);
         }}
         onPause={() => setIsPlaying(false)}
         onEnded={() => setIsPlaying(false)}

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -55,7 +55,7 @@ function TrackAudioPlayer({
   claimExclusive: (el: HTMLAudioElement | null) => void;
 }) {
   const audioRef = useRef<HTMLAudioElement>(null);
-  const [srcHydrated, setSrcHydrated] = useState(false);
+  const lastAssignedSrcRef = useRef<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
 
   const labelPlaying = `Pause audio sample: ${trackTitle}`;
@@ -65,9 +65,9 @@ function TrackAudioPlayer({
     const audio = audioRef.current;
     if (!audio) return;
 
-    if (!srcHydrated) {
+    if (lastAssignedSrcRef.current !== src) {
       audio.src = src;
-      setSrcHydrated(true);
+      lastAssignedSrcRef.current = src;
     }
 
     if (audio.paused) {

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import { Pause, Play } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -27,12 +30,157 @@ function formatDuration(sec: number | null): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
+function useExclusiveAudioPlayback() {
+  const activeRef = useRef<HTMLAudioElement | null>(null);
+
+  const claimExclusive = useCallback((el: HTMLAudioElement | null) => {
+    if (activeRef.current && activeRef.current !== el) {
+      activeRef.current.pause();
+    }
+    activeRef.current = el;
+  }, []);
+
+  return claimExclusive;
+}
+
+function TrackAudioPlayer({
+  stableId,
+  trackTitle,
+  src,
+  claimExclusive,
+}: {
+  stableId: string;
+  trackTitle: string;
+  src: string;
+  claimExclusive: (el: HTMLAudioElement | null) => void;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [srcHydrated, setSrcHydrated] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const labelPlaying = `Pause audio sample: ${trackTitle}`;
+  const labelPaused = `Play audio sample: ${trackTitle}`;
+
+  const togglePlayback = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (!srcHydrated) {
+      audio.src = src;
+      setSrcHydrated(true);
+    }
+
+    if (audio.paused) {
+      void audio.play().catch(() => {
+        /* Autoplay policy / decode errors — leave paused */
+      });
+    } else {
+      audio.pause();
+    }
+  };
+
+  return (
+    <div className="rounded-sm border border-sage/30 bg-sage/10 p-3">
+      <audio
+        ref={audioRef}
+        id={`audio-sample-${stableId}`}
+        preload="none"
+        playsInline
+        crossOrigin="anonymous"
+        aria-label={trackTitle}
+        onPlay={() => {
+          setIsPlaying(true);
+          claimExclusive(audioRef.current);
+        }}
+        onPause={() => setIsPlaying(false)}
+        onEnded={() => setIsPlaying(false)}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-10 w-full gap-2 border-sage/40 text-ivory hover:bg-sage/20"
+        onClick={togglePlayback}
+        aria-controls={`audio-sample-${stableId}`}
+        aria-pressed={isPlaying}
+        aria-label={isPlaying ? labelPlaying : labelPaused}
+      >
+        {isPlaying ? (
+          <Pause className="size-4 shrink-0" aria-hidden />
+        ) : (
+          <Play className="size-4 shrink-0" aria-hidden />
+        )}
+        <span className="font-titillium text-xs font-normal normal-case tracking-normal">
+          {isPlaying ? "Pause sample" : "Play sample"}
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+function AudioPortfolioEmpty() {
+  return (
+    <section
+      id="audio-portfolio"
+      className="relative bg-forest px-4 py-20"
+      aria-labelledby="audio-portfolio-heading"
+    >
+      <div className="absolute inset-0 bg-texture-stone opacity-20" />
+
+      <div className="relative z-10 mx-auto max-w-6xl">
+        <div className="mb-16 text-center">
+          <h2
+            id="audio-portfolio-heading"
+            className="mb-6 font-acumin text-3xl font-bold text-sand md:text-4xl"
+          >
+            STUDIO PORTFOLIO
+          </h2>
+          <p className="mx-auto max-w-3xl font-titillium text-lg leading-relaxed text-ivory/80">
+            Listen to the quality and character that artists achieve at Lula Lake
+            Sound. From intimate acoustic sessions to full band recordings, hear how
+            our space and expertise bring out the best in every project.
+          </p>
+        </div>
+
+        <div
+          className="mb-12 flex min-h-[12rem] flex-col items-center justify-center rounded-sm border border-sage/25 bg-washed-black/40 px-6 py-16 text-center"
+          role="status"
+        >
+          <p className="max-w-md font-titillium text-base text-ivory/70">
+            New studio samples will appear here after they are published. Check back
+            soon, or get in touch to hear more in person.
+          </p>
+        </div>
+
+        <div className="text-center">
+          <p className="mb-6 font-titillium text-ivory/70">
+            Ready to create something extraordinary?
+          </p>
+          <Button
+            variant="outline"
+            size="lg"
+            className="h-10 px-6"
+            onClick={() =>
+              document
+                .getElementById("artist-inquiries")
+                ?.scrollIntoView({ behavior: "smooth" })
+            }
+          >
+            START YOUR PROJECT
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function AudioPortfolio({
   tracks,
 }: {
   tracks: PublishedAudioTrack[] | null | undefined;
 }) {
   const isLoading = tracks === undefined;
+  const claimExclusive = useExclusiveAudioPlayback();
 
   if (isLoading) {
     return (
@@ -60,16 +208,23 @@ export function AudioPortfolio({
   const list = tracks ?? [];
 
   if (list.length === 0) {
-    return null;
+    return <AudioPortfolioEmpty />;
   }
 
   return (
-    <section id="audio-portfolio" className="relative bg-forest px-4 py-20">
+    <section
+      id="audio-portfolio"
+      className="relative bg-forest px-4 py-20"
+      aria-labelledby="audio-portfolio-heading-loaded"
+    >
       <div className="absolute inset-0 bg-texture-stone opacity-20" />
 
       <div className="relative z-10 mx-auto max-w-6xl">
         <div className="mb-16 text-center">
-          <h2 className="mb-6 font-acumin text-3xl font-bold text-sand md:text-4xl">
+          <h2
+            id="audio-portfolio-heading-loaded"
+            className="mb-6 font-acumin text-3xl font-bold text-sand md:text-4xl"
+          >
             STUDIO PORTFOLIO
           </h2>
           <p className="mx-auto max-w-3xl font-titillium text-lg leading-relaxed text-ivory/80">
@@ -81,9 +236,10 @@ export function AudioPortfolio({
 
         <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {list.map((track) => (
-            <div
+            <article
               key={track.stableId}
               className="rounded-sm border border-sage/30 bg-washed-black/60 p-6 transition-colors hover:border-sand/50"
+              aria-labelledby={`track-title-${track.stableId}`}
             >
               <div className="relative mb-4 aspect-square overflow-hidden rounded-sm bg-sage/20">
                 {track.albumThumbnailDisplayUrl ? (
@@ -106,7 +262,10 @@ export function AudioPortfolio({
               </div>
 
               <div className="mb-4">
-                <h3 className="mb-1 font-acumin text-lg font-bold text-sand">
+                <h3
+                  id={`track-title-${track.stableId}`}
+                  className="mb-1 font-acumin text-lg font-bold text-sand"
+                >
                   {track.title}
                 </h3>
                 {track.artist ? (
@@ -154,16 +313,13 @@ export function AudioPortfolio({
                 </div>
               ) : null}
 
-              <div className="rounded-sm border border-sage/30 bg-sage/10 p-3">
-                <audio
-                  controls
-                  className="h-9 w-full"
-                  src={track.url}
-                  crossOrigin="anonymous"
-                  preload="metadata"
-                />
-              </div>
-            </div>
+              <TrackAudioPlayer
+                stableId={track.stableId}
+                trackTitle={track.title}
+                src={track.url}
+                claimExclusive={claimExclusive}
+              />
+            </article>
           ))}
         </div>
 

--- a/src/components/audio-portfolio.tsx
+++ b/src/components/audio-portfolio.tsx
@@ -94,6 +94,7 @@ function TrackAudioPlayer({
         }}
         onPause={() => setIsPlaying(false)}
         onEnded={() => setIsPlaying(false)}
+        onError={() => setIsPlaying(false)}
       />
       <Button
         type="button"

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -43,7 +43,7 @@ interface HomepageShellProps {
   readonly gear: GearPayload | null | undefined;
   /** Published (or preview) gallery payload. */
   readonly photos: GalleryPhoto[] | null | undefined;
-  /** Published (or preview) audio portfolio; empty array hides the section. */
+  /** Published (or preview) audio portfolio; empty array shows an empty state. */
   readonly audioTracks: PublishedAudioTrack[] | null | undefined;
   readonly banner?: React.ReactNode;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the marketing **Studio portfolio** section wiring for INF-97 by tightening playback, prefetch behavior, empty state, and accessibility. Data already comes from Convex (`getPublishedAudioTracks` on the homepage and `getPreviewAudioTracks` for signed-in owner preview).

## Changes

- **Streaming / prefetch:** Removed native `<audio controls>` with `src` set up front. Each track uses `preload="none"` and assigns the Convex signed `url` only when the user clicks **Play sample**, so the browser does not prefetch every file.
- **Mobile Safari:** `playsInline` on the audio element; `crossOrigin="anonymous"` retained for signed Convex file URLs.
- **UX:** Only one sample plays at a time (starting another pauses the previous).
- **Empty state:** When there are zero published tracks, the section still shows the headline and a short message plus the existing CTA, instead of returning `null`.
- **A11y:** Visible "Play sample" / "Pause sample" text with icons; `aria-controls`, `aria-pressed`, and descriptive `aria-label` on the control; section `aria-labelledby`; cards use `<article>` with `aria-labelledby` tied to track titles.

## Testing

- `bun run lint`
- `bun run build`
- `bun test convex/audioTracks.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-97](https://linear.app/only-football-fans/issue/INF-97/lls-public-audio-portfolio-from-cms-published-preview)

<div><a href="https://cursor.com/agents/bc-7e74d206-c39e-44ad-98df-d1e93ab08aac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e74d206-c39e-44ad-98df-d1e93ab08aac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

