### PR TITLE
INF-121: FAQ CMS (Convex draft/publish)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as cmsPublishHelpers from "../cmsPublishHelpers.js";
 import type * as cmsShared from "../cmsShared.js";
 import type * as crons from "../crons.js";
 import type * as errors from "../errors.js";
+import type * as faqPreviewDraft from "../faqPreviewDraft.js";
 import type * as galleryPhotos from "../galleryPhotos.js";
 import type * as gearEquipmentSeed from "../gearEquipmentSeed.js";
 import type * as gearLegacySeed from "../gearLegacySeed.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   cmsShared: typeof cmsShared;
   crons: typeof crons;
   errors: typeof errors;
+  faqPreviewDraft: typeof faqPreviewDraft;
   galleryPhotos: typeof galleryPhotos;
   gearEquipmentSeed: typeof gearEquipmentSeed;
   gearLegacySeed: typeof gearLegacySeed;

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -3,12 +3,14 @@ import { v } from "convex/values";
 import {
   aboutContentValidator,
   cmsSectionValidator,
+  faqContentValidator,
   pricingContentValidator,
   settingsContentValidator,
 } from "./schema.shared";
 import {
   defaultSnapshotForSection,
   type AboutSnapshot,
+  type FaqSnapshot,
   type PricingSnapshot,
   type SettingsSnapshot,
 } from "./cmsShared";
@@ -49,6 +51,12 @@ import {
   loadSettingsContent,
   replaceSettingsDraft,
 } from "./settingsTree";
+import {
+  copyFaqScope,
+  loadFaqTree,
+  materializeFaqCategories,
+  replaceFaqDraftFromCategories,
+} from "./faqTree";
 import { cmsValidationError } from "./errors";
 
 /**
@@ -107,6 +115,7 @@ export const saveDraft = mutation({
       settingsContentValidator,
       pricingContentValidator,
       aboutContentValidator,
+      faqContentValidator,
     ),
   },
   handler: async (ctx, args) => {
@@ -123,6 +132,9 @@ export const saveDraft = mutation({
         ?.priceTabEnabled !== undefined;
     const isAboutPayload =
       "heroTitle" in args.content && "body" in args.content;
+    const isFaqPayload =
+      "categories" in args.content &&
+      Array.isArray((args.content as { categories?: unknown }).categories);
 
     if (args.section === "settings") {
       if (!isSettingsPayload) {
@@ -151,6 +163,10 @@ export const saveDraft = mutation({
           "content",
         );
       }
+    } else if (args.section === "faq") {
+      if (!isFaqPayload) {
+        cmsValidationError("FAQ content must include a categories array.", "content");
+      }
     } else {
       cmsValidationError(
         "Recordings has no content; only the visibility flag is editable.",
@@ -168,6 +184,11 @@ export const saveDraft = mutation({
       const beforeUnion = await unionAboutTeamStorage(ctx);
       await replaceAboutDraftFromSnapshot(ctx, args.content as AboutSnapshot);
       await pruneAboutTeamBlobsAfterSaveDraftScoped(ctx, beforeUnion);
+    } else if (args.section === "faq") {
+      await replaceFaqDraftFromCategories(
+        ctx,
+        (args.content as FaqSnapshot).categories,
+      );
     }
 
     await recomputeSectionHasDraftChanges(ctx, args.section, updatedBy);
@@ -202,7 +223,13 @@ export const listPendingDrafts = query({
     if (identity === null) {
       return {
         sections: [] as Array<
-          "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+          | "settings"
+          | "pricing"
+          | "about"
+          | "recordings"
+          | "faq"
+          | "gear"
+          | "photos"
         >,
       };
     }
@@ -222,7 +249,13 @@ export const listPendingDrafts = query({
     ]);
 
     const sections: Array<
-      "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+      | "settings"
+      | "pricing"
+      | "about"
+      | "recordings"
+      | "faq"
+      | "gear"
+      | "photos"
     > = [];
     for (const row of cmsRows) {
       if (row.hasDraftChanges) sections.push(row.section);
@@ -567,6 +600,8 @@ export const discardDraft = mutation({
         await copyPricingScope(ctx, "published", "draft");
       } else if (args.section === "settings") {
         await copySettingsScope(ctx, "published", "draft");
+      } else if (args.section === "faq") {
+        await copyFaqScope(ctx, "published", "draft");
       }
     }
 
@@ -664,6 +699,16 @@ async function readSnapshotForAdmin(
           }
         : {}),
     } satisfies AboutSnapshot;
+  }
+
+  if (section === "faq") {
+    const tree = await loadFaqTree(ctx, scope);
+    if (tree.categories.length === 0) {
+      return defaultSnapshotForSection("faq");
+    }
+    return {
+      categories: materializeFaqCategories(tree),
+    } satisfies FaqSnapshot;
   }
 
   // recordings — flag-only, no content. Return an empty about-shaped default

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import {
   aboutContentValidator,
   cmsSectionValidator,
-  faqContentValidator,
+  cmsSnapshotValidator,
   pricingContentValidator,
   settingsContentValidator,
 } from "./schema.shared";
@@ -111,12 +111,7 @@ export const getSection = query({
 export const saveDraft = mutation({
   args: {
     section: cmsSectionValidator,
-    content: v.union(
-      settingsContentValidator,
-      pricingContentValidator,
-      aboutContentValidator,
-      faqContentValidator,
-    ),
+    content: cmsSnapshotValidator,
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
@@ -704,6 +699,9 @@ async function readSnapshotForAdmin(
   if (section === "faq") {
     const tree = await loadFaqTree(ctx, scope);
     if (tree.categories.length === 0) {
+      if (scope === "draft") {
+        return { categories: [] } satisfies FaqSnapshot;
+      }
       return defaultSnapshotForSection("faq");
     }
     return {

--- a/convex/cmsMeta.test.ts
+++ b/convex/cmsMeta.test.ts
@@ -32,6 +32,10 @@ describe("DEFAULT_IS_ENABLED", () => {
     expect(DEFAULT_IS_ENABLED.about).toBe(false);
     expect(DEFAULT_IS_ENABLED.recordings).toBe(false);
   });
+
+  test("faq defaults on (homepage block always available)", () => {
+    expect(DEFAULT_IS_ENABLED.faq).toBe(true);
+  });
 });
 
 describe("effectiveIsEnabled", () => {

--- a/convex/cmsMeta.ts
+++ b/convex/cmsMeta.ts
@@ -107,7 +107,11 @@ export function publishedIsEnabled(
  * means the owner removed every package in draft and must be able to publish
  * that deletion.
  *
- * **FAQ** follows the same rule as pricing for an empty draft scope.
+ * **FAQ** matches **about**: an empty draft scope means no in-progress FAQ
+ * edit. Publishing an empty FAQ tree is invalid (at least one category is
+ * required), so unlike pricing we must not treat "empty draft + published
+ * content" as a content diff — that would block flag-only visibility publishes
+ * and would incorrectly run validation against an empty draft.
  */
 export async function sectionHasContentDraftDiff(
   ctx: QueryCtx | MutationCtx,
@@ -117,10 +121,8 @@ export async function sectionHasContentDraftDiff(
 
   if (section === "faq") {
     const draft = await loadFaqTree(ctx, "draft");
+    if (draft.categories.length === 0) return false;
     const published = await loadFaqTree(ctx, "published");
-    if (draft.categories.length === 0) {
-      return published.categories.length > 0;
-    }
     return !faqDraftMatchesPublished(draft, published);
   }
 

--- a/convex/cmsMeta.ts
+++ b/convex/cmsMeta.ts
@@ -14,6 +14,7 @@ import {
   loadSettingsContent,
   settingsDraftMatchesPublished,
 } from "./settingsTree";
+import { loadFaqTree, faqDraftMatchesPublished } from "./faqTree";
 
 /**
  * Default `isEnabled` value for a brand-new deployment / row. Matches the
@@ -25,6 +26,7 @@ export const DEFAULT_IS_ENABLED: Record<CmsSection, boolean> = {
   pricing: true,
   about: false,
   recordings: false,
+  faq: true,
 };
 
 export async function getSectionMetaRow(
@@ -104,12 +106,23 @@ export function publishedIsEnabled(
  * **Pricing** is different: an empty draft with a non-empty published catalogue
  * means the owner removed every package in draft and must be able to publish
  * that deletion.
+ *
+ * **FAQ** follows the same rule as pricing for an empty draft scope.
  */
 export async function sectionHasContentDraftDiff(
   ctx: QueryCtx | MutationCtx,
   section: CmsSection,
 ): Promise<boolean> {
   if (section === "recordings") return false;
+
+  if (section === "faq") {
+    const draft = await loadFaqTree(ctx, "draft");
+    const published = await loadFaqTree(ctx, "published");
+    if (draft.categories.length === 0) {
+      return published.categories.length > 0;
+    }
+    return !faqDraftMatchesPublished(draft, published);
+  }
 
   if (section === "about") {
     const draft = await loadAboutTree(ctx, "draft");

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -305,7 +305,9 @@ async function collectFaqIssues(
   const tree =
     draft.categories.length > 0
       ? draft
-      : await loadFaqTree(ctx, "published");
+      : (await sectionHasContentDraftDiff(ctx, "faq"))
+        ? draft
+        : await loadFaqTree(ctx, "published");
   const issues: PublishIssue[] = [];
 
   if (tree.categories.length === 0) {

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -18,7 +18,7 @@ import {
   loadPricingPackages,
 } from "./pricingTree";
 import { copySettingsScope, loadSettingsContent } from "./settingsTree";
-import { copyFaqScope, loadFaqTree } from "./faqTree";
+import { copyFaqScope, loadFaqTree, type FaqTree } from "./faqTree";
 import {
   DEFAULT_IS_ENABLED,
   effectiveIsEnabled,
@@ -302,12 +302,13 @@ async function collectFaqIssues(
   ctx: QueryCtx | MutationCtx,
 ): Promise<PublishIssue[]> {
   const draft = await loadFaqTree(ctx, "draft");
-  const tree =
-    draft.categories.length > 0
-      ? draft
-      : (await sectionHasContentDraftDiff(ctx, "faq"))
-        ? draft
-        : await loadFaqTree(ctx, "published");
+  let tree: FaqTree;
+  if (draft.categories.length > 0) {
+    tree = draft;
+  } else {
+    const published = await loadFaqTree(ctx, "published");
+    tree = published.categories.length > 0 ? draft : published;
+  }
   const issues: PublishIssue[] = [];
 
   if (tree.categories.length === 0) {

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -307,7 +307,7 @@ async function collectFaqIssues(
     tree = draft;
   } else {
     const published = await loadFaqTree(ctx, "published");
-    tree = published.categories.length > 0 ? draft : published;
+    tree = published;
   }
   const issues: PublishIssue[] = [];
 

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -18,6 +18,7 @@ import {
   loadPricingPackages,
 } from "./pricingTree";
 import { copySettingsScope, loadSettingsContent } from "./settingsTree";
+import { copyFaqScope, loadFaqTree } from "./faqTree";
 import {
   DEFAULT_IS_ENABLED,
   effectiveIsEnabled,
@@ -291,7 +292,119 @@ export async function collectPublishIssues(
       : await loadAboutTree(ctx, "published");
     return collectAboutIssuesFromTree(ctx, tree);
   }
+  if (section === "faq") {
+    return collectFaqIssues(ctx);
+  }
   return [];
+}
+
+async function collectFaqIssues(
+  ctx: QueryCtx | MutationCtx,
+): Promise<PublishIssue[]> {
+  const draft = await loadFaqTree(ctx, "draft");
+  const tree =
+    draft.categories.length > 0
+      ? draft
+      : await loadFaqTree(ctx, "published");
+  const issues: PublishIssue[] = [];
+
+  if (tree.categories.length === 0) {
+    issues.push({
+      path: "categories",
+      message: "At least one FAQ category is required to publish.",
+    });
+    return issues;
+  }
+
+  const seenCategoryIds = new Set<string>();
+  for (let i = 0; i < tree.categories.length; i++) {
+    const c = tree.categories[i];
+    const base = `categories[${i}]`;
+    if (c.stableId.trim().length === 0) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: "Each category requires a stable id.",
+      });
+    } else if (seenCategoryIds.has(c.stableId)) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: `Duplicate category id: ${c.stableId}`,
+      });
+    } else {
+      seenCategoryIds.add(c.stableId);
+    }
+    if (c.title.trim().length === 0) {
+      issues.push({
+        path: `${base}.title`,
+        message: "Category title cannot be empty.",
+      });
+    }
+  }
+
+  const qsInKnownCategories = tree.questions.filter((q) =>
+    seenCategoryIds.has(q.categoryStableId),
+  );
+  if (qsInKnownCategories.length === 0) {
+    issues.push({
+      path: "questions",
+      message: "Each category needs at least one question.",
+    });
+  }
+
+  for (const q of tree.questions) {
+    if (!seenCategoryIds.has(q.categoryStableId)) {
+      issues.push({
+        path: `question.${q.stableId}.categoryStableId`,
+        message: `Unknown category id: ${q.categoryStableId}`,
+      });
+    }
+  }
+
+  const seenQuestionIds = new Set<string>();
+  for (const q of tree.questions) {
+    if (!seenCategoryIds.has(q.categoryStableId)) {
+      continue;
+    }
+    if (q.stableId.trim().length === 0) {
+      issues.push({
+        path: `question.${q.categoryStableId}.stableId`,
+        message: "Each question requires a stable id.",
+      });
+    } else if (seenQuestionIds.has(q.stableId)) {
+      issues.push({
+        path: `question.${q.stableId}`,
+        message: `Duplicate question id: ${q.stableId}`,
+      });
+    } else {
+      seenQuestionIds.add(q.stableId);
+    }
+    if (q.question.trim().length === 0) {
+      issues.push({
+        path: `question.${q.stableId}.question`,
+        message: "Question text cannot be empty.",
+      });
+    }
+    if (q.answer.trim().length === 0) {
+      issues.push({
+        path: `question.${q.stableId}.answer`,
+        message: "Answer text cannot be empty.",
+      });
+    }
+  }
+
+  for (const cat of tree.categories) {
+    const count = tree.questions.filter(
+      (q) => q.categoryStableId === cat.stableId,
+    ).length;
+    if (count === 0) {
+      issues.push({
+        path: `categories.${cat.stableId}.questions`,
+        message: `Category "${cat.title}" needs at least one question.`,
+      });
+    }
+  }
+
+  return issues;
 }
 
 export type PublishSectionResult =
@@ -368,6 +481,8 @@ export async function publishSectionCore(
       await copyPricingScope(ctx, "draft", "published");
     } else if (section === "settings") {
       await copySettingsScope(ctx, "draft", "published");
+    } else if (section === "faq") {
+      await copyFaqScope(ctx, "draft", "published");
     }
   }
 

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -305,6 +305,10 @@ async function collectFaqIssues(
   let tree: FaqTree;
   if (draft.categories.length > 0) {
     tree = draft;
+  } else if (await sectionHasContentDraftDiff(ctx, "faq")) {
+    // Empty draft that will replace published (same idea as pricing's
+    // `sectionHasContentDraftDiff` branch) — validate what publish will copy.
+    tree = draft;
   } else {
     const published = await loadFaqTree(ctx, "published");
     tree = published;

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -302,17 +302,10 @@ async function collectFaqIssues(
   ctx: QueryCtx | MutationCtx,
 ): Promise<PublishIssue[]> {
   const draft = await loadFaqTree(ctx, "draft");
-  let tree: FaqTree;
-  if (draft.categories.length > 0) {
-    tree = draft;
-  } else if (await sectionHasContentDraftDiff(ctx, "faq")) {
-    // Empty draft that will replace published (same idea as pricing's
-    // `sectionHasContentDraftDiff` branch) — validate what publish will copy.
-    tree = draft;
-  } else {
-    const published = await loadFaqTree(ctx, "published");
-    tree = published;
-  }
+  const tree: FaqTree =
+    draft.categories.length > 0
+      ? draft
+      : await loadFaqTree(ctx, "published");
   const issues: PublishIssue[] = [];
 
   if (tree.categories.length === 0) {

--- a/convex/cmsShared.test.ts
+++ b/convex/cmsShared.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ABOUT_DEFAULTS,
   DEFAULT_PRICING_PACKAGES,
+  FAQ_DEFAULTS,
   MARKETING_FEATURE_FLAGS_DEFAULTS,
   PRICING_DEFAULTS,
   SETTINGS_DEFAULTS,
@@ -72,6 +73,22 @@ describe("MARKETING_FEATURE_FLAGS_DEFAULTS", () => {
   });
 });
 
+describe("FAQ_DEFAULTS", () => {
+  test("has categories with questions", () => {
+    expect(FAQ_DEFAULTS.categories.length).toBeGreaterThan(0);
+    for (const c of FAQ_DEFAULTS.categories) {
+      expect(c.stableId.length).toBeGreaterThan(0);
+      expect(c.title.length).toBeGreaterThan(0);
+      expect(c.questions.length).toBeGreaterThan(0);
+      for (const q of c.questions) {
+        expect(q.stableId.length).toBeGreaterThan(0);
+        expect(q.question.length).toBeGreaterThan(0);
+        expect(q.answer.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
 describe("ABOUT_DEFAULTS", () => {
   test("has a hero title and at least one body block", () => {
     expect(ABOUT_DEFAULTS.heroTitle.length).toBeGreaterThan(0);
@@ -91,6 +108,7 @@ describe("defaultSnapshotForSection", () => {
     expect(defaultSnapshotForSection("settings")).toEqual(SETTINGS_DEFAULTS);
     expect(defaultSnapshotForSection("pricing")).toEqual(PRICING_DEFAULTS);
     expect(defaultSnapshotForSection("about")).toEqual(ABOUT_DEFAULTS);
+    expect(defaultSnapshotForSection("faq")).toEqual(FAQ_DEFAULTS);
   });
 
   test("recordings returns an about-shaped placeholder (no content table)", () => {

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -4,12 +4,14 @@ import type {
   aboutContentValidator,
   aboutTeamMemberValidator,
   cmsSectionValidator,
+  faqContentValidator,
   marketingFeatureFlagsSnapshotValidator,
   pricingBillingCadenceValidator,
   pricingContentValidator,
   pricingPackageValidator,
   settingsContentValidator,
 } from "./schema.shared";
+import { DEFAULT_FAQ_CATEGORIES } from "./faqSeedData";
 
 export type CmsSection = Infer<typeof cmsSectionValidator>;
 
@@ -22,7 +24,10 @@ export type CmsSection = Infer<typeof cmsSectionValidator>;
 export type CmsSnapshot =
   | Infer<typeof settingsContentValidator>
   | Infer<typeof pricingContentValidator>
-  | Infer<typeof aboutContentValidator>;
+  | Infer<typeof aboutContentValidator>
+  | Infer<typeof faqContentValidator>;
+
+export type FaqSnapshot = Infer<typeof faqContentValidator>;
 
 export type SettingsSnapshot = Infer<typeof settingsContentValidator>;
 export type PricingSnapshot = Infer<typeof pricingContentValidator>;
@@ -150,6 +155,22 @@ export const MARKETING_FEATURE_FLAGS_DEFAULTS: MarketingFeatureFlagsSnapshot = {
  * the published scope of `aboutContent` + `aboutHighlights` + `aboutTeamMembers`
  * so the public route renders before the owner has published.
  */
+/**
+ * Default FAQ shipped with seed / empty editor baseline (matches historical
+ * homepage copy).
+ */
+export const FAQ_DEFAULTS: FaqSnapshot = {
+  categories: DEFAULT_FAQ_CATEGORIES.map((c) => ({
+    stableId: c.stableId,
+    title: c.title,
+    questions: c.questions.map((q) => ({
+      stableId: q.stableId,
+      question: q.question,
+      answer: q.answer,
+    })),
+  })),
+};
+
 export const ABOUT_DEFAULTS: AboutSnapshot = {
   heroTitle: "About Lula Lake Sound",
   heroSubtitle: "A creative space for music production and recording.",
@@ -182,6 +203,8 @@ export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
       // `recordings` has no content table; return an empty about-shaped
       // placeholder so the union typechecks. Nothing reads this branch.
       return { ...ABOUT_DEFAULTS };
+    case "faq":
+      return FAQ_DEFAULTS;
   }
 }
 

--- a/convex/faqPreviewDraft.ts
+++ b/convex/faqPreviewDraft.ts
@@ -1,0 +1,39 @@
+import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import { FAQ_DEFAULTS } from "./cmsShared";
+import { getSectionMetaRow } from "./cmsMeta";
+import { loadFaqTree, materializeFaqCategories } from "./faqTree";
+
+/**
+ * Owner-only homepage FAQ preview: draft scope when it has content, else
+ * published (same effective tree as the admin editor).
+ */
+export const getPreviewFaq = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const draft = await loadFaqTree(ctx, "draft");
+    const published = await loadFaqTree(ctx, "published");
+    const tree =
+      draft.categories.length > 0 ? draft : published;
+    const categories =
+      tree.categories.length > 0
+        ? materializeFaqCategories(tree)
+        : FAQ_DEFAULTS.categories;
+
+    const row = await getSectionMetaRow(ctx, "faq");
+
+    return {
+      categories,
+      hasDraftChanges: row?.hasDraftChanges ?? false,
+    };
+  },
+});

--- a/convex/faqPreviewDraft.ts
+++ b/convex/faqPreviewDraft.ts
@@ -5,8 +5,9 @@ import { getSectionMetaRow } from "./cmsMeta";
 import { loadFaqTree, materializeFaqCategories } from "./faqTree";
 
 /**
- * Owner-only homepage FAQ preview: draft scope when it has content, else
- * published (same effective tree as the admin editor).
+ * Owner-only homepage FAQ preview: draft scope when it has categories, when
+ * `hasDraftChanges` marks a pending delete-all over published content (mirrors
+ * `pricingPreviewDraft`), else published.
  */
 export const getPreviewFaq = query({
   args: {},
@@ -20,16 +21,20 @@ export const getPreviewFaq = query({
       return null;
     }
 
-    const draft = await loadFaqTree(ctx, "draft");
-    const published = await loadFaqTree(ctx, "published");
+    const [row, draft, published] = await Promise.all([
+      getSectionMetaRow(ctx, "faq"),
+      loadFaqTree(ctx, "draft"),
+      loadFaqTree(ctx, "published"),
+    ]);
     const tree =
-      draft.categories.length > 0 ? draft : published;
+      draft.categories.length > 0 ||
+      ((row?.hasDraftChanges ?? false) && published.categories.length > 0)
+        ? draft
+        : published;
     const categories =
       tree.categories.length > 0
         ? materializeFaqCategories(tree)
         : FAQ_DEFAULTS.categories;
-
-    const row = await getSectionMetaRow(ctx, "faq");
 
     return {
       categories,

--- a/convex/faqSeedData.ts
+++ b/convex/faqSeedData.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical homepage FAQ seed (INF-121). Imported by seed/migration and the
+ * Next.js FAQ component fallback.
+ */
+
+export type FaqQuestionSeed = {
+  stableId: string;
+  question: string;
+  answer: string;
+};
+
+export type FaqCategorySeed = {
+  stableId: string;
+  title: string;
+  questions: FaqQuestionSeed[];
+};
+
+export const DEFAULT_FAQ_CATEGORIES: readonly FaqCategorySeed[] = [
+  {
+    stableId: "cat_studio_sessions",
+    title: "Studio Sessions & Recording",
+    questions: [
+      {
+        stableId: "q_1",
+        question: "What should I bring to my recording session?",
+        answer:
+          "Bring your instruments, any specific pedals or equipment you want to use, backup cables, and your music (charts, lyrics, demo recordings). We provide all basic cables, microphones, and recording equipment. If you have specific instruments you prefer (like your own snare drum or guitar), feel free to bring them!",
+      },
+      {
+        stableId: "q_2",
+        question: "Do you provide instruments and amplifiers?",
+        answer:
+          "Yes! Please see our gear list for a list of our available instruments and amplifiers.",
+      },
+      {
+        stableId: "q_3",
+        question: "Can I bring my own engineer or producer?",
+        answer:
+          "Absolutely! We welcome outside engineers and producers. Our studio engineer will assist with setup and technical support. If you prefer to work solo or with your team, that's perfectly fine too. We're here to support your creative process however works best for you.",
+      },
+      {
+        stableId: "q_4",
+        question: "How far in advance should I book?",
+        answer:
+          "We recommend booking 2-4 weeks in advance, especially during busy seasons (spring and fall). However, we often have last-minute availability. Contact us to check our current schedule - sometimes we can accommodate short-notice bookings.",
+      },
+    ],
+  },
+  {
+    stableId: "cat_studio_logistics",
+    title: "Studio Logistics",
+    questions: [
+      {
+        stableId: "q_9",
+        question: "Is there accommodation nearby?",
+        answer:
+          "Yes! We can help arrange lodging for out-of-town artists. Many artists love staying nearby to maintain the creative flow between sessions.",
+      },
+    ],
+  },
+];

--- a/convex/faqTree.test.ts
+++ b/convex/faqTree.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc } from "./_generated/dataModel";
+import {
+  faqDraftMatchesPublished,
+  materializeFaqCategories,
+  type FaqTree,
+} from "./faqTree";
+
+function mockCategory(
+  overrides: Partial<Doc<"faqCategories">> &
+    Pick<Doc<"faqCategories">, "stableId" | "title" | "sort" | "scope">,
+): Doc<"faqCategories"> {
+  return {
+    _id: "c" as Doc<"faqCategories">["_id"],
+    _creationTime: 0,
+    ...overrides,
+  } as Doc<"faqCategories">;
+}
+
+function mockQuestion(
+  overrides: Partial<Doc<"faqQuestions">> &
+    Pick<
+      Doc<"faqQuestions">,
+      "stableId" | "categoryStableId" | "sort" | "scope" | "question" | "answer"
+    >,
+): Doc<"faqQuestions"> {
+  return {
+    _id: "q" as Doc<"faqQuestions">["_id"],
+    _creationTime: 0,
+    ...overrides,
+  } as Doc<"faqQuestions">;
+}
+
+describe("faqDraftMatchesPublished", () => {
+  test("identical trees match", () => {
+    const tree: FaqTree = {
+      categories: [
+        mockCategory({
+          scope: "draft",
+          stableId: "a",
+          title: "A",
+          sort: 0,
+        }),
+      ],
+      questions: [
+        mockQuestion({
+          scope: "draft",
+          stableId: "q1",
+          categoryStableId: "a",
+          sort: 0,
+          question: "Q?",
+          answer: "A.",
+        }),
+      ],
+    };
+    expect(faqDraftMatchesPublished(tree, tree)).toBe(true);
+  });
+
+  test("different answer text does not match", () => {
+    const a: FaqTree = {
+      categories: [
+        mockCategory({ scope: "draft", stableId: "a", title: "A", sort: 0 }),
+      ],
+      questions: [
+        mockQuestion({
+          scope: "draft",
+          stableId: "q1",
+          categoryStableId: "a",
+          sort: 0,
+          question: "Q?",
+          answer: "One",
+        }),
+      ],
+    };
+    const b: FaqTree = {
+      categories: [
+        mockCategory({ scope: "published", stableId: "a", title: "A", sort: 0 }),
+      ],
+      questions: [
+        mockQuestion({
+          scope: "published",
+          stableId: "q1",
+          categoryStableId: "a",
+          sort: 0,
+          question: "Q?",
+          answer: "Two",
+        }),
+      ],
+    };
+    expect(faqDraftMatchesPublished(a, b)).toBe(false);
+  });
+});
+
+describe("materializeFaqCategories", () => {
+  test("orders categories and questions by sort", () => {
+    const tree: FaqTree = {
+      categories: [
+        mockCategory({
+          scope: "published",
+          stableId: "second",
+          title: "Second",
+          sort: 1,
+        }),
+        mockCategory({
+          scope: "published",
+          stableId: "first",
+          title: "First",
+          sort: 0,
+        }),
+      ],
+      questions: [
+        mockQuestion({
+          scope: "published",
+          stableId: "q_b",
+          categoryStableId: "first",
+          sort: 1,
+          question: "B",
+          answer: "b",
+        }),
+        mockQuestion({
+          scope: "published",
+          stableId: "q_a",
+          categoryStableId: "first",
+          sort: 0,
+          question: "A",
+          answer: "a",
+        }),
+      ],
+    };
+    const out = materializeFaqCategories(tree);
+    expect(out.map((c) => c.stableId)).toEqual(["first", "second"]);
+    expect(out[0].questions.map((q) => q.stableId)).toEqual(["q_a", "q_b"]);
+  });
+});

--- a/convex/faqTree.ts
+++ b/convex/faqTree.ts
@@ -1,0 +1,225 @@
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import type { Infer } from "convex/values";
+import type { faqCategoryValidator, faqContentValidator } from "./schema.shared";
+
+export type CmsScope = "draft" | "published";
+
+export type FaqCategoryInput = Infer<typeof faqCategoryValidator>;
+export type FaqContentSnapshot = Infer<typeof faqContentValidator>;
+
+type FaqCategoryDoc = Doc<"faqCategories">;
+type FaqQuestionDoc = Doc<"faqQuestions">;
+
+export type FaqTree = {
+  categories: FaqCategoryDoc[];
+  questions: FaqQuestionDoc[];
+};
+
+function compareBySortThenStableId(
+  a: { sort: number; stableId: string },
+  b: { sort: number; stableId: string },
+): number {
+  return a.sort - b.sort || a.stableId.localeCompare(b.stableId);
+}
+
+export async function loadFaqCategories(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<FaqCategoryDoc[]> {
+  const rows = await ctx.db
+    .query("faqCategories")
+    .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+    .collect();
+  rows.sort(compareBySortThenStableId);
+  return rows;
+}
+
+export async function loadFaqQuestions(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<FaqQuestionDoc[]> {
+  const rows = await ctx.db
+    .query("faqQuestions")
+    .withIndex("by_scope_and_stableId", (q) => q.eq("scope", scope))
+    .collect();
+  rows.sort((a, b) => {
+    const cat = a.categoryStableId.localeCompare(b.categoryStableId);
+    if (cat !== 0) return cat;
+    return compareBySortThenStableId(a, b);
+  });
+  return rows;
+}
+
+export async function loadFaqTree(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<FaqTree> {
+  const [categories, questions] = await Promise.all([
+    loadFaqCategories(ctx, scope),
+    loadFaqQuestions(ctx, scope),
+  ]);
+  return { categories, questions };
+}
+
+export function normalizeFaqTreeForCompare(tree: FaqTree): unknown {
+  const categories = [...tree.categories]
+    .sort(compareBySortThenStableId)
+    .map((c) => ({
+      stableId: c.stableId,
+      title: c.title,
+      sort: c.sort,
+    }));
+  const questions = [...tree.questions]
+    .sort((a, b) => {
+      const cat = a.categoryStableId.localeCompare(b.categoryStableId);
+      if (cat !== 0) return cat;
+      return compareBySortThenStableId(a, b);
+    })
+    .map((q) => ({
+      stableId: q.stableId,
+      categoryStableId: q.categoryStableId,
+      question: q.question,
+      answer: q.answer,
+      sort: q.sort,
+    }));
+  return { categories, questions };
+}
+
+export function faqDraftMatchesPublished(
+  draft: FaqTree,
+  published: FaqTree,
+): boolean {
+  return (
+    JSON.stringify(normalizeFaqTreeForCompare(draft)) ===
+    JSON.stringify(normalizeFaqTreeForCompare(published))
+  );
+}
+
+export async function deleteAllFaqForScope(
+  ctx: MutationCtx,
+  scope: CmsScope,
+): Promise<void> {
+  for (;;) {
+    const batch = await ctx.db
+      .query("faqQuestions")
+      .withIndex("by_scope_and_stableId", (q) => q.eq("scope", scope))
+      .take(100);
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+  }
+  for (;;) {
+    const batch = await ctx.db
+      .query("faqCategories")
+      .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+      .take(100);
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+  }
+}
+
+export async function copyFaqScope(
+  ctx: MutationCtx,
+  from: CmsScope,
+  to: CmsScope,
+): Promise<void> {
+  await deleteAllFaqForScope(ctx, to);
+  const source = await loadFaqTree(ctx, from);
+
+  for (const c of source.categories) {
+    await ctx.db.insert("faqCategories", {
+      scope: to,
+      stableId: c.stableId,
+      title: c.title,
+      sort: c.sort,
+    });
+  }
+  for (const q of source.questions) {
+    await ctx.db.insert("faqQuestions", {
+      scope: to,
+      stableId: q.stableId,
+      categoryStableId: q.categoryStableId,
+      sort: q.sort,
+      question: q.question,
+      answer: q.answer,
+    });
+  }
+}
+
+export async function replaceFaqScopeFromCategories(
+  ctx: MutationCtx,
+  scope: CmsScope,
+  categories: FaqCategoryInput[],
+): Promise<void> {
+  await deleteAllFaqForScope(ctx, scope);
+
+  for (let ci = 0; ci < categories.length; ci++) {
+    const cat = categories[ci];
+    await ctx.db.insert("faqCategories", {
+      scope,
+      stableId: cat.stableId,
+      title: cat.title,
+      sort: ci,
+    });
+    for (let qi = 0; qi < cat.questions.length; qi++) {
+      const q = cat.questions[qi];
+      await ctx.db.insert("faqQuestions", {
+        scope,
+        stableId: q.stableId,
+        categoryStableId: cat.stableId,
+        sort: qi,
+        question: q.question,
+        answer: q.answer,
+      });
+    }
+  }
+}
+
+export async function replaceFaqDraftFromCategories(
+  ctx: MutationCtx,
+  categories: FaqCategoryInput[],
+): Promise<void> {
+  await replaceFaqScopeFromCategories(ctx, "draft", categories);
+}
+
+export type PublicFaqQuestion = {
+  stableId: string;
+  question: string;
+  answer: string;
+};
+
+export type PublicFaqCategory = {
+  stableId: string;
+  title: string;
+  questions: PublicFaqQuestion[];
+};
+
+/**
+ * Fold scoped rows into nested categories for public / preview loaders.
+ */
+export function materializeFaqCategories(tree: FaqTree): PublicFaqCategory[] {
+  const orderedCats = [...tree.categories].sort(compareBySortThenStableId);
+  const out: PublicFaqCategory[] = [];
+
+  for (const cat of orderedCats) {
+    const qs = tree.questions
+      .filter((q) => q.categoryStableId === cat.stableId)
+      .sort(compareBySortThenStableId)
+      .map((q) => ({
+        stableId: q.stableId,
+        question: q.question,
+        answer: q.answer,
+      }));
+    out.push({
+      stableId: cat.stableId,
+      title: cat.title,
+      questions: qs,
+    });
+  }
+
+  return out;
+}

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -10,6 +10,8 @@ import type { Doc } from "./_generated/dataModel";
 import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
 import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
 import { getSectionMetaRow, publishedIsEnabled } from "./cmsMeta";
+import { FAQ_DEFAULTS } from "./cmsShared";
+import { loadFaqTree, materializeFaqCategories } from "./faqTree";
 
 /**
  * **Public (anonymous) site reads** — published only.
@@ -114,6 +116,21 @@ export const getPublishedAudioTracks = query({
  * and returns the historical shape `{ aboutPage, recordingsPage, pricingSection }`
  * so the existing frontend consumers keep working without changes.
  */
+/**
+ * Published homepage FAQ (plain text answers). Falls back to shipped defaults
+ * when the published scope has not been seeded yet.
+ */
+export const getPublishedFaq = query({
+  args: {},
+  handler: async (ctx) => {
+    const tree = await loadFaqTree(ctx, "published");
+    if (tree.categories.length === 0) {
+      return { categories: FAQ_DEFAULTS.categories };
+    }
+    return { categories: materializeFaqCategories(tree) };
+  },
+});
+
 export const getPublishedMarketingFeatureFlags = query({
   args: {},
   handler: async (ctx) => {

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -9,6 +9,7 @@ import { v } from "convex/values";
  * - `pricing`    — pricing package catalogue that drives the public pricing block.
  * - `about`      — About page hero copy, body block array, optional highlights, SEO meta, optional team headshots.
  * - `recordings` — public recordings page (flag-only; content lives in `src/app/recordings/recordings-data.ts`).
+ * - `faq`        — homepage FAQ (categories → questions → answers); scoped rows in `faqCategories` / `faqQuestions`.
  *
  * Content for each section (when any) lives in dedicated scoped tables using the
  * gear/photos pattern (`scope: "draft" | "published"` column); `cmsSections`
@@ -132,6 +133,27 @@ export const aboutTeamMemberValidator = v.object({
   storageId: v.optional(v.id("_storage")),
 });
 
+/** One FAQ answer row as authored in admin / snapshot payloads (plain text). */
+export const faqQuestionValidator = v.object({
+  stableId: v.string(),
+  question: v.string(),
+  answer: v.string(),
+});
+
+/** One FAQ category with ordered questions. */
+export const faqCategoryValidator = v.object({
+  stableId: v.string(),
+  title: v.string(),
+  questions: v.array(faqQuestionValidator),
+});
+
+/**
+ * Homepage FAQ snapshot shape (admin `saveDraft` + `getSection` overlay).
+ */
+export const faqContentValidator = v.object({
+  categories: v.array(faqCategoryValidator),
+});
+
 /**
  * @deprecated `about` content now lives in `aboutContent` + `aboutHighlights`
  * + `aboutTeamMembers` scoped tables. This validator remains only so that
@@ -152,6 +174,16 @@ export const aboutContentValidator = v.object({
 });
 
 /**
+ * Union of section snapshot payloads (admin `saveDraft` / `getSection` content).
+ */
+export const cmsSnapshotValidator = v.union(
+  settingsContentValidator,
+  pricingContentValidator,
+  aboutContentValidator,
+  faqContentValidator,
+);
+
+/**
  * The set of sections tracked in `cmsSections`. `recordings` was added when
  * flags moved off the `marketingFeatureFlags` singleton and onto `cmsSections`
  * rows; it has no content table today (flag-only).
@@ -161,6 +193,7 @@ export const cmsSectionValidator = v.union(
   v.literal("pricing"),
   v.literal("about"),
   v.literal("recordings"),
+  v.literal("faq"),
 );
 
 /**
@@ -225,6 +258,24 @@ export const settingsContentRowValidator = {
   scope: cmsScopeValidator,
   title: v.optional(v.string()),
   description: v.optional(v.string()),
+} as const;
+
+/** FAQ category heading — one row per category per scope. */
+export const faqCategoryRowValidator = {
+  scope: cmsScopeValidator,
+  stableId: v.string(),
+  title: v.string(),
+  sort: v.number(),
+} as const;
+
+/** FAQ Q&A — one row per question per scope. */
+export const faqQuestionRowValidator = {
+  scope: cmsScopeValidator,
+  stableId: v.string(),
+  categoryStableId: v.string(),
+  sort: v.number(),
+  question: v.string(),
+  answer: v.string(),
 } as const;
 
 /** Draft vs published rows in `gearCategories` / `gearItems` (INF-86). */

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,6 +5,8 @@ import {
   aboutHighlightRowValidator,
   aboutTeamMemberRowValidator,
   cmsSectionValidator,
+  faqCategoryRowValidator,
+  faqQuestionRowValidator,
   gearScopeValidator,
   gearSpecsValidator,
   pricingPackageRowValidator,
@@ -24,6 +26,7 @@ import {
  *   scope onto the published scope in a single mutation.
  * - The `recordings` section is flag-only (no content table); the public page
  *   reads copy from `src/app/recordings/recordings-data.ts`.
+ * - The `faq` section uses `faqCategories` + `faqQuestions` scoped tables.
  */
 export default defineSchema({
   inquiries: defineTable({
@@ -69,6 +72,18 @@ export default defineSchema({
   settingsContent: defineTable(settingsContentRowValidator).index("by_scope", [
     "scope",
   ]),
+
+  faqCategories: defineTable(faqCategoryRowValidator)
+    .index("by_scope_and_sort", ["scope", "sort"])
+    .index("by_scope_and_stableId", ["scope", "stableId"]),
+
+  faqQuestions: defineTable(faqQuestionRowValidator)
+    .index("by_scope_and_category_and_sort", [
+      "scope",
+      "categoryStableId",
+      "sort",
+    ])
+    .index("by_scope_and_stableId", ["scope", "stableId"]),
 
   gearMeta: defineTable({
     singletonKey: v.literal("default"),

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -12,13 +12,15 @@ import {
 import { ABOUT_CONTENT_DEFAULTS, loadAboutContent } from "./aboutTree";
 import { loadPricingPackages } from "./pricingTree";
 import { loadSettingsContent } from "./settingsTree";
+import { DEFAULT_FAQ_CATEGORIES } from "./faqSeedData";
+import { loadFaqTree, replaceFaqScopeFromCategories } from "./faqTree";
 import { LEGACY_EQUIPMENT_SEED } from "./gearEquipmentSeed";
 import { insertLegacyEquipmentSeedDraft } from "./gearLegacySeed";
 import { deleteAllGearForScope, loadGearDocs } from "./gearTree";
 
 /**
- * Idempotent seed for local dev: creates the four `cmsSections` metadata rows
- * (settings, pricing, about, recordings) and seeds per-section published-scope
+ * Idempotent seed for local dev: creates the `cmsSections` metadata rows
+ * (settings, pricing, about, recordings, faq) and seeds per-section published-scope
  * content so the admin editors and public queries have a consistent baseline.
  *
  * Run once after deploying schema:
@@ -28,13 +30,19 @@ export const seedSiteSettingsDefaults = internalMutation({
   args: {},
   handler: async (ctx) => {
     type SectionSeedResult = {
-      section: "settings" | "pricing" | "about" | "recordings";
+      section: "settings" | "pricing" | "about" | "recordings" | "faq";
       status: "already_seeded" | "inserted";
     };
 
     const results: SectionSeedResult[] = [];
 
-    for (const section of ["settings", "pricing", "about", "recordings"] as const) {
+    for (const section of [
+      "settings",
+      "pricing",
+      "about",
+      "recordings",
+      "faq",
+    ] as const) {
       const before = await ctx.db
         .query("cmsSections")
         .withIndex("by_section", (q) => q.eq("section", section))
@@ -106,11 +114,58 @@ export const seedSiteSettingsDefaults = internalMutation({
       }
     }
 
+    const faqPublished = await loadFaqTree(ctx, "published");
+    if (faqPublished.categories.length === 0) {
+      await replaceFaqScopeFromCategories(
+        ctx,
+        "published",
+        DEFAULT_FAQ_CATEGORIES.map((c) => ({
+          stableId: c.stableId,
+          title: c.title,
+          questions: c.questions.map((q) => ({
+            stableId: q.stableId,
+            question: q.question,
+            answer: q.answer,
+          })),
+        })),
+      );
+    }
+
     return {
       results,
       defaultIsEnabled: DEFAULT_IS_ENABLED,
       aboutDefaultsHeroTitle: ABOUT_DEFAULTS.heroTitle,
     };
+  },
+});
+
+/**
+ * One-time backfill: seeds `scope="published"` FAQ rows from shipped defaults
+ * when the published tree is empty. Safe to run on existing deployments
+ * (`bunx convex run internal.seed.migrateFaqPublishedIfEmpty`).
+ */
+export const migrateFaqPublishedIfEmpty = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const published = await loadFaqTree(ctx, "published");
+    if (published.categories.length > 0) {
+      return { ok: true as const, kind: "already_has_content" as const };
+    }
+    await ensureSectionMetaRow(ctx, "faq", undefined);
+    await replaceFaqScopeFromCategories(
+      ctx,
+      "published",
+      DEFAULT_FAQ_CATEGORIES.map((c) => ({
+        stableId: c.stableId,
+        title: c.title,
+        questions: c.questions.map((q) => ({
+          stableId: q.stableId,
+          question: q.question,
+          answer: q.answer,
+        })),
+      })),
+    );
+    return { ok: true as const, kind: "inserted" as const };
   },
 });
 

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -3,6 +3,7 @@ import { internalMutation } from "./_generated/server";
 import {
   ABOUT_DEFAULTS,
   DEFAULT_PRICING_PACKAGES,
+  FAQ_DEFAULTS,
   SETTINGS_DEFAULTS,
 } from "./cmsShared";
 import {
@@ -12,7 +13,6 @@ import {
 import { ABOUT_CONTENT_DEFAULTS, loadAboutContent } from "./aboutTree";
 import { loadPricingPackages } from "./pricingTree";
 import { loadSettingsContent } from "./settingsTree";
-import { DEFAULT_FAQ_CATEGORIES } from "./faqSeedData";
 import { loadFaqTree, replaceFaqScopeFromCategories } from "./faqTree";
 import { LEGACY_EQUIPMENT_SEED } from "./gearEquipmentSeed";
 import { insertLegacyEquipmentSeedDraft } from "./gearLegacySeed";
@@ -119,15 +119,7 @@ export const seedSiteSettingsDefaults = internalMutation({
       await replaceFaqScopeFromCategories(
         ctx,
         "published",
-        DEFAULT_FAQ_CATEGORIES.map((c) => ({
-          stableId: c.stableId,
-          title: c.title,
-          questions: c.questions.map((q) => ({
-            stableId: q.stableId,
-            question: q.question,
-            answer: q.answer,
-          })),
-        })),
+        FAQ_DEFAULTS.categories,
       );
     }
 
@@ -155,15 +147,7 @@ export const migrateFaqPublishedIfEmpty = internalMutation({
     await replaceFaqScopeFromCategories(
       ctx,
       "published",
-      DEFAULT_FAQ_CATEGORIES.map((c) => ({
-        stableId: c.stableId,
-        title: c.title,
-        questions: c.questions.map((q) => ({
-          stableId: q.stableId,
-          question: q.question,
-          answer: q.answer,
-        })),
-      })),
+      FAQ_DEFAULTS.categories,
     );
     return { ok: true as const, kind: "inserted" as const };
   },

--- a/docs/cms-publish.md
+++ b/docs/cms-publish.md
@@ -19,6 +19,7 @@ so public readers never see a half-written structure.
 | `pricing`    | `pricingPackages` (scope)                                        | Homepage pricing block + primary-nav link      | `/admin/pricing`     |
 | `about`      | `aboutContent`, `aboutHighlights`, `aboutTeamMembers` (scope)    | Public `/about` route + homepage nav link      | `/admin/about`       |
 | `recordings` | (flag-only; copy lives in `src/app/recordings/recordings-data.ts`) | Public `/recordings` route + homepage nav link | `/admin/audio`       |
+| `faq`        | `faqCategories`, `faqQuestions` (scope)                          | Homepage FAQ block                               | `/admin/faq`         |
 
 Each section has its own `cmsSections` metadata row and therefore its own
 independent draft / publish lifecycle. The `isEnabled` flag and its draft
@@ -34,10 +35,12 @@ edits.
 | Anonymous / marketing site — pricing          | `pricingPackages` (published) + `cmsSections.pricing.isEnabled` — `api.public.getPublishedPricingFlags`         |
 | Anonymous / marketing site — marketing flags  | Reads each section row's `isEnabled` — `api.public.getPublishedMarketingFeatureFlags`                           |
 | Anonymous / marketing site — About copy       | `aboutContent` + `aboutHighlights` + `aboutTeamMembers` (published, resolved URLs) — `api.public.getPublishedAbout` |
+| Anonymous / marketing site — Homepage FAQ     | `faqCategories` + `faqQuestions` (published) — `api.public.getPublishedFaq` |
 | Studio / preview — metadata                   | `api.siteSettingsPreviewDraft.getPreviewSiteSettings` (draft when present, else published; owner-gated)         |
 | Studio / preview — pricing                    | `api.pricingPreviewDraft.getPreviewPricingFlags` (draft packages when present, else published; owner-gated)     |
 | Studio / preview — marketing flags            | `api.cms.getPreviewMarketingFeatureFlags` (owner-gated; applies `isEnabledDraft` overrides)                     |
 | Studio / preview — About copy                 | `api.aboutPreviewDraft.getPreviewAbout` (draft scope, falls back to published; owner-gated)                     |
+| Studio / preview — Homepage FAQ             | `api.faqPreviewDraft.getPreviewFaq` (owner-gated)                                                                 |
 
 ## Admin UI
 

--- a/src/app/admin/faq/faq-editor.tsx
+++ b/src/app/admin/faq/faq-editor.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import {
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useQuery,
+  useMutation,
+} from "convex/react";
+import { useUser } from "@clerk/nextjs";
+import { api } from "../../../../convex/_generated/api";
+import { useCallback, useRef, useState } from "react";
+import { Effect } from "effect";
+import { toast } from "sonner";
+import { Plus, Trash2 } from "lucide-react";
+import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import { runAdminEffect } from "@/lib/admin-run-effect";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
+import { useAutosaveDraft } from "@/lib/use-autosave-draft";
+import type { FaqSnapshot } from "../../../../convex/cmsShared";
+import { Button } from "@/components/ui/button";
+
+const fieldClass =
+  "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/50";
+
+function newStableId(prefix: string): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+export function FaqEditor() {
+  return (
+    <>
+      <AuthLoading>
+        <p className="body-text text-muted-foreground">Authenticating…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <p className="body-text text-muted-foreground">
+          Sign in to manage FAQ content.
+        </p>
+      </Unauthenticated>
+      <Authenticated>
+        <FaqForm />
+      </Authenticated>
+    </>
+  );
+}
+
+function FaqForm() {
+  const { user } = useUser();
+  const section = useQuery(api.cms.getSection, { section: "faq" });
+  const saveDraft = useMutation(api.cms.saveDraft);
+  const publish = useMutation(api.cms.publishSection);
+  const discard = useMutation(api.cms.discardDraft);
+
+  const [localDraft, setLocalDraft] = useState<FaqSnapshot | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const kickAutosaveRef = useRef<() => void>(() => {});
+  const cancelAutosaveRef = useRef<() => void>(() => {});
+
+  const source: FaqSnapshot | undefined =
+    localDraft ??
+    (section
+      ? ((section.draftSnapshot ?? section.publishedSnapshot) as FaqSnapshot)
+      : undefined);
+
+  const setCategories = useCallback(
+    (categories: FaqSnapshot["categories"]) => {
+      if (!source) return;
+      setInlineError(null);
+      setLocalDraft({ categories });
+      kickAutosaveRef.current();
+    },
+    [source],
+  );
+
+  const addCategory = useCallback(() => {
+    if (!source) return;
+    setCategories([
+      ...source.categories,
+      {
+        stableId: newStableId("cat"),
+        title: "New category",
+        questions: [
+          {
+            stableId: newStableId("q"),
+            question: "",
+            answer: "",
+          },
+        ],
+      },
+    ]);
+  }, [setCategories, source]);
+
+  const removeCategory = useCallback(
+    (stableId: string) => {
+      if (!source) return;
+      setCategories(source.categories.filter((c) => c.stableId !== stableId));
+    },
+    [setCategories, source],
+  );
+
+  const updateCategoryTitle = useCallback(
+    (stableId: string, title: string) => {
+      if (!source) return;
+      setCategories(
+        source.categories.map((c) =>
+          c.stableId === stableId ? { ...c, title } : c,
+        ),
+      );
+    },
+    [setCategories, source],
+  );
+
+  const addQuestion = useCallback(
+    (categoryStableId: string) => {
+      if (!source) return;
+      setCategories(
+        source.categories.map((c) =>
+          c.stableId === categoryStableId
+            ? {
+                ...c,
+                questions: [
+                  ...c.questions,
+                  {
+                    stableId: newStableId("q"),
+                    question: "",
+                    answer: "",
+                  },
+                ],
+              }
+            : c,
+        ),
+      );
+    },
+    [setCategories, source],
+  );
+
+  const removeQuestion = useCallback(
+    (categoryStableId: string, questionStableId: string) => {
+      if (!source) return;
+      setCategories(
+        source.categories.map((c) =>
+          c.stableId === categoryStableId
+            ? {
+                ...c,
+                questions: c.questions.filter(
+                  (q) => q.stableId !== questionStableId,
+                ),
+              }
+            : c,
+        ),
+      );
+    },
+    [setCategories, source],
+  );
+
+  const updateQuestion = useCallback(
+    (
+      categoryStableId: string,
+      questionStableId: string,
+      patch: Partial<{ question: string; answer: string }>,
+    ) => {
+      if (!source) return;
+      setCategories(
+        source.categories.map((c) =>
+          c.stableId === categoryStableId
+            ? {
+                ...c,
+                questions: c.questions.map((q) =>
+                  q.stableId === questionStableId ? { ...q, ...patch } : q,
+                ),
+              }
+            : c,
+        ),
+      );
+    },
+    [setCategories, source],
+  );
+
+  const runAction = useCallback(
+    async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
+      cancelAutosaveRef.current();
+      setInlineError(null);
+      setBusy(label);
+      const outcome = await runAdminEffect(program, {
+        onErrorMessage: setInlineError,
+      });
+      if (outcome !== undefined) {
+        setLocalDraft(null);
+      }
+      setBusy(null);
+      return outcome;
+    },
+    [],
+  );
+
+  const hasDraftOnServer = section?.hasDraftChanges ?? false;
+  const hasLocalEdits = localDraft !== null;
+
+  const {
+    status: autosaveStatus,
+    flush: flushAutosave,
+    kick: kickAutosave,
+    cancel: cancelAutosave,
+    onUnmount: autosaveOnUnmount,
+  } = useAutosaveDraft({
+    isDirty: hasLocalEdits && source !== undefined,
+    pauseWhen: busy !== null,
+    saveEffect: () =>
+      convexMutationEffect(() =>
+        saveDraft({
+          section: "faq",
+          content: source ?? { categories: [] },
+        }),
+      ),
+    onSaved: () => setLocalDraft(null),
+  });
+  kickAutosaveRef.current = kickAutosave;
+  cancelAutosaveRef.current = cancelAutosave;
+
+  const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
+    cancelAutosaveRef.current();
+    setInlineError(null);
+    if (hasDraftOnServer) {
+      setBusy("Discarding…");
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() => discard({ section: "faq" })),
+        { onErrorMessage: setInlineError },
+      );
+      setBusy(null);
+      if (outcome === undefined) {
+        return false;
+      }
+    }
+    setLocalDraft(null);
+    toast.success(
+      hasDraftOnServer
+        ? "Draft discarded. The editor now matches the published site."
+        : "Unsaved changes discarded.",
+    );
+    return true;
+  }, [discard, hasDraftOnServer]);
+
+  const handlePublish = useCallback(() => {
+    const publishOnce = convexMutationEffect(() =>
+      publish({ section: "faq" }),
+    );
+    void (async () => {
+      if (hasLocalEdits) {
+        const flushed = await flushAutosave();
+        if (!flushed) return;
+      }
+      await runAction("Publishing…", publishOnce);
+    })();
+  }, [flushAutosave, hasLocalEdits, publish, runAction]);
+
+  const publishedByLabel =
+    section?.publishedBy && user?.id === section.publishedBy ? "You" : undefined;
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "faq",
+    sectionLabel: "homepage FAQ",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: section?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    autosaveStatus,
+    inlineError,
+    previewHref: "/preview",
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAutosave,
+  });
+
+  const handleEditorRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      editorRef(node);
+      autosaveOnUnmount(node);
+    },
+    [autosaveOnUnmount, editorRef],
+  );
+
+  if (source === undefined) {
+    return (
+      <div className="body-text text-muted-foreground" ref={handleEditorRef}>
+        Loading FAQ…
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {toolbarPortal}
+      <div ref={handleEditorRef} className="mx-auto max-w-3xl space-y-10 p-6">
+        <div>
+          <h2 className="headline-secondary text-foreground mb-1 text-lg">
+            Homepage FAQ
+          </h2>
+          <p className="body-text-small text-muted-foreground">
+            Categories and Q&amp;A appear on the marketing homepage. Answers are
+            plain text (no HTML). Publish to go live.
+          </p>
+        </div>
+
+        <div className="space-y-12">
+          {source.categories.map((cat) => (
+            <div
+              key={cat.stableId}
+              className="rounded-lg border border-border bg-card p-5"
+            >
+              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <label className="body-text-small text-muted-foreground">
+                    Category title
+                  </label>
+                  <input
+                    className={fieldClass}
+                    value={cat.title}
+                    onChange={(e) =>
+                      updateCategoryTitle(cat.stableId, e.target.value)
+                    }
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 gap-1"
+                  onClick={() => removeCategory(cat.stableId)}
+                >
+                  <Trash2 className="size-3.5" />
+                  Remove category
+                </Button>
+              </div>
+
+              <div className="space-y-6 border-t border-border pt-5">
+                {cat.questions.map((q) => (
+                  <div
+                    key={q.stableId}
+                    className="space-y-3 rounded-md bg-muted/30 p-4"
+                  >
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 gap-1 text-muted-foreground"
+                        onClick={() =>
+                          removeQuestion(cat.stableId, q.stableId)
+                        }
+                      >
+                        <Trash2 className="size-3.5" />
+                        Remove
+                      </Button>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="body-text-small text-muted-foreground">
+                        Question
+                      </label>
+                      <input
+                        className={fieldClass}
+                        value={q.question}
+                        onChange={(e) =>
+                          updateQuestion(cat.stableId, q.stableId, {
+                            question: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="body-text-small text-muted-foreground">
+                        Answer
+                      </label>
+                      <textarea
+                        className={`${fieldClass} min-h-[100px] resize-y`}
+                        value={q.answer}
+                        onChange={(e) =>
+                          updateQuestion(cat.stableId, q.stableId, {
+                            answer: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="gap-1"
+                  onClick={() => addQuestion(cat.stableId)}
+                >
+                  <Plus className="size-3.5" />
+                  Add question
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <Button type="button" variant="default" className="gap-1" onClick={addCategory}>
+          <Plus className="size-4" />
+          Add category
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/app/admin/faq/page.tsx
+++ b/src/app/admin/faq/page.tsx
@@ -1,0 +1,13 @@
+import { AdminHeader } from "@/components/admin/admin-header";
+import { FaqEditor } from "./faq-editor";
+
+export default function AdminFaqPage() {
+  return (
+    <>
+      <AdminHeader title="FAQ" />
+      <div className="flex-1">
+        <FaqEditor />
+      </div>
+    </>
+  );
+}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -5,11 +5,15 @@ import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
 import type { PublishedAudioTrack } from "@/components/audio-portfolio";
 import type { GalleryPhoto } from "@/components/the-space";
+import type { FaqCategoryProps } from "@/components/faq";
 
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
 type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
 type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos> | null;
 type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks> | null;
+type PreloadedFaq = Preloaded<typeof api.public.getPublishedFaq> | null;
+
+type PublishedFaqPayload = { categories: readonly FaqCategoryProps[] };
 
 function PhotosData({
   preloaded,
@@ -116,16 +120,51 @@ function AudioLive({
   return <>{children(audio)}</>;
 }
 
+function FaqData({
+  preloaded,
+  children,
+}: {
+  preloaded: PreloadedFaq;
+  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+}) {
+  if (preloaded) {
+    return <FaqFromPreload preloaded={preloaded}>{children}</FaqFromPreload>;
+  }
+  return <FaqLive>{children}</FaqLive>;
+}
+
+function FaqFromPreload({
+  preloaded,
+  children,
+}: {
+  preloaded: NonNullable<PreloadedFaq>;
+  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+}) {
+  const faq = usePreloadedQuery(preloaded);
+  return <>{children(faq)}</>;
+}
+
+function FaqLive({
+  children,
+}: {
+  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+}) {
+  const faq = useQuery(api.public.getPublishedFaq);
+  return <>{children(faq)}</>;
+}
+
 function BothPreloaded({
   preloadedPricing,
   preloadedGear,
   photos,
   audioTracks,
+  faq,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
   audioTracks: PublishedAudioTrack[] | undefined;
+  faq: PublishedFaqPayload | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = usePreloadedQuery(preloadedGear);
@@ -136,6 +175,7 @@ function BothPreloaded({
       gear={gear}
       photos={photos}
       audioTracks={audioTracks}
+      faqCategories={faq?.categories}
     />
   );
 }
@@ -144,10 +184,12 @@ function PricingPreloadedGearLive({
   preloadedPricing,
   photos,
   audioTracks,
+  faq,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   photos: GalleryPhoto[] | undefined;
   audioTracks: PublishedAudioTrack[] | undefined;
+  faq: PublishedFaqPayload | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = useQuery(api.public.getPublishedGear);
@@ -158,6 +200,7 @@ function PricingPreloadedGearLive({
       gear={gear}
       photos={photos}
       audioTracks={audioTracks}
+      faqCategories={faq?.categories}
     />
   );
 }
@@ -166,10 +209,12 @@ function PricingLiveGearPreloaded({
   preloadedGear,
   photos,
   audioTracks,
+  faq,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
   audioTracks: PublishedAudioTrack[] | undefined;
+  faq: PublishedFaqPayload | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = usePreloadedQuery(preloadedGear);
@@ -180,6 +225,7 @@ function PricingLiveGearPreloaded({
       gear={gear}
       photos={photos}
       audioTracks={audioTracks}
+      faqCategories={faq?.categories}
     />
   );
 }
@@ -187,9 +233,11 @@ function PricingLiveGearPreloaded({
 function BothLive({
   photos,
   audioTracks,
+  faq,
 }: {
   photos: GalleryPhoto[] | undefined;
   audioTracks: PublishedAudioTrack[] | undefined;
+  faq: PublishedFaqPayload | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = useQuery(api.public.getPublishedGear);
@@ -200,6 +248,7 @@ function BothLive({
       gear={gear}
       photos={photos}
       audioTracks={audioTracks}
+      faqCategories={faq?.categories}
     />
   );
 }
@@ -209,49 +258,62 @@ export function HomeClient({
   preloadedGear,
   preloadedPhotos,
   preloadedAudio,
+  preloadedFaq,
 }: {
   preloadedPricing: PreloadedPricing;
   preloadedGear: PreloadedGear;
   preloadedPhotos: PreloadedPhotos;
   preloadedAudio: PreloadedAudio;
+  preloadedFaq: PreloadedFaq;
 }) {
   return (
     <PhotosData preloaded={preloadedPhotos}>
       {(photos) => (
         <AudioData preloaded={preloadedAudio}>
-          {(audioTracks) => {
-            if (preloadedPricing && preloadedGear) {
-              return (
-                <BothPreloaded
-                  preloadedPricing={preloadedPricing}
-                  preloadedGear={preloadedGear}
-                  photos={photos}
-                  audioTracks={audioTracks}
-                />
-              );
-            }
-            if (preloadedPricing) {
-              return (
-                <PricingPreloadedGearLive
-                  preloadedPricing={preloadedPricing}
-                  photos={photos}
-                  audioTracks={audioTracks}
-                />
-              );
-            }
-            if (preloadedGear) {
-              return (
-                <PricingLiveGearPreloaded
-                  preloadedGear={preloadedGear}
-                  photos={photos}
-                  audioTracks={audioTracks}
-                />
-              );
-            }
-            return (
-              <BothLive photos={photos} audioTracks={audioTracks} />
-            );
-          }}
+          {(audioTracks) => (
+            <FaqData preloaded={preloadedFaq}>
+              {(faq) => {
+                if (preloadedPricing && preloadedGear) {
+                  return (
+                    <BothPreloaded
+                      preloadedPricing={preloadedPricing}
+                      preloadedGear={preloadedGear}
+                      photos={photos}
+                      audioTracks={audioTracks}
+                      faq={faq}
+                    />
+                  );
+                }
+                if (preloadedPricing) {
+                  return (
+                    <PricingPreloadedGearLive
+                      preloadedPricing={preloadedPricing}
+                      photos={photos}
+                      audioTracks={audioTracks}
+                      faq={faq}
+                    />
+                  );
+                }
+                if (preloadedGear) {
+                  return (
+                    <PricingLiveGearPreloaded
+                      preloadedGear={preloadedGear}
+                      photos={photos}
+                      audioTracks={audioTracks}
+                      faq={faq}
+                    />
+                  );
+                }
+                return (
+                  <BothLive
+                    photos={photos}
+                    audioTracks={audioTracks}
+                    faq={faq}
+                  />
+                );
+              }}
+            </FaqData>
+          )}
         </AudioData>
       )}
     </PhotosData>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,12 +5,13 @@ import { HomepageShell } from "@/components/homepage-shell";
 
 export default async function Home() {
   try {
-    const [pricingSettled, gearSettled, photosSettled, audioSettled] =
+    const [pricingSettled, gearSettled, photosSettled, audioSettled, faqSettled] =
       await Promise.allSettled([
         preloadQuery(api.public.getPublishedPricingFlags),
         preloadQuery(api.public.getPublishedGear),
         preloadQuery(api.public.getPublishedGalleryPhotos),
         preloadQuery(api.public.getPublishedAudioTracks),
+        preloadQuery(api.public.getPublishedFaq),
       ]);
     const preloadedPricing =
       pricingSettled.status === "fulfilled" ? pricingSettled.value : null;
@@ -20,11 +21,14 @@ export default async function Home() {
       photosSettled.status === "fulfilled" ? photosSettled.value : null;
     const preloadedAudio =
       audioSettled.status === "fulfilled" ? audioSettled.value : null;
+    const preloadedFaq =
+      faqSettled.status === "fulfilled" ? faqSettled.value : null;
     if (
       preloadedPricing === null &&
       preloadedGear === null &&
       preloadedPhotos === null &&
-      preloadedAudio === null
+      preloadedAudio === null &&
+      preloadedFaq === null
     ) {
       return (
         <HomepageShell
@@ -33,6 +37,7 @@ export default async function Home() {
           gear={null}
           photos={null}
           audioTracks={null}
+          faqCategories={null}
         />
       );
     }
@@ -42,6 +47,7 @@ export default async function Home() {
         preloadedGear={preloadedGear}
         preloadedPhotos={preloadedPhotos}
         preloadedAudio={preloadedAudio}
+        preloadedFaq={preloadedFaq}
       />
     );
   } catch {
@@ -52,6 +58,7 @@ export default async function Home() {
         gear={null}
         photos={null}
         audioTracks={null}
+        faqCategories={null}
       />
     );
   }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -17,6 +17,7 @@ function PreviewContent() {
   // Tracks whether the About section has unpublished draft content so the
   // preview banner can reflect it. Owner-only — returns `null` for non-owners.
   const aboutPreview = useQuery(api.aboutPreviewDraft.getPreviewAbout);
+  const faqPreview = useQuery(api.faqPreviewDraft.getPreviewFaq);
   const marketingPreview = useQuery(api.cms.getPreviewMarketingFeatureFlags);
 
   if (
@@ -25,6 +26,7 @@ function PreviewContent() {
     photoPreview === undefined ||
     audioPreview === undefined ||
     aboutPreview === undefined ||
+    faqPreview === undefined ||
     marketingPreview === undefined
   ) {
     return (
@@ -40,6 +42,7 @@ function PreviewContent() {
     photoPreview === null ||
     audioPreview === null ||
     aboutPreview === null ||
+    faqPreview === null ||
     marketingPreview === null
   ) {
     return (
@@ -57,6 +60,7 @@ function PreviewContent() {
     photoPreview.hasDraftChanges ||
     audioPreview.hasDraftChanges ||
     aboutPreview.hasDraftChanges ||
+    faqPreview.hasDraftChanges ||
     marketingPreview.hasDraftChanges;
 
   const audioTracks: PublishedAudioTrack[] = audioPreview.tracks
@@ -91,6 +95,7 @@ function PreviewContent() {
       gear={{ categories: gearPreview.categories }}
       photos={photoPreview.photos}
       audioTracks={audioTracks}
+      faqCategories={faqPreview.categories}
       banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />
   );

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -10,51 +10,30 @@ import {
 } from "@/components/ui/accordion";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { DEFAULT_FAQ_CATEGORIES } from "../../convex/faqSeedData";
 
-const FAQ_CATEGORIES = [
-  {
-    category: "Studio Sessions & Recording",
-    questions: [
-      {
-        id: 1,
-        question: "What should I bring to my recording session?",
-        answer:
-          "Bring your instruments, any specific pedals or equipment you want to use, backup cables, and your music (charts, lyrics, demo recordings). We provide all basic cables, microphones, and recording equipment. If you have specific instruments you prefer (like your own snare drum or guitar), feel free to bring them!",
-      },
-      {
-        id: 2,
-        question: "Do you provide instruments and amplifiers?",
-        answer:
-          "Yes! Please see our gear list for a list of our available instruments and amplifiers.",
-      },
-      {
-        id: 3,
-        question: "Can I bring my own engineer or producer?",
-        answer:
-          "Absolutely! We welcome outside engineers and producers. Our studio engineer will assist with setup and technical support. If you prefer to work solo or with your team, that's perfectly fine too. We're here to support your creative process however works best for you.",
-      },
-      {
-        id: 4,
-        question: "How far in advance should I book?",
-        answer:
-          "We recommend booking 2-4 weeks in advance, especially during busy seasons (spring and fall). However, we often have last-minute availability. Contact us to check our current schedule - sometimes we can accommodate short-notice bookings.",
-      },
-    ],
-  },
-  {
-    category: "Studio Logistics",
-    questions: [
-      {
-        id: 9,
-        question: "Is there accommodation nearby?",
-        answer:
-          "Yes! We can help arrange lodging for out-of-town artists. Many artists love staying nearby to maintain the creative flow between sessions.",
-      },
-    ],
-  },
-] as const;
+export type FaqQuestionProps = {
+  stableId: string;
+  question: string;
+  answer: string;
+};
 
-export function FAQ() {
+export type FaqCategoryProps = {
+  stableId: string;
+  title: string;
+  questions: FaqQuestionProps[];
+};
+
+export type FaqProps = {
+  categories?: readonly FaqCategoryProps[];
+};
+
+export function FAQ({ categories }: FaqProps) {
+  const data =
+    categories && categories.length > 0
+      ? categories
+      : DEFAULT_FAQ_CATEGORIES;
+
   return (
     <section
       id="faq"
@@ -89,15 +68,15 @@ export function FAQ() {
         </div>
 
         <div className="reveal reveal-delay-2 space-y-16">
-          {FAQ_CATEGORIES.map((category) => (
-            <div key={category.category}>
+          {data.map((category) => (
+            <div key={category.stableId}>
               <h3 className="eyebrow mb-8 border-b border-sand/22 pb-4 text-sand">
-                {category.category}
+                {category.title}
               </h3>
 
               <Accordion multiple>
                 {category.questions.map((faq) => (
-                  <AccordionItem key={faq.id} value={String(faq.id)}>
+                  <AccordionItem key={faq.stableId} value={faq.stableId}>
                     <AccordionTrigger>
                       <span className="body-text text-base text-warm-white">
                         {faq.question}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -7,7 +7,7 @@ import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { MarketingPricingSection } from "@/components/dynamic-pricing";
 import { EquipmentSpecs, type GearPayload } from "@/components/equipment-specs";
-import { FAQ } from "@/components/faq";
+import { FAQ, type FaqCategoryProps } from "@/components/faq";
 import { Header } from "@/components/header";
 import { Hero } from "@/components/hero";
 import { SiteFooter } from "@/components/site-footer";
@@ -45,6 +45,8 @@ interface HomepageShellProps {
   readonly photos: GalleryPhoto[] | null | undefined;
   /** Published (or preview) audio portfolio; empty array hides the section. */
   readonly audioTracks: PublishedAudioTrack[] | null | undefined;
+  /** FAQ categories from Convex; omit to use client fallback defaults. */
+  readonly faqCategories?: readonly FaqCategoryProps[] | null | undefined;
   readonly banner?: React.ReactNode;
 }
 
@@ -54,6 +56,7 @@ export function HomepageShell({
   gear,
   photos,
   audioTracks,
+  faqCategories,
   banner,
 }: HomepageShellProps) {
   const { scrollY, containerRef } = useScrollAndReveal();
@@ -113,7 +116,13 @@ export function HomepageShell({
           isPreviewRoute={isPreview}
         />
         <AmenitiesNearby />
-        <FAQ />
+        <FAQ
+          categories={
+            faqCategories === undefined || faqCategories === null
+              ? undefined
+              : faqCategories
+          }
+        />
         <ArtistInquiries />
       </main>
 

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -11,6 +11,7 @@ describe("ADMIN_MANAGE_NAV_ITEMS", () => {
       "/admin/videos",
       "/admin/audio",
       "/admin/about",
+      "/admin/faq",
       "/admin/settings",
     ]);
   });

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -7,6 +7,7 @@ import {
   Music,
   User,
   Settings,
+  CircleHelp,
 } from "lucide-react";
 
 /** Shared routes for admin sidebar and dashboard cards (excludes /admin root). */
@@ -53,6 +54,12 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Studio bio & story",
   },
   {
+    title: "FAQ",
+    href: "/admin/faq",
+    icon: CircleHelp,
+    description: "Homepage questions & answers",
+  },
+  {
     title: "Settings",
     href: "/admin/settings",
     icon: Settings,
@@ -70,6 +77,7 @@ export type PendingDraftKey =
   | "pricing"
   | "about"
   | "recordings"
+  | "faq"
   | "gear"
   | "photos";
 
@@ -85,6 +93,7 @@ export const PENDING_SECTION_NAV: Record<
   pricing: { href: "/admin/pricing", label: "Pricing" },
   about: { href: "/admin/about", label: "About" },
   recordings: { href: "/admin/audio", label: "Audio" },
+  faq: { href: "/admin/faq", label: "FAQ" },
   gear: { href: "/admin/gear", label: "Gear" },
   photos: { href: "/admin/photos", label: "Photos" },
 };
@@ -94,6 +103,7 @@ export const PENDING_SECTION_ORDER: readonly PendingDraftKey[] = [
   "settings",
   "pricing",
   "about",
+  "faq",
   "gear",
   "photos",
   "recordings",

--- a/src/lib/route-prewarm.ts
+++ b/src/lib/route-prewarm.ts
@@ -100,6 +100,11 @@ export function prewarmAdminNavigation(
       makeRouteQuerySpec(api.cms.listMarketingFlagsDraft, {}),
     ]);
   }
+  if (href === "/admin/faq") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.cms.getSection, { section: "faq" }),
+    ]);
+  }
   if (href === "/admin/audio") {
     prewarmSpecs(convex, [
       makeRouteQuerySpec(api.cms.listMarketingFlagsDraft, {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements homepage FAQ content in Convex using the same scoped draft/publish pattern as About and Pricing: `faqCategories` and `faqQuestions` tables with `scope: "draft" | "published"`, a new `faq` row in `cmsSections`, and full wiring through `saveDraft`, `getSection`, `publishSection`, `discardDraft`, and `validatePublishSection`.

## Details

- **Schema:** `cmsSectionValidator` includes `literal("faq")`. Validators: `faqQuestionValidator`, `faqCategoryValidator`, `faqContentValidator`, plus `cmsSnapshotValidator` union for admin payloads.
- **Seed:** `internal.seed.seedSiteSettingsDefaults` ensures a `faq` metadata row and seeds published FAQ from `convex/faqSeedData.ts` when empty. **`internal.seed.migrateFaqPublishedIfEmpty`** backfills published FAQ on existing deployments without clobbering authored data.
- **Public / preview:** `api.public.getPublishedFaq` reads published scope (falls back to defaults if empty). `api.faqPreviewDraft.getPreviewFaq` is owner-gated for `/preview`.
- **Frontend:** `/admin/faq` editor (autosave, publish toolbar). Home and preview load FAQ from Convex; `FAQ` still falls back to the same seed data if the query fails or returns empty categories.

## Deployment notes

After deploying Convex schema, run **`bunx convex run internal.seed.migrateFaqPublishedIfEmpty`** once on production if you need published rows without re-running the full site seed.

## Testing

- `bun run lint`
- `bun test`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-121](https://linear.app/only-football-fans/issue/INF-121/lls-faq-section-content-model-convex-draftpublish)

<div><a href="https://cursor.com/agents/bc-c63109b9-2955-4f66-a1f5-20a287ce8776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c63109b9-2955-4f66-a1f5-20a287ce8776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

