### PR TITLE
feat(cms): Amenities nearby Convex draft/publish (INF-122)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,9 @@
 import type * as aboutPreviewDraft from "../aboutPreviewDraft.js";
 import type * as aboutTeamStorage from "../aboutTeamStorage.js";
 import type * as aboutTree from "../aboutTree.js";
+import type * as amenitiesNearbyCms from "../amenitiesNearbyCms.js";
+import type * as amenitiesPreviewDraft from "../amenitiesPreviewDraft.js";
+import type * as amenitiesTree from "../amenitiesTree.js";
 import type * as admin_about from "../admin/about.js";
 import type * as admin_aboutTeam from "../admin/aboutTeam.js";
 import type * as admin_audio from "../admin/audio.js";
@@ -33,6 +36,7 @@ import type * as gearLegacySeed from "../gearLegacySeed.js";
 import type * as gearPreviewDraft from "../gearPreviewDraft.js";
 import type * as gearTree from "../gearTree.js";
 import type * as inquiries from "../inquiries.js";
+import type * as lib_amenitiesUrl from "../lib/amenitiesUrl.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_sentryConvex from "../lib/sentryConvex.js";
 import type * as marketingFeatureFlags from "../marketingFeatureFlags.js";
@@ -59,6 +63,9 @@ declare const fullApi: ApiFromModules<{
   aboutPreviewDraft: typeof aboutPreviewDraft;
   aboutTeamStorage: typeof aboutTeamStorage;
   aboutTree: typeof aboutTree;
+  amenitiesNearbyCms: typeof amenitiesNearbyCms;
+  amenitiesPreviewDraft: typeof amenitiesPreviewDraft;
+  amenitiesTree: typeof amenitiesTree;
   "admin/about": typeof admin_about;
   "admin/aboutTeam": typeof admin_aboutTeam;
   "admin/audio": typeof admin_audio;
@@ -81,6 +88,7 @@ declare const fullApi: ApiFromModules<{
   gearPreviewDraft: typeof gearPreviewDraft;
   gearTree: typeof gearTree;
   inquiries: typeof inquiries;
+  "lib/amenitiesUrl": typeof lib_amenitiesUrl;
   "lib/auth": typeof lib_auth;
   "lib/sentryConvex": typeof lib_sentryConvex;
   marketingFeatureFlags: typeof marketingFeatureFlags;

--- a/convex/amenitiesNearbyCms.ts
+++ b/convex/amenitiesNearbyCms.ts
@@ -1,0 +1,69 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { amenitiesNearbySnapshotValidator } from "./schema.shared";
+import { requireCmsOwner } from "./lib/auth";
+import {
+  effectiveIsEnabled,
+  ensureSectionMetaRow,
+  getSectionMetaRow,
+  publishedIsEnabled,
+  recomputeSectionHasDraftChanges,
+  sectionHasContentDraftDiff,
+} from "./cmsMeta";
+import {
+  loadAmenitiesNearbyTree,
+  replaceAmenitiesNearbyDraft,
+  snapshotFromAmenitiesTree,
+} from "./amenitiesTree";
+
+/**
+ * Owner-only editor payload: published baseline, optional draft overlay, meta.
+ */
+export const getAdminAmenitiesNearby = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const row = await getSectionMetaRow(ctx, "amenitiesNearby");
+    const publishedTree = await loadAmenitiesNearbyTree(ctx, "published");
+    const publishedSnapshot = snapshotFromAmenitiesTree(publishedTree);
+    const hasContentDraft = await sectionHasContentDraftDiff(
+      ctx,
+      "amenitiesNearby",
+    );
+    const draftSnapshot = hasContentDraft
+      ? snapshotFromAmenitiesTree(await loadAmenitiesNearbyTree(ctx, "draft"))
+      : null;
+
+    return {
+      section: "amenitiesNearby" as const,
+      publishedSnapshot,
+      publishedAt: row?.publishedAt ?? null,
+      publishedBy: row?.publishedBy ?? null,
+      draftSnapshot,
+      hasDraftChanges: row?.hasDraftChanges ?? false,
+      updatedAt: row?.updatedAt ?? null,
+      updatedBy: row?.updatedBy ?? null,
+      isEnabled: row
+        ? publishedIsEnabled(row, "amenitiesNearby")
+        : true,
+      isEnabledDraft: effectiveIsEnabled(row ?? null, "amenitiesNearby"),
+    };
+  },
+});
+
+export const saveAmenitiesNearbyDraft = mutation({
+  args: {
+    snapshot: amenitiesNearbySnapshotValidator,
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureSectionMetaRow(ctx, "amenitiesNearby", updatedBy);
+    await replaceAmenitiesNearbyDraft(ctx, args.snapshot);
+    await recomputeSectionHasDraftChanges(ctx, "amenitiesNearby", updatedBy);
+    const row = await getSectionMetaRow(ctx, "amenitiesNearby");
+    return {
+      ok: true as const,
+      hasDraftChanges: row?.hasDraftChanges ?? false,
+    };
+  },
+});

--- a/convex/amenitiesPreviewDraft.ts
+++ b/convex/amenitiesPreviewDraft.ts
@@ -1,0 +1,81 @@
+import { query } from "./_generated/server";
+import { requireCmsOwner } from "./lib/auth";
+import {
+  loadAmenitiesNearbyTree,
+  materializePublicAmenitiesNearby,
+  materializePublicAmenitiesNearbyFromSnapshot,
+} from "./amenitiesTree";
+import { AMENITIES_NEARBY_DEFAULT_ROWS } from "./cmsShared";
+import { effectiveIsEnabled, getSectionMetaRow } from "./cmsMeta";
+
+/**
+ * Owner preview: draft amenities when present, else published (with default-row
+ * fallback when published is empty). Returns `null` for non-owners.
+ */
+export const getPreviewAmenitiesNearby = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const [draftTree, publishedTree, row] = await Promise.all([
+      loadAmenitiesNearbyTree(ctx, "draft"),
+      loadAmenitiesNearbyTree(ctx, "published"),
+      getSectionMetaRow(ctx, "amenitiesNearby"),
+    ]);
+
+    if (!effectiveIsEnabled(row, "amenitiesNearby")) {
+      return {
+        isEnabled: false as const,
+        eyebrow: null as string | null,
+        heading: null as string | null,
+        intro: null as string | null,
+        rows: [] as Array<{
+          stableId: string;
+          name: string;
+          type: string;
+          description: string;
+          website: string;
+        }>,
+        hasDraftChanges: row?.hasDraftChanges ?? false,
+      };
+    }
+
+    const hasDraftRows =
+      draftTree.items.length > 0 || draftTree.copy !== null;
+    const sourceTree = hasDraftRows ? draftTree : publishedTree;
+    const materialized = materializePublicAmenitiesNearby(sourceTree);
+    const withFallback =
+      materialized.rows.length > 0
+        ? materialized
+        : materializePublicAmenitiesNearbyFromSnapshot({
+            ...(sourceTree.copy?.eyebrow !== undefined &&
+            sourceTree.copy.eyebrow.trim().length > 0
+              ? { eyebrow: sourceTree.copy.eyebrow }
+              : {}),
+            ...(sourceTree.copy?.heading !== undefined &&
+            sourceTree.copy.heading.trim().length > 0
+              ? { heading: sourceTree.copy.heading }
+              : {}),
+            ...(sourceTree.copy?.intro !== undefined &&
+            sourceTree.copy.intro.trim().length > 0
+              ? { intro: sourceTree.copy.intro }
+              : {}),
+            rows: AMENITIES_NEARBY_DEFAULT_ROWS,
+          });
+
+    return {
+      isEnabled: true as const,
+      eyebrow: withFallback.eyebrow,
+      heading: withFallback.heading,
+      intro: withFallback.intro,
+      rows: withFallback.rows,
+      hasDraftChanges: row?.hasDraftChanges ?? false,
+    };
+  },
+});

--- a/convex/amenitiesPreviewDraft.ts
+++ b/convex/amenitiesPreviewDraft.ts
@@ -1,11 +1,11 @@
 import { query } from "./_generated/server";
 import { requireCmsOwner } from "./lib/auth";
 import {
+  fallbackAmenitiesSnapshotFromTree,
   loadAmenitiesNearbyTree,
   materializePublicAmenitiesNearby,
   materializePublicAmenitiesNearbyFromSnapshot,
 } from "./amenitiesTree";
-import { AMENITIES_NEARBY_DEFAULT_ROWS } from "./cmsShared";
 import { effectiveIsEnabled, getSectionMetaRow } from "./cmsMeta";
 
 /**
@@ -53,21 +53,9 @@ export const getPreviewAmenitiesNearby = query({
     const withFallback =
       materialized.rows.length > 0
         ? materialized
-        : materializePublicAmenitiesNearbyFromSnapshot({
-            ...(sourceTree.copy?.eyebrow !== undefined &&
-            sourceTree.copy.eyebrow.trim().length > 0
-              ? { eyebrow: sourceTree.copy.eyebrow }
-              : {}),
-            ...(sourceTree.copy?.heading !== undefined &&
-            sourceTree.copy.heading.trim().length > 0
-              ? { heading: sourceTree.copy.heading }
-              : {}),
-            ...(sourceTree.copy?.intro !== undefined &&
-            sourceTree.copy.intro.trim().length > 0
-              ? { intro: sourceTree.copy.intro }
-              : {}),
-            rows: AMENITIES_NEARBY_DEFAULT_ROWS,
-          });
+        : materializePublicAmenitiesNearbyFromSnapshot(
+            fallbackAmenitiesSnapshotFromTree(sourceTree),
+          );
 
     return {
       isEnabled: true as const,

--- a/convex/amenitiesTree.ts
+++ b/convex/amenitiesTree.ts
@@ -1,0 +1,346 @@
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import type { AmenitiesNearbySnapshot } from "./cmsShared";
+import {
+  normalizeAmenitiesWebsiteInput,
+  websiteForStorage,
+} from "./lib/amenitiesUrl";
+
+export type CmsScope = "draft" | "published";
+
+type CopyDoc = Doc<"amenitiesNearbyCopy">;
+type ItemDoc = Doc<"amenitiesNearbyItems">;
+
+export type AmenitiesNearbyTree = {
+  copy: CopyDoc | null;
+  items: ItemDoc[];
+};
+
+function compareBySortThenStableId(
+  a: { sort: number; stableId: string },
+  b: { sort: number; stableId: string },
+): number {
+  return a.sort - b.sort || a.stableId.localeCompare(b.stableId);
+}
+
+export async function loadAmenitiesNearbyCopy(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<CopyDoc | null> {
+  return await ctx.db
+    .query("amenitiesNearbyCopy")
+    .withIndex("by_scope", (q) => q.eq("scope", scope))
+    .unique();
+}
+
+export async function loadAmenitiesNearbyItems(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<ItemDoc[]> {
+  const rows = await ctx.db
+    .query("amenitiesNearbyItems")
+    .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+    .collect();
+  rows.sort(compareBySortThenStableId);
+  return rows;
+}
+
+export async function loadAmenitiesNearbyTree(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsScope,
+): Promise<AmenitiesNearbyTree> {
+  const [copy, items] = await Promise.all([
+    loadAmenitiesNearbyCopy(ctx, scope),
+    loadAmenitiesNearbyItems(ctx, scope),
+  ]);
+  return { copy, items };
+}
+
+function normalizeTreeForCompare(tree: AmenitiesNearbyTree): unknown {
+  const c = tree.copy;
+  return {
+    eyebrow: c?.eyebrow?.trim() ?? null,
+    heading: c?.heading?.trim() ?? null,
+    intro: c?.intro?.trim() ?? null,
+    items: [...tree.items].sort(compareBySortThenStableId).map((r) => ({
+      stableId: r.stableId,
+      name: r.name,
+      type: r.type,
+      description: r.description,
+      website: r.website,
+      sort: r.sort,
+    })),
+  };
+}
+
+export function amenitiesNearbyDraftMatchesPublished(
+  draft: AmenitiesNearbyTree,
+  published: AmenitiesNearbyTree,
+): boolean {
+  return (
+    JSON.stringify(normalizeTreeForCompare(draft)) ===
+    JSON.stringify(normalizeTreeForCompare(published))
+  );
+}
+
+export async function deleteAllAmenitiesItemsForScope(
+  ctx: MutationCtx,
+  scope: CmsScope,
+): Promise<void> {
+  for (;;) {
+    const batch = await ctx.db
+      .query("amenitiesNearbyItems")
+      .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+      .take(100);
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      await ctx.db.delete(row._id);
+    }
+  }
+}
+
+export async function deleteAmenitiesCopyForScope(
+  ctx: MutationCtx,
+  scope: CmsScope,
+): Promise<void> {
+  const row = await loadAmenitiesNearbyCopy(ctx, scope);
+  if (row) await ctx.db.delete(row._id);
+}
+
+export async function copyAmenitiesNearbyScope(
+  ctx: MutationCtx,
+  from: CmsScope,
+  to: CmsScope,
+): Promise<void> {
+  await deleteAmenitiesCopyForScope(ctx, to);
+  await deleteAllAmenitiesItemsForScope(ctx, to);
+
+  const sourceCopy = await loadAmenitiesNearbyCopy(ctx, from);
+  if (sourceCopy) {
+    await ctx.db.insert("amenitiesNearbyCopy", {
+      scope: to,
+      ...(sourceCopy.eyebrow !== undefined ? { eyebrow: sourceCopy.eyebrow } : {}),
+      ...(sourceCopy.heading !== undefined ? { heading: sourceCopy.heading } : {}),
+      ...(sourceCopy.intro !== undefined ? { intro: sourceCopy.intro } : {}),
+    });
+  }
+
+  const sourceItems = await loadAmenitiesNearbyItems(ctx, from);
+  for (const row of sourceItems) {
+    await ctx.db.insert("amenitiesNearbyItems", {
+      scope: to,
+      stableId: row.stableId,
+      name: row.name,
+      type: row.type,
+      description: row.description,
+      website: row.website,
+      sort: row.sort,
+    });
+  }
+}
+
+function trimOpt(s: string | undefined): string | undefined {
+  if (s === undefined) return undefined;
+  const t = s.trim();
+  return t.length === 0 ? undefined : t;
+}
+
+/**
+ * Replace draft-scope amenities content (copy row + item rows).
+ */
+export async function replaceAmenitiesNearbyDraft(
+  ctx: MutationCtx,
+  snapshot: AmenitiesNearbySnapshot,
+): Promise<void> {
+  await deleteAmenitiesCopyForScope(ctx, "draft");
+  await deleteAllAmenitiesItemsForScope(ctx, "draft");
+
+  const eyebrow = trimOpt(snapshot.eyebrow);
+  const heading = trimOpt(snapshot.heading);
+  const intro = trimOpt(snapshot.intro);
+  if (eyebrow !== undefined || heading !== undefined || intro !== undefined) {
+    await ctx.db.insert("amenitiesNearbyCopy", {
+      scope: "draft",
+      ...(eyebrow !== undefined ? { eyebrow } : {}),
+      ...(heading !== undefined ? { heading } : {}),
+      ...(intro !== undefined ? { intro } : {}),
+    });
+  }
+
+  for (let i = 0; i < snapshot.rows.length; i++) {
+    const row = snapshot.rows[i];
+    const normalized = normalizeAmenitiesWebsiteInput(row.website);
+    const websiteStored =
+      normalized !== null ? websiteForStorage(normalized) : "";
+    await ctx.db.insert("amenitiesNearbyItems", {
+      scope: "draft",
+      stableId: row.stableId.trim(),
+      name: row.name.trim(),
+      type: row.type.trim(),
+      description: row.description.trim(),
+      website: websiteStored,
+      sort: i,
+    });
+  }
+}
+
+export function snapshotFromAmenitiesTree(
+  tree: AmenitiesNearbyTree,
+): AmenitiesNearbySnapshot {
+  const c = tree.copy;
+  return {
+    ...(c?.eyebrow !== undefined && c.eyebrow.trim().length > 0
+      ? { eyebrow: c.eyebrow }
+      : {}),
+    ...(c?.heading !== undefined && c.heading.trim().length > 0
+      ? { heading: c.heading }
+      : {}),
+    ...(c?.intro !== undefined && c.intro.trim().length > 0
+      ? { intro: c.intro }
+      : {}),
+    rows: tree.items.map((r) => ({
+      stableId: r.stableId,
+      name: r.name,
+      type: r.type,
+      description: r.description,
+      website: r.website,
+    })),
+  };
+}
+
+export async function collectAmenitiesNearbyPublishIssues(
+  ctx: QueryCtx | MutationCtx,
+): Promise<Array<{ path: string; message: string }>> {
+  const draftTree = await loadAmenitiesNearbyTree(ctx, "draft");
+  const draftHasRows = draftTree.items.length > 0 || draftTree.copy !== null;
+  const tree = draftHasRows
+    ? draftTree
+    : await loadAmenitiesNearbyTree(ctx, "published");
+
+  const issues: Array<{ path: string; message: string }> = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < tree.items.length; i++) {
+    const row = tree.items[i];
+    const base = `rows[${i}]`;
+    if (typeof row.stableId !== "string" || row.stableId.trim().length === 0) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: "Each amenity requires a stable id.",
+      });
+    } else if (seen.has(row.stableId)) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: `Duplicate stable id: ${row.stableId}`,
+      });
+    } else {
+      seen.add(row.stableId);
+    }
+    if (typeof row.name !== "string" || row.name.trim().length === 0) {
+      issues.push({
+        path: `${base}.name`,
+        message: "Display name is required.",
+      });
+    }
+    if (typeof row.type !== "string" || row.type.trim().length === 0) {
+      issues.push({
+        path: `${base}.type`,
+        message: "Category line is required.",
+      });
+    }
+    const normalized = normalizeAmenitiesWebsiteInput(row.website);
+    if (normalized === null) {
+      issues.push({
+        path: `${base}.website`,
+        message: "Enter a valid http(s) URL for the external link.",
+      });
+    }
+  }
+
+  return issues;
+}
+
+export type PublicAmenityCard = {
+  stableId: string;
+  name: string;
+  type: string;
+  description: string;
+  website: string;
+};
+
+export type PublicAmenitiesNearbyPayload = {
+  eyebrow: string | null;
+  heading: string | null;
+  intro: string | null;
+  rows: PublicAmenityCard[];
+};
+
+/**
+ * Published read: drop cards with invalid links; trim optional chrome.
+ */
+/**
+ * Build the public payload from an in-memory snapshot (defaults / fallbacks
+ * without Convex `_id` rows).
+ */
+export function materializePublicAmenitiesNearbyFromSnapshot(
+  snapshot: AmenitiesNearbySnapshot,
+): PublicAmenitiesNearbyPayload {
+  const eyebrow = trimOpt(snapshot.eyebrow) ?? null;
+  const heading = trimOpt(snapshot.heading) ?? null;
+  const intro = trimOpt(snapshot.intro) ?? null;
+  const rows: PublicAmenityCard[] = [];
+  for (const r of snapshot.rows) {
+    const name = r.name.trim();
+    if (name.length === 0) continue;
+    const normalized = normalizeAmenitiesWebsiteInput(r.website);
+    if (normalized === null) continue;
+    const website = websiteForStorage(normalized);
+    rows.push({
+      stableId: r.stableId.trim(),
+      name,
+      type: r.type.trim(),
+      description: r.description.trim(),
+      website,
+    });
+  }
+  return {
+    eyebrow: eyebrow ?? null,
+    heading: heading ?? null,
+    intro: intro ?? null,
+    rows,
+  };
+}
+
+export function materializePublicAmenitiesNearby(
+  tree: AmenitiesNearbyTree,
+): PublicAmenitiesNearbyPayload {
+  const c = tree.copy;
+  const eyebrow =
+    c?.eyebrow !== undefined && c.eyebrow.trim().length > 0
+      ? c.eyebrow.trim()
+      : null;
+  const heading =
+    c?.heading !== undefined && c.heading.trim().length > 0
+      ? c.heading.trim()
+      : null;
+  const intro =
+    c?.intro !== undefined && c.intro.trim().length > 0 ? c.intro.trim() : null;
+
+  const rows: PublicAmenityCard[] = [];
+  for (const r of tree.items) {
+    const name = r.name.trim();
+    if (name.length === 0) continue;
+    const normalized = normalizeAmenitiesWebsiteInput(r.website);
+    if (normalized === null) continue;
+    const website = websiteForStorage(normalized);
+    rows.push({
+      stableId: r.stableId,
+      name,
+      type: r.type.trim(),
+      description: r.description.trim(),
+      website,
+    });
+  }
+
+  return { eyebrow, heading, intro, rows };
+}

--- a/convex/amenitiesTree.ts
+++ b/convex/amenitiesTree.ts
@@ -1,6 +1,9 @@
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
-import type { AmenitiesNearbySnapshot } from "./cmsShared";
+import {
+  AMENITIES_NEARBY_DEFAULT_ROWS,
+  type AmenitiesNearbySnapshot,
+} from "./cmsShared";
 import {
   normalizeAmenitiesWebsiteInput,
   websiteForStorage,
@@ -54,6 +57,32 @@ export async function loadAmenitiesNearbyTree(
     loadAmenitiesNearbyItems(ctx, scope),
   ]);
   return { copy, items };
+}
+
+/** Same URL string written by {@link replaceAmenitiesNearbyDraft} / publish paths. */
+export function amenitiesWebsiteForDbStorage(raw: string): string {
+  const normalized = normalizeAmenitiesWebsiteInput(raw);
+  return normalized !== null ? websiteForStorage(normalized) : "";
+}
+
+/**
+ * Snapshot used when DB rows are empty: optional copy from the tree plus
+ * shipped default cards.
+ */
+export function fallbackAmenitiesSnapshotFromTree(
+  tree: AmenitiesNearbyTree,
+): AmenitiesNearbySnapshot {
+  const c = tree.copy;
+  return {
+    ...(c?.eyebrow !== undefined && c.eyebrow.trim().length > 0
+      ? { eyebrow: c.eyebrow }
+      : {}),
+    ...(c?.heading !== undefined && c.heading.trim().length > 0
+      ? { heading: c.heading }
+      : {}),
+    ...(c?.intro !== undefined && c.intro.trim().length > 0 ? { intro: c.intro } : {}),
+    rows: AMENITIES_NEARBY_DEFAULT_ROWS,
+  };
 }
 
 function normalizeTreeForCompare(tree: AmenitiesNearbyTree): unknown {
@@ -169,16 +198,13 @@ export async function replaceAmenitiesNearbyDraft(
 
   for (let i = 0; i < snapshot.rows.length; i++) {
     const row = snapshot.rows[i];
-    const normalized = normalizeAmenitiesWebsiteInput(row.website);
-    const websiteStored =
-      normalized !== null ? websiteForStorage(normalized) : "";
     await ctx.db.insert("amenitiesNearbyItems", {
       scope: "draft",
       stableId: row.stableId.trim(),
       name: row.name.trim(),
       type: row.type.trim(),
       description: row.description.trim(),
-      website: websiteStored,
+      website: amenitiesWebsiteForDbStorage(row.website),
       sort: i,
     });
   }

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -2,6 +2,7 @@ import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import {
   aboutContentValidator,
+  amenitiesNearbySnapshotValidator,
   cmsSectionValidator,
   pricingContentValidator,
   settingsContentValidator,
@@ -9,6 +10,7 @@ import {
 import {
   defaultSnapshotForSection,
   type AboutSnapshot,
+  type AmenitiesNearbySnapshot,
   type PricingSnapshot,
   type SettingsSnapshot,
 } from "./cmsShared";
@@ -49,6 +51,12 @@ import {
   loadSettingsContent,
   replaceSettingsDraft,
 } from "./settingsTree";
+import {
+  copyAmenitiesNearbyScope,
+  loadAmenitiesNearbyTree,
+  replaceAmenitiesNearbyDraft,
+  snapshotFromAmenitiesTree,
+} from "./amenitiesTree";
 import { cmsValidationError } from "./errors";
 
 /**
@@ -107,6 +115,7 @@ export const saveDraft = mutation({
       settingsContentValidator,
       pricingContentValidator,
       aboutContentValidator,
+      amenitiesNearbySnapshotValidator,
     ),
   },
   handler: async (ctx, args) => {
@@ -123,6 +132,8 @@ export const saveDraft = mutation({
         ?.priceTabEnabled !== undefined;
     const isAboutPayload =
       "heroTitle" in args.content && "body" in args.content;
+    const isAmenitiesPayload =
+      "rows" in args.content && Array.isArray(args.content.rows);
 
     if (args.section === "settings") {
       if (!isSettingsPayload) {
@@ -151,6 +162,13 @@ export const saveDraft = mutation({
           "content",
         );
       }
+    } else if (args.section === "amenitiesNearby") {
+      if (!isAmenitiesPayload) {
+        cmsValidationError(
+          "Amenities content must include a rows array.",
+          "content",
+        );
+      }
     } else {
       cmsValidationError(
         "Recordings has no content; only the visibility flag is editable.",
@@ -168,6 +186,11 @@ export const saveDraft = mutation({
       const beforeUnion = await unionAboutTeamStorage(ctx);
       await replaceAboutDraftFromSnapshot(ctx, args.content as AboutSnapshot);
       await pruneAboutTeamBlobsAfterSaveDraftScoped(ctx, beforeUnion);
+    } else if (args.section === "amenitiesNearby") {
+      await replaceAmenitiesNearbyDraft(
+        ctx,
+        args.content as AmenitiesNearbySnapshot,
+      );
     }
 
     await recomputeSectionHasDraftChanges(ctx, args.section, updatedBy);
@@ -202,7 +225,13 @@ export const listPendingDrafts = query({
     if (identity === null) {
       return {
         sections: [] as Array<
-          "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+          | "settings"
+          | "pricing"
+          | "about"
+          | "recordings"
+          | "amenitiesNearby"
+          | "gear"
+          | "photos"
         >,
       };
     }
@@ -222,7 +251,13 @@ export const listPendingDrafts = query({
     ]);
 
     const sections: Array<
-      "settings" | "pricing" | "about" | "recordings" | "gear" | "photos"
+      | "settings"
+      | "pricing"
+      | "about"
+      | "recordings"
+      | "amenitiesNearby"
+      | "gear"
+      | "photos"
     > = [];
     for (const row of cmsRows) {
       if (row.hasDraftChanges) sections.push(row.section);
@@ -567,6 +602,8 @@ export const discardDraft = mutation({
         await copyPricingScope(ctx, "published", "draft");
       } else if (args.section === "settings") {
         await copySettingsScope(ctx, "published", "draft");
+      } else if (args.section === "amenitiesNearby") {
+        await copyAmenitiesNearbyScope(ctx, "published", "draft");
       }
     }
 
@@ -664,6 +701,11 @@ async function readSnapshotForAdmin(
           }
         : {}),
     } satisfies AboutSnapshot;
+  }
+
+  if (section === "amenitiesNearby") {
+    const tree = await loadAmenitiesNearbyTree(ctx, scope);
+    return snapshotFromAmenitiesTree(tree);
   }
 
   // recordings — flag-only, no content. Return an empty about-shaped default

--- a/convex/cmsMeta.test.ts
+++ b/convex/cmsMeta.test.ts
@@ -32,6 +32,10 @@ describe("DEFAULT_IS_ENABLED", () => {
     expect(DEFAULT_IS_ENABLED.about).toBe(false);
     expect(DEFAULT_IS_ENABLED.recordings).toBe(false);
   });
+
+  test("amenities nearby ships on with the homepage", () => {
+    expect(DEFAULT_IS_ENABLED.amenitiesNearby).toBe(true);
+  });
 });
 
 describe("effectiveIsEnabled", () => {

--- a/convex/cmsMeta.ts
+++ b/convex/cmsMeta.ts
@@ -14,6 +14,10 @@ import {
   loadSettingsContent,
   settingsDraftMatchesPublished,
 } from "./settingsTree";
+import {
+  amenitiesNearbyDraftMatchesPublished,
+  loadAmenitiesNearbyTree,
+} from "./amenitiesTree";
 
 /**
  * Default `isEnabled` value for a brand-new deployment / row. Matches the
@@ -25,6 +29,7 @@ export const DEFAULT_IS_ENABLED: Record<CmsSection, boolean> = {
   pricing: true,
   about: false,
   recordings: false,
+  amenitiesNearby: true,
 };
 
 export async function getSectionMetaRow(
@@ -110,6 +115,13 @@ export async function sectionHasContentDraftDiff(
   section: CmsSection,
 ): Promise<boolean> {
   if (section === "recordings") return false;
+
+  if (section === "amenitiesNearby") {
+    const draft = await loadAmenitiesNearbyTree(ctx, "draft");
+    const published = await loadAmenitiesNearbyTree(ctx, "published");
+    if (draft.items.length === 0 && draft.copy === null) return false;
+    return !amenitiesNearbyDraftMatchesPublished(draft, published);
+  }
 
   if (section === "about") {
     const draft = await loadAboutTree(ctx, "draft");

--- a/convex/cmsMeta.ts
+++ b/convex/cmsMeta.ts
@@ -133,8 +133,8 @@ export async function sectionHasContentDraftDiff(
 
   if (section === "amenitiesNearby") {
     const draft = await loadAmenitiesNearbyTree(ctx, "draft");
-    const published = await loadAmenitiesNearbyTree(ctx, "published");
     if (draft.items.length === 0 && draft.copy === null) return false;
+    const published = await loadAmenitiesNearbyTree(ctx, "published");
     return !amenitiesNearbyDraftMatchesPublished(draft, published);
   }
 

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -19,6 +19,10 @@ import {
 } from "./pricingTree";
 import { copySettingsScope, loadSettingsContent } from "./settingsTree";
 import {
+  collectAmenitiesNearbyPublishIssues,
+  copyAmenitiesNearbyScope,
+} from "./amenitiesTree";
+import {
   DEFAULT_IS_ENABLED,
   effectiveIsEnabled,
   ensureSectionMetaRow,
@@ -291,6 +295,9 @@ export async function collectPublishIssues(
       : await loadAboutTree(ctx, "published");
     return collectAboutIssuesFromTree(ctx, tree);
   }
+  if (section === "amenitiesNearby") {
+    return collectAmenitiesNearbyPublishIssues(ctx);
+  }
   return [];
 }
 
@@ -368,6 +375,8 @@ export async function publishSectionCore(
       await copyPricingScope(ctx, "draft", "published");
     } else if (section === "settings") {
       await copySettingsScope(ctx, "draft", "published");
+    } else if (section === "amenitiesNearby") {
+      await copyAmenitiesNearbyScope(ctx, "draft", "published");
     }
   }
 

--- a/convex/cmsShared.test.ts
+++ b/convex/cmsShared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ABOUT_DEFAULTS,
+  AMENITIES_NEARBY_DEFAULT_ROWS,
   DEFAULT_PRICING_PACKAGES,
   MARKETING_FEATURE_FLAGS_DEFAULTS,
   PRICING_DEFAULTS,
@@ -86,11 +87,24 @@ describe("ABOUT_DEFAULTS", () => {
   });
 });
 
+describe("AMENITIES_NEARBY_DEFAULT_ROWS", () => {
+  test("has four seeded cards with unique stableIds and valid-looking URLs", () => {
+    expect(AMENITIES_NEARBY_DEFAULT_ROWS.length).toBe(4);
+    const ids = AMENITIES_NEARBY_DEFAULT_ROWS.map((r) => r.stableId);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const r of AMENITIES_NEARBY_DEFAULT_ROWS) {
+      expect(r.name.trim().length).toBeGreaterThan(0);
+      expect(r.website.startsWith("http")).toBe(true);
+    }
+  });
+});
+
 describe("defaultSnapshotForSection", () => {
   test("returns the matching defaults for each section", () => {
     expect(defaultSnapshotForSection("settings")).toEqual(SETTINGS_DEFAULTS);
     expect(defaultSnapshotForSection("pricing")).toEqual(PRICING_DEFAULTS);
     expect(defaultSnapshotForSection("about")).toEqual(ABOUT_DEFAULTS);
+    expect(defaultSnapshotForSection("amenitiesNearby")).toEqual({ rows: [] });
   });
 
   test("recordings returns an about-shaped placeholder (no content table)", () => {

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -3,6 +3,7 @@ import type {
   aboutBlockValidator,
   aboutContentValidator,
   aboutTeamMemberValidator,
+  amenitiesNearbySnapshotValidator,
   cmsSectionValidator,
   marketingFeatureFlagsSnapshotValidator,
   pricingBillingCadenceValidator,
@@ -22,7 +23,12 @@ export type CmsSection = Infer<typeof cmsSectionValidator>;
 export type CmsSnapshot =
   | Infer<typeof settingsContentValidator>
   | Infer<typeof pricingContentValidator>
-  | Infer<typeof aboutContentValidator>;
+  | Infer<typeof aboutContentValidator>
+  | Infer<typeof amenitiesNearbySnapshotValidator>;
+
+export type AmenitiesNearbySnapshot = Infer<
+  typeof amenitiesNearbySnapshotValidator
+>;
 
 export type SettingsSnapshot = Infer<typeof settingsContentValidator>;
 export type PricingSnapshot = Infer<typeof pricingContentValidator>;
@@ -150,6 +156,42 @@ export const MARKETING_FEATURE_FLAGS_DEFAULTS: MarketingFeatureFlagsSnapshot = {
  * the published scope of `aboutContent` + `aboutHighlights` + `aboutTeamMembers`
  * so the public route renders before the owner has published.
  */
+/** Initial homepage "Local Favorites" cards (INF-122 seed + public fallback). */
+export const AMENITIES_NEARBY_DEFAULT_ROWS: AmenitiesNearbySnapshot["rows"] = [
+  {
+    stableId: "amenity_masseys_kitchen",
+    name: "Massey's Kitchen",
+    type: "Mediterranean Cuisine",
+    description:
+      "Elevated dining experience featuring made-from-scratch Mediterranean dishes. Authentic flavors crafted with imported ingredients and techniques learned from travels across the Mediterranean region.",
+    website: "https://www.masseyskitchen.com",
+  },
+  {
+    stableId: "amenity_canopy_coffee",
+    name: "Canopy Coffee & Wine Bar",
+    type: "Coffee · Wine · Craft Beer",
+    description:
+      "Authentic Lookout Mountain experience in a casual, cozy atmosphere. Perfect community gathering spot with excellent coffee, local beer selections, and wine in a trendy yet laid-back setting.",
+    website: "https://www.canopylkt.com",
+  },
+  {
+    stableId: "amenity_canyon_grill",
+    name: "Canyon Grill",
+    type: "Fine Dining · Fresh Seafood",
+    description:
+      "Relaxed fine dining featuring sustainably sourced seafood and hickory wood-grilled specialties. Simple, careful preparation highlights natural flavors with ingredients stored on ice for optimal freshness.",
+    website: "https://www.canyongrill.com",
+  },
+  {
+    stableId: "amenity_mountain_escape_spa",
+    name: "Mountain Escape Spa",
+    type: "Spa · Wellness · Relaxation",
+    description:
+      "Full-service spa offering a range of treatments designed to rejuvenate and restore balance. Massages, facials, body treatments, and more, all designed to help guests feel relaxed and refreshed.",
+    website: "https://www.mountainescapespa.com/",
+  },
+];
+
 export const ABOUT_DEFAULTS: AboutSnapshot = {
   heroTitle: "About Lula Lake Sound",
   heroSubtitle: "A creative space for music production and recording.",
@@ -182,6 +224,8 @@ export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
       // `recordings` has no content table; return an empty about-shaped
       // placeholder so the union typechecks. Nothing reads this branch.
       return { ...ABOUT_DEFAULTS };
+    case "amenitiesNearby":
+      return { rows: [] };
   }
 }
 

--- a/convex/lib/amenitiesUrl.test.ts
+++ b/convex/lib/amenitiesUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeAmenitiesWebsiteInput,
+  websiteForStorage,
+} from "./amenitiesUrl";
+
+describe("normalizeAmenitiesWebsiteInput", () => {
+  test("returns null for empty", () => {
+    expect(normalizeAmenitiesWebsiteInput("")).toBeNull();
+    expect(normalizeAmenitiesWebsiteInput("   ")).toBeNull();
+  });
+
+  test("adds https when scheme missing", () => {
+    expect(normalizeAmenitiesWebsiteInput("example.com/foo")).toBe(
+      "https://example.com/foo",
+    );
+  });
+
+  test("accepts http and https", () => {
+    expect(normalizeAmenitiesWebsiteInput("https://a.test")).toBe(
+      "https://a.test/",
+    );
+    expect(normalizeAmenitiesWebsiteInput("http://b.test")).toBe("http://b.test/");
+  });
+
+  test("rejects javascript: URLs", () => {
+    expect(normalizeAmenitiesWebsiteInput("javascript:alert(1)")).toBeNull();
+  });
+});
+
+describe("websiteForStorage", () => {
+  test("upgrades http to https", () => {
+    expect(websiteForStorage("http://canopylkt.com/")).toBe(
+      "https://canopylkt.com/",
+    );
+  });
+});

--- a/convex/lib/amenitiesUrl.ts
+++ b/convex/lib/amenitiesUrl.ts
@@ -1,45 +1,4 @@
-/**
- * Normalize user-entered URLs for amenities (editor + Convex save path).
- * Returns `null` when the value should be treated as "no link" (empty / invalid).
- */
-export function normalizeAmenitiesWebsiteInput(raw: string): string | null {
-  const t = raw.trim();
-  if (t.length === 0) return null;
-
-  let candidate = t;
-  if (!/^[a-zA-Z][a-zA-Z+.-]*:/.test(candidate)) {
-    candidate = `https://${candidate.replace(/^\/+/, "")}`;
-  }
-
-  try {
-    const u = new URL(candidate);
-    if (u.protocol !== "http:" && u.protocol !== "https:") {
-      return null;
-    }
-    if (u.username || u.password) {
-      return null;
-    }
-    const host = u.hostname;
-    if (!host || host === "localhost") {
-      return null;
-    }
-    const out = u.toString();
-    return out.length > 2048 ? null : out;
-  } catch {
-    return null;
-  }
-}
-
-/** Prefer https for storage when the URL parses as http. */
-export function websiteForStorage(normalized: string): string {
-  try {
-    const u = new URL(normalized);
-    if (u.protocol === "http:") {
-      u.protocol = "https:";
-      return u.toString();
-    }
-    return normalized;
-  } catch {
-    return normalized;
-  }
-}
+export {
+  normalizeAmenitiesWebsiteInput,
+  websiteForStorage,
+} from "../../src/lib/amenities-url";

--- a/convex/lib/amenitiesUrl.ts
+++ b/convex/lib/amenitiesUrl.ts
@@ -1,0 +1,45 @@
+/**
+ * Normalize user-entered URLs for amenities (editor + Convex save path).
+ * Returns `null` when the value should be treated as "no link" (empty / invalid).
+ */
+export function normalizeAmenitiesWebsiteInput(raw: string): string | null {
+  const t = raw.trim();
+  if (t.length === 0) return null;
+
+  let candidate = t;
+  if (!/^[a-zA-Z][a-zA-Z+.-]*:/.test(candidate)) {
+    candidate = `https://${candidate.replace(/^\/+/, "")}`;
+  }
+
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return null;
+    }
+    if (u.username || u.password) {
+      return null;
+    }
+    const host = u.hostname;
+    if (!host || host === "localhost") {
+      return null;
+    }
+    const out = u.toString();
+    return out.length > 2048 ? null : out;
+  } catch {
+    return null;
+  }
+}
+
+/** Prefer https for storage when the URL parses as http. */
+export function websiteForStorage(normalized: string): string {
+  try {
+    const u = new URL(normalized);
+    if (u.protocol === "http:") {
+      u.protocol = "https:";
+      return u.toString();
+    }
+    return normalized;
+  } catch {
+    return normalized;
+  }
+}

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -11,11 +11,12 @@ import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
 import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
 import { getSectionMetaRow, publishedIsEnabled } from "./cmsMeta";
 import {
+  fallbackAmenitiesSnapshotFromTree,
   loadAmenitiesNearbyTree,
   materializePublicAmenitiesNearby,
   materializePublicAmenitiesNearbyFromSnapshot,
 } from "./amenitiesTree";
-import { AMENITIES_NEARBY_DEFAULT_ROWS, FAQ_DEFAULTS } from "./cmsShared";
+import { FAQ_DEFAULTS } from "./cmsShared";
 import { loadFaqTree, materializeFaqCategories } from "./faqTree";
 
 /**
@@ -146,18 +147,9 @@ export const getPublishedAmenitiesNearby = query({
     if (out.rows.length === 0) {
       return {
         isEnabled: true as const,
-        ...materializePublicAmenitiesNearbyFromSnapshot({
-          ...(tree.copy?.eyebrow !== undefined && tree.copy.eyebrow.trim().length > 0
-            ? { eyebrow: tree.copy.eyebrow }
-            : {}),
-          ...(tree.copy?.heading !== undefined && tree.copy.heading.trim().length > 0
-            ? { heading: tree.copy.heading }
-            : {}),
-          ...(tree.copy?.intro !== undefined && tree.copy.intro.trim().length > 0
-            ? { intro: tree.copy.intro }
-            : {}),
-          rows: AMENITIES_NEARBY_DEFAULT_ROWS,
-        }),
+        ...materializePublicAmenitiesNearbyFromSnapshot(
+          fallbackAmenitiesSnapshotFromTree(tree),
+        ),
       };
     }
     return { isEnabled: true as const, ...out };

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -10,6 +10,12 @@ import type { Doc } from "./_generated/dataModel";
 import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
 import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
 import { getSectionMetaRow, publishedIsEnabled } from "./cmsMeta";
+import {
+  loadAmenitiesNearbyTree,
+  materializePublicAmenitiesNearby,
+  materializePublicAmenitiesNearbyFromSnapshot,
+} from "./amenitiesTree";
+import { AMENITIES_NEARBY_DEFAULT_ROWS } from "./cmsShared";
 
 /**
  * **Public (anonymous) site reads** — published only.
@@ -114,6 +120,57 @@ export const getPublishedAudioTracks = query({
  * and returns the historical shape `{ aboutPage, recordingsPage, pricingSection }`
  * so the existing frontend consumers keep working without changes.
  */
+/**
+ * Published homepage "Local Favorites" block.
+ * When `isEnabled` is false the section is hidden (empty payload).
+ * When enabled and published rows are empty, falls back to
+ * {@link AMENITIES_NEARBY_DEFAULT_ROWS}.
+ */
+export const getPublishedAmenitiesNearby = query({
+  args: {},
+  handler: async (ctx) => {
+    const row = await getSectionMetaRow(ctx, "amenitiesNearby");
+    if (!publishedIsEnabled(row, "amenitiesNearby")) {
+      return {
+        isEnabled: false as const,
+        eyebrow: null as string | null,
+        heading: null as string | null,
+        intro: null as string | null,
+        rows: [] as Array<{
+          stableId: string;
+          name: string;
+          type: string;
+          description: string;
+          website: string;
+        }>,
+      };
+    }
+    const defaultsPayload = materializePublicAmenitiesNearbyFromSnapshot({
+      rows: AMENITIES_NEARBY_DEFAULT_ROWS,
+    });
+    const tree = await loadAmenitiesNearbyTree(ctx, "published");
+    const out = materializePublicAmenitiesNearby(tree);
+    if (out.rows.length === 0) {
+      return {
+        isEnabled: true as const,
+        ...materializePublicAmenitiesNearbyFromSnapshot({
+          ...(tree.copy?.eyebrow !== undefined && tree.copy.eyebrow.trim().length > 0
+            ? { eyebrow: tree.copy.eyebrow }
+            : {}),
+          ...(tree.copy?.heading !== undefined && tree.copy.heading.trim().length > 0
+            ? { heading: tree.copy.heading }
+            : {}),
+          ...(tree.copy?.intro !== undefined && tree.copy.intro.trim().length > 0
+            ? { intro: tree.copy.intro }
+            : {}),
+          rows: AMENITIES_NEARBY_DEFAULT_ROWS,
+        }),
+      };
+    }
+    return { isEnabled: true as const, ...out };
+  },
+});
+
 export const getPublishedMarketingFeatureFlags = query({
   args: {},
   handler: async (ctx) => {

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -9,6 +9,7 @@ import { v } from "convex/values";
  * - `pricing`    — pricing package catalogue that drives the public pricing block.
  * - `about`      — About page hero copy, body block array, optional highlights, SEO meta, optional team headshots.
  * - `recordings` — public recordings page (flag-only; content lives in `src/app/recordings/recordings-data.ts`).
+ * - `amenitiesNearby` — homepage "Local Favorites" cards (`amenitiesNearbyCopy` + `amenitiesNearbyItems`).
  *
  * Content for each section (when any) lives in dedicated scoped tables using the
  * gear/photos pattern (`scope: "draft" | "published"` column); `cmsSections`
@@ -161,6 +162,7 @@ export const cmsSectionValidator = v.union(
   v.literal("pricing"),
   v.literal("about"),
   v.literal("recordings"),
+  v.literal("amenitiesNearby"),
 );
 
 /**
@@ -226,6 +228,40 @@ export const settingsContentRowValidator = {
   title: v.optional(v.string()),
   description: v.optional(v.string()),
 } as const;
+
+/** Optional section chrome for homepage amenities block — one row per scope. */
+export const amenitiesNearbyCopyRowValidator = {
+  scope: cmsScopeValidator,
+  eyebrow: v.optional(v.string()),
+  heading: v.optional(v.string()),
+  intro: v.optional(v.string()),
+} as const;
+
+/** One amenity card per row; ordered by `sort`. */
+export const amenitiesNearbyItemRowValidator = {
+  scope: cmsScopeValidator,
+  stableId: v.string(),
+  name: v.string(),
+  type: v.string(),
+  description: v.string(),
+  website: v.string(),
+  sort: v.number(),
+} as const;
+
+export const amenitiesNearbyEntryValidator = v.object({
+  stableId: v.string(),
+  name: v.string(),
+  type: v.string(),
+  description: v.string(),
+  website: v.string(),
+});
+
+export const amenitiesNearbySnapshotValidator = v.object({
+  eyebrow: v.optional(v.string()),
+  heading: v.optional(v.string()),
+  intro: v.optional(v.string()),
+  rows: v.array(amenitiesNearbyEntryValidator),
+});
 
 /** Draft vs published rows in `gearCategories` / `gearItems` (INF-86). */
 export const gearScopeValidator = cmsScopeValidator;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,6 +4,8 @@ import {
   aboutContentRowValidator,
   aboutHighlightRowValidator,
   aboutTeamMemberRowValidator,
+  amenitiesNearbyCopyRowValidator,
+  amenitiesNearbyItemRowValidator,
   cmsSectionValidator,
   gearScopeValidator,
   gearSpecsValidator,
@@ -24,6 +26,8 @@ import {
  *   scope onto the published scope in a single mutation.
  * - The `recordings` section is flag-only (no content table); the public page
  *   reads copy from `src/app/recordings/recordings-data.ts`.
+ * - `amenitiesNearby` — homepage local favorites (`amenitiesNearbyCopy` +
+ *   `amenitiesNearbyItems` scoped tables).
  */
 export default defineSchema({
   inquiries: defineTable({
@@ -69,6 +73,15 @@ export default defineSchema({
   settingsContent: defineTable(settingsContentRowValidator).index("by_scope", [
     "scope",
   ]),
+
+  amenitiesNearbyCopy: defineTable(amenitiesNearbyCopyRowValidator).index(
+    "by_scope",
+    ["scope"],
+  ),
+
+  amenitiesNearbyItems: defineTable(amenitiesNearbyItemRowValidator)
+    .index("by_scope_and_sort", ["scope", "sort"])
+    .index("by_scope_and_stableId", ["scope", "stableId"]),
 
   gearMeta: defineTable({
     singletonKey: v.literal("default"),

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import {
   ABOUT_DEFAULTS,
+  AMENITIES_NEARBY_DEFAULT_ROWS,
   DEFAULT_PRICING_PACKAGES,
   SETTINGS_DEFAULTS,
 } from "./cmsShared";
@@ -12,13 +13,17 @@ import {
 import { ABOUT_CONTENT_DEFAULTS, loadAboutContent } from "./aboutTree";
 import { loadPricingPackages } from "./pricingTree";
 import { loadSettingsContent } from "./settingsTree";
+import {
+  loadAmenitiesNearbyCopy,
+  loadAmenitiesNearbyItems,
+} from "./amenitiesTree";
 import { LEGACY_EQUIPMENT_SEED } from "./gearEquipmentSeed";
 import { insertLegacyEquipmentSeedDraft } from "./gearLegacySeed";
 import { deleteAllGearForScope, loadGearDocs } from "./gearTree";
 
 /**
- * Idempotent seed for local dev: creates the four `cmsSections` metadata rows
- * (settings, pricing, about, recordings) and seeds per-section published-scope
+ * Idempotent seed for local dev: creates the five `cmsSections` metadata rows
+ * (settings, pricing, about, recordings, amenitiesNearby) and seeds per-section published-scope
  * content so the admin editors and public queries have a consistent baseline.
  *
  * Run once after deploying schema:
@@ -28,13 +33,24 @@ export const seedSiteSettingsDefaults = internalMutation({
   args: {},
   handler: async (ctx) => {
     type SectionSeedResult = {
-      section: "settings" | "pricing" | "about" | "recordings";
+      section:
+        | "settings"
+        | "pricing"
+        | "about"
+        | "recordings"
+        | "amenitiesNearby";
       status: "already_seeded" | "inserted";
     };
 
     const results: SectionSeedResult[] = [];
 
-    for (const section of ["settings", "pricing", "about", "recordings"] as const) {
+    for (const section of [
+      "settings",
+      "pricing",
+      "about",
+      "recordings",
+      "amenitiesNearby",
+    ] as const) {
       const before = await ctx.db
         .query("cmsSections")
         .withIndex("by_section", (q) => q.eq("section", section))
@@ -102,6 +118,29 @@ export const seedSiteSettingsDefaults = internalMutation({
           sortOrder: pkg.sortOrder,
           isActive: pkg.isActive,
           ...(pkg.features !== undefined ? { features: pkg.features } : {}),
+        });
+      }
+    }
+
+    const amenitiesCopyPublished = await loadAmenitiesNearbyCopy(
+      ctx,
+      "published",
+    );
+    const amenitiesItemsPublished = await loadAmenitiesNearbyItems(
+      ctx,
+      "published",
+    );
+    if (amenitiesCopyPublished === null && amenitiesItemsPublished.length === 0) {
+      for (let i = 0; i < AMENITIES_NEARBY_DEFAULT_ROWS.length; i++) {
+        const row = AMENITIES_NEARBY_DEFAULT_ROWS[i];
+        await ctx.db.insert("amenitiesNearbyItems", {
+          scope: "published",
+          stableId: row.stableId,
+          name: row.name,
+          type: row.type,
+          description: row.description,
+          website: row.website,
+          sort: i,
         });
       }
     }

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -15,6 +15,7 @@ import { ABOUT_CONTENT_DEFAULTS, loadAboutContent } from "./aboutTree";
 import { loadPricingPackages } from "./pricingTree";
 import { loadSettingsContent } from "./settingsTree";
 import {
+  amenitiesWebsiteForDbStorage,
   loadAmenitiesNearbyCopy,
   loadAmenitiesNearbyItems,
 } from "./amenitiesTree";
@@ -153,7 +154,7 @@ export const seedSiteSettingsDefaults = internalMutation({
           name: row.name,
           type: row.type,
           description: row.description,
-          website: row.website,
+          website: amenitiesWebsiteForDbStorage(row.website),
           sort: i,
         });
       }

--- a/src/app/admin/amenities-nearby/amenities-editor-skeleton.tsx
+++ b/src/app/admin/amenities-nearby/amenities-editor-skeleton.tsx
@@ -1,0 +1,9 @@
+export function AmenitiesEditorSkeleton() {
+  return (
+    <div className="animate-pulse space-y-6">
+      <div className="h-10 w-full max-w-md rounded-md bg-muted" />
+      <div className="h-32 w-full rounded-md bg-muted" />
+      <div className="h-48 w-full rounded-md bg-muted" />
+    </div>
+  );
+}

--- a/src/app/admin/amenities-nearby/amenities-editor.tsx
+++ b/src/app/admin/amenities-nearby/amenities-editor.tsx
@@ -1,0 +1,530 @@
+"use client";
+
+import {
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useMutation,
+  useQuery,
+} from "convex/react";
+import { useUser } from "@clerk/nextjs";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
+import { api } from "../../../../convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { convexMutationEffect } from "@/lib/effect-errors";
+import { runAdminEffect } from "@/lib/admin-run-effect";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
+import { useAutosaveDraft } from "@/lib/use-autosave-draft";
+import {
+  normalizeAmenitiesWebsiteInput,
+  websiteForStorage,
+} from "@/lib/amenities-url";
+import { Effect } from "effect";
+import { ValidationError } from "@/lib/effect-errors";
+
+export type AmenityRow = {
+  stableId: string;
+  name: string;
+  type: string;
+  description: string;
+  website: string;
+};
+
+export type AmenitiesNearbyEditorSnapshot = {
+  eyebrow?: string;
+  heading?: string;
+  intro?: string;
+  rows: AmenityRow[];
+};
+
+const FIELD_CLASS =
+  "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/50";
+
+function generateStableId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `amenity_${crypto.randomUUID()}`;
+  }
+  return `amenity_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+function cloneSnapshot(s: AmenitiesNearbyEditorSnapshot): AmenitiesNearbyEditorSnapshot {
+  return {
+    ...(s.eyebrow !== undefined ? { eyebrow: s.eyebrow } : {}),
+    ...(s.heading !== undefined ? { heading: s.heading } : {}),
+    ...(s.intro !== undefined ? { intro: s.intro } : {}),
+    rows: s.rows.map((r) => ({ ...r })),
+  };
+}
+
+function snapshotFromServer(
+  published: AmenitiesNearbyEditorSnapshot,
+  draft: AmenitiesNearbyEditorSnapshot | null,
+): AmenitiesNearbyEditorSnapshot {
+  if (draft) return cloneSnapshot(draft);
+  return cloneSnapshot(published);
+}
+
+export function AmenitiesEditor() {
+  return (
+    <>
+      <AuthLoading>
+        <p className="body-text text-muted-foreground">Authenticating…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <p className="body-text text-muted-foreground">
+          Sign in to edit amenities.
+        </p>
+      </Unauthenticated>
+      <Authenticated>
+        <AmenitiesForm />
+      </Authenticated>
+    </>
+  );
+}
+
+function AmenitiesForm() {
+  const { user } = useUser();
+  const data = useQuery(api.amenitiesNearbyCms.getAdminAmenitiesNearby);
+  const saveDraft = useMutation(api.amenitiesNearbyCms.saveAmenitiesNearbyDraft);
+  const saveFlag = useMutation(api.cms.saveSectionIsEnabledDraft);
+  const publish = useMutation(api.admin.publish.publish);
+  const discard = useMutation(api.cms.discardDraft);
+  const validate = useQuery(api.cms.validatePublishSection, {
+    section: "amenitiesNearby",
+  });
+
+  const [localSnapshot, setLocalSnapshot] =
+    useState<AmenitiesNearbyEditorSnapshot | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const kickAutosaveRef = useRef<() => void>(() => {});
+  const cancelAutosaveRef = useRef<() => void>(() => {});
+
+  const serverSnapshot = useMemo((): AmenitiesNearbyEditorSnapshot | undefined => {
+    if (!data) return undefined;
+    return snapshotFromServer(
+      data.publishedSnapshot as AmenitiesNearbyEditorSnapshot,
+      data.draftSnapshot as AmenitiesNearbyEditorSnapshot | null,
+    );
+  }, [data]);
+
+  const source = localSnapshot ?? serverSnapshot;
+
+  const hasLocalEdits = localSnapshot !== null;
+  const hasDraftOnServer = data?.hasDraftChanges ?? false;
+
+  const saveEffect = useCallback(() => {
+    if (!source) {
+      return Effect.fail(
+        new ValidationError({
+          message: "Nothing to save.",
+          field: "snapshot",
+        }),
+      );
+    }
+    return convexMutationEffect(() =>
+      saveDraft({ snapshot: source }),
+    );
+  }, [saveDraft, source]);
+
+  const {
+    status: autosaveStatus,
+    kick,
+    cancel: cancelAutosave,
+    flush: flushAutosave,
+    onUnmount: autosaveOnUnmount,
+  } = useAutosaveDraft({
+    isDirty: hasLocalEdits,
+    saveEffect,
+    onSaved: () => setLocalSnapshot(null),
+    pauseWhen: busy !== null,
+  });
+
+  kickAutosaveRef.current = kick;
+  cancelAutosaveRef.current = cancelAutosave;
+
+  const mutate = useCallback(
+    (next: AmenitiesNearbyEditorSnapshot) => {
+      setInlineError(null);
+      setLocalSnapshot(next);
+      kickAutosaveRef.current();
+    },
+    [],
+  );
+
+  const setSectionVisible = useCallback(
+    (enabled: boolean) => {
+      void runAdminEffect(convexMutationEffect(() =>
+        saveFlag({ section: "amenitiesNearby", isEnabled: enabled }),
+      ), { onErrorMessage: setInlineError });
+    },
+    [saveFlag],
+  );
+
+  const addRow = useCallback(() => {
+    if (!source) return;
+    mutate({
+      ...source,
+      rows: [
+        ...source.rows,
+        {
+          stableId: generateStableId(),
+          name: "New place",
+          type: "",
+          description: "",
+          website: "",
+        },
+      ],
+    });
+  }, [source, mutate]);
+
+  const updateRow = useCallback(
+    (stableId: string, patch: Partial<AmenityRow>) => {
+      if (!source) return;
+      mutate({
+        ...source,
+        rows: source.rows.map((r) =>
+          r.stableId === stableId ? { ...r, ...patch } : r,
+        ),
+      });
+    },
+    [source, mutate],
+  );
+
+  const removeRow = useCallback(
+    (stableId: string) => {
+      if (!source) return;
+      mutate({
+        ...source,
+        rows: source.rows.filter((r) => r.stableId !== stableId),
+      });
+    },
+    [source, mutate],
+  );
+
+  const moveRow = useCallback(
+    (index: number, dir: -1 | 1) => {
+      if (!source) return;
+      const j = index + dir;
+      if (j < 0 || j >= source.rows.length) return;
+      const next = [...source.rows];
+      const t = next[index];
+      const u = next[j];
+      if (t === undefined || u === undefined) return;
+      next[index] = u;
+      next[j] = t;
+      mutate({ ...source, rows: next });
+    },
+    [source, mutate],
+  );
+
+  const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
+    cancelAutosaveRef.current();
+    setInlineError(null);
+    setBusy("Discarding…");
+    const outcome = await runAdminEffect(
+      convexMutationEffect(() =>
+        discard({ section: "amenitiesNearby" }),
+      ),
+      { onErrorMessage: setInlineError },
+    );
+    setBusy(null);
+    if (outcome === undefined) return false;
+    setLocalSnapshot(null);
+    toast.success("Draft discarded.");
+    return true;
+  }, [discard]);
+
+  const handlePublish = useCallback(() => {
+    void (async () => {
+      cancelAutosaveRef.current();
+      if (hasLocalEdits) {
+        const flushed = await flushAutosave();
+        if (!flushed) return;
+      }
+      setInlineError(null);
+      setBusy("Publishing…");
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() =>
+          publish({ section: "amenitiesNearby" }),
+        ),
+        { onErrorMessage: setInlineError },
+      );
+      setBusy(null);
+      if (outcome !== undefined) {
+        setLocalSnapshot(null);
+        toast.success("Amenities published.");
+      }
+    })();
+  }, [flushAutosave, hasLocalEdits, publish]);
+
+  const publishedByLabel =
+    data?.publishedBy && user?.id === data.publishedBy ? "You" : undefined;
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "amenitiesNearby",
+    sectionLabel: "amenities nearby",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt: data?.publishedAt ?? null,
+    publishedByLabel,
+    busy,
+    autosaveStatus,
+    inlineError,
+    previewHref: "/preview#local-favorites",
+    onPublish: handlePublish,
+    onDiscardConfirm: handleDiscardConfirm,
+    flush: flushAutosave,
+  });
+
+  const handleEditorRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      autosaveOnUnmount(el);
+      editorRef(el);
+    },
+    [autosaveOnUnmount, editorRef],
+  );
+
+  if (data === undefined) {
+    return <p className="body-text text-muted-foreground">Loading…</p>;
+  }
+
+  if (!source) {
+    return (
+      <p className="body-text text-muted-foreground">No data available.</p>
+    );
+  }
+
+  const sectionVisible = data.isEnabledDraft;
+
+  return (
+    <div className="space-y-10 pb-24" ref={handleEditorRef}>
+      {toolbarPortal}
+
+      <fieldset className="space-y-4">
+        <legend className="label-text text-muted-foreground">Site visibility</legend>
+        <div className="flex items-start gap-3">
+          <Switch
+            id="amenities-section-visible"
+            checked={sectionVisible}
+            onCheckedChange={setSectionVisible}
+          />
+          <div className="space-y-1">
+            <label
+              htmlFor="amenities-section-visible"
+              className="body-text-small cursor-pointer text-foreground"
+            >
+              Show “Local favorites” block on homepage
+            </label>
+            <p className="body-text-small text-muted-foreground">
+              When off, the block is hidden from the public site (preview still
+              respects draft visibility for owners).
+            </p>
+          </div>
+        </div>
+      </fieldset>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Section labels (optional)</h2>
+        <p className="body-text-small text-muted-foreground">
+          Leave blank to use the default eyebrow, heading, and no intro paragraph
+          on the marketing site.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">
+              Eyebrow
+            </span>
+            <Input
+              className={FIELD_CLASS}
+              value={source.eyebrow ?? ""}
+              onChange={(e) =>
+                mutate({ ...source, eyebrow: e.target.value })
+              }
+              placeholder="Local Favorites"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">
+              Heading
+            </span>
+            <Input
+              className={FIELD_CLASS}
+              value={source.heading ?? ""}
+              onChange={(e) =>
+                mutate({ ...source, heading: e.target.value })
+              }
+              placeholder="Amenities Nearby"
+            />
+          </label>
+        </div>
+        <label className="space-y-1 block">
+          <span className="text-xs font-medium text-muted-foreground">
+            Intro (optional)
+          </span>
+          <Textarea
+            className={cn(FIELD_CLASS, "min-h-[88px]")}
+            value={source.intro ?? ""}
+            onChange={(e) => mutate({ ...source, intro: e.target.value })}
+            placeholder="Short line under the heading…"
+          />
+        </label>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">Places</h2>
+            <p className="body-text-small text-muted-foreground">
+              Ordered list of cards. Website must be a valid http(s) URL to
+              publish (saved drafts may omit until you are ready).
+            </p>
+          </div>
+          <Button type="button" variant="outline" onClick={addRow}>
+            <Plus className="mr-1 size-4" aria-hidden />
+            Add place
+          </Button>
+        </div>
+
+        {validate && !validate.ok ? (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm"
+            role="status"
+          >
+            <p className="font-medium text-destructive mb-2">
+              Fix before publishing:
+            </p>
+            <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
+              {validate.issues.map((issue, i) => (
+                <li key={i}>
+                  <span className="font-mono text-xs">{issue.path}</span> —{" "}
+                  {issue.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {source.rows.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            No cards yet. Add a place or run the site seed to load defaults.
+          </p>
+        ) : (
+          <ul className="space-y-6">
+            {source.rows.map((row, index) => (
+              <li
+                key={row.stableId}
+                className="rounded-lg border border-border bg-background p-4 shadow-sm space-y-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-mono text-xs text-muted-foreground">
+                    #{index + 1}
+                  </span>
+                  <div className="flex flex-wrap gap-1">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      aria-label="Move up"
+                      disabled={index === 0}
+                      onClick={() => moveRow(index, -1)}
+                    >
+                      <ArrowUp className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      aria-label="Move down"
+                      disabled={index === source.rows.length - 1}
+                      onClick={() => moveRow(index, 1)}
+                    >
+                      <ArrowDown className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className="text-destructive"
+                      aria-label="Remove"
+                      onClick={() => removeRow(row.stableId)}
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </div>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="space-y-1 sm:col-span-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Name
+                    </span>
+                    <Input
+                      className={FIELD_CLASS}
+                      value={row.name}
+                      onChange={(e) =>
+                        updateRow(row.stableId, { name: e.target.value })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 sm:col-span-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Type / category line
+                    </span>
+                    <Input
+                      className={FIELD_CLASS}
+                      value={row.type}
+                      onChange={(e) =>
+                        updateRow(row.stableId, { type: e.target.value })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 sm:col-span-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Description
+                    </span>
+                    <Textarea
+                      className={cn(FIELD_CLASS, "min-h-[100px]")}
+                      value={row.description}
+                      onChange={(e) =>
+                        updateRow(row.stableId, {
+                          description: e.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 sm:col-span-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Website URL
+                    </span>
+                    <Input
+                      className={FIELD_CLASS}
+                      value={row.website}
+                      onChange={(e) =>
+                        updateRow(row.stableId, { website: e.target.value })
+                      }
+                      onBlur={() => {
+                        const n = normalizeAmenitiesWebsiteInput(row.website);
+                        if (n !== null) {
+                          updateRow(row.stableId, {
+                            website: websiteForStorage(n),
+                          });
+                        }
+                      }}
+                      placeholder="https://…"
+                    />
+                  </label>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/amenities-nearby/page.tsx
+++ b/src/app/admin/amenities-nearby/page.tsx
@@ -1,0 +1,27 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { AmenitiesEditorSkeleton } from "./amenities-editor-skeleton";
+
+const AmenitiesEditor = dynamic(
+  () =>
+    import("./amenities-editor").then((m) => ({ default: m.AmenitiesEditor })),
+  { loading: () => <AmenitiesEditorSkeleton /> },
+);
+
+export const metadata: Metadata = {
+  title: "Amenities nearby",
+};
+
+export default function AmenitiesNearbyAdminPage() {
+  return (
+    <>
+      <AdminHeader title="Amenities nearby" />
+      <div className="flex-1 p-6">
+        <div className="mx-auto max-w-3xl">
+          <AmenitiesEditor />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "convex/react";
 import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import { PreviewBanner } from "@/components/preview-banner";
 import type { PublishedAudioTrack } from "@/components/audio-portfolio";
 
@@ -18,6 +19,9 @@ function PreviewContent() {
   // preview banner can reflect it. Owner-only — returns `null` for non-owners.
   const aboutPreview = useQuery(api.aboutPreviewDraft.getPreviewAbout);
   const marketingPreview = useQuery(api.cms.getPreviewMarketingFeatureFlags);
+  const amenitiesPreview = useQuery(
+    api.amenitiesPreviewDraft.getPreviewAmenitiesNearby,
+  );
 
   if (
     pricingFlags === undefined ||
@@ -25,7 +29,8 @@ function PreviewContent() {
     photoPreview === undefined ||
     audioPreview === undefined ||
     aboutPreview === undefined ||
-    marketingPreview === undefined
+    marketingPreview === undefined ||
+    amenitiesPreview === undefined
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
@@ -40,7 +45,8 @@ function PreviewContent() {
     photoPreview === null ||
     audioPreview === null ||
     aboutPreview === null ||
-    marketingPreview === null
+    marketingPreview === null ||
+    amenitiesPreview === null
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-washed-black">
@@ -57,7 +63,16 @@ function PreviewContent() {
     photoPreview.hasDraftChanges ||
     audioPreview.hasDraftChanges ||
     aboutPreview.hasDraftChanges ||
-    marketingPreview.hasDraftChanges;
+    marketingPreview.hasDraftChanges ||
+    amenitiesPreview.hasDraftChanges;
+
+  const amenitiesPayload: PublishedAmenitiesNearby = {
+    isEnabled: amenitiesPreview.isEnabled,
+    eyebrow: amenitiesPreview.eyebrow,
+    heading: amenitiesPreview.heading,
+    intro: amenitiesPreview.intro,
+    rows: amenitiesPreview.rows,
+  };
 
   const audioTracks: PublishedAudioTrack[] = audioPreview.tracks
     .filter((t): t is typeof t & { url: string } => t.url !== null)
@@ -91,6 +106,7 @@ function PreviewContent() {
       gear={{ categories: gearPreview.categories }}
       photos={photoPreview.photos}
       audioTracks={audioTracks}
+      amenities={amenitiesPayload}
       banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />
   );

--- a/src/components/amenities-nearby.tsx
+++ b/src/components/amenities-nearby.tsx
@@ -1,37 +1,65 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
 import { AmenityCard } from "./ui/amenity-card";
 
-const AMENITIES_DATA = [
-  {
-    name: "Massey's Kitchen",
-    type: "Mediterranean Cuisine",
-    description:
-      "Elevated dining experience featuring made-from-scratch Mediterranean dishes. Authentic flavors crafted with imported ingredients and techniques learned from travels across the Mediterranean region.",
-    website: "https://www.masseyskitchen.com",
-  },
-  {
-    name: "Canopy Coffee & Wine Bar",
-    type: "Coffee \u00B7 Wine \u00B7 Craft Beer",
-    description:
-      "Authentic Lookout Mountain experience in a casual, cozy atmosphere. Perfect community gathering spot with excellent coffee, local beer selections, and wine in a trendy yet laid-back setting.",
-    website: "http://www.canopylkt.com",
-  },
-  {
-    name: "Canyon Grill",
-    type: "Fine Dining \u00B7 Fresh Seafood",
-    description:
-      "Relaxed fine dining featuring sustainably sourced seafood and hickory wood-grilled specialties. Simple, careful preparation highlights natural flavors with ingredients stored on ice for optimal freshness.",
-    website: "https://www.canyongrill.com",
-  },
-  {
-    name: "Mountain Escape Spa",
-    type: "Spa \u00B7 Wellness \u00B7 Relaxation",
-    description:
-      "Full-service spa offering a range of treatments designed to rejuvenate and restore balance. Massages, facials, body treatments, and more, all designed to help guests feel relaxed and refreshed.",
-    website: "https://www.mountainescapespa.com/",
-  },
-] as const;
+const STATIC_EYEBROW = "Local Favorites";
+const STATIC_HEADING = "Amenities Nearby";
 
-export function AmenitiesNearby() {
+export type PublishedAmenitiesNearby = {
+  readonly isEnabled: boolean;
+  readonly eyebrow: string | null;
+  readonly heading: string | null;
+  readonly intro: string | null;
+  readonly rows: ReadonlyArray<{
+    readonly stableId: string;
+    readonly name: string;
+    readonly type: string;
+    readonly description: string;
+    readonly website: string;
+  }>;
+};
+
+type AmenitiesNearbyProps = {
+  /** When provided (e.g. preview), skips the public Convex subscription. */
+  readonly amenities?: PublishedAmenitiesNearby | null | undefined;
+};
+
+export function AmenitiesNearby({ amenities: amenitiesFromProps }: AmenitiesNearbyProps) {
+  const live = useQuery(
+    api.public.getPublishedAmenitiesNearby,
+    amenitiesFromProps !== undefined ? "skip" : {},
+  );
+  const data =
+    amenitiesFromProps !== undefined ? amenitiesFromProps : live;
+
+  if (data === undefined) {
+    return (
+      <section
+        id="local-favorites"
+        className="relative overflow-hidden bg-forest px-6 py-28 md:py-40"
+      >
+        <div className="absolute inset-0 bg-texture-canvas opacity-14" />
+        <div className="relative z-10 mx-auto max-w-6xl">
+          <div className="h-48 animate-pulse rounded-md bg-warm-white/5" />
+        </div>
+      </section>
+    );
+  }
+
+  if (data === null) {
+    return null;
+  }
+
+  if (!data.isEnabled || data.rows.length === 0) {
+    return null;
+  }
+
+  const eyebrow = data.eyebrow?.trim() || STATIC_EYEBROW;
+  const heading = data.heading?.trim() || STATIC_HEADING;
+  const intro = data.intro?.trim();
+
   return (
     <section
       id="local-favorites"
@@ -41,17 +69,22 @@ export function AmenitiesNearby() {
 
       <div className="relative z-10 mx-auto max-w-6xl">
         <div className="reveal mb-20 text-center">
-          <p className="eyebrow mb-6 text-sand/82">Local Favorites</p>
+          <p className="eyebrow mb-6 text-sand/82">{eyebrow}</p>
           <h2 className="headline-primary mb-8 text-[2.25rem] text-warm-white md:text-[3rem] lg:text-[3.5rem]">
-            Amenities Nearby
+            {heading}
           </h2>
+          {intro ? (
+            <p className="body-text-small mx-auto mb-8 max-w-2xl text-ivory/78">
+              {intro}
+            </p>
+          ) : null}
           <div className="section-rule mx-auto max-w-[9rem]" />
         </div>
 
         <div className="reveal reveal-delay-2 grid grid-cols-1 divide-y divide-sand/14 border-y border-sand/14 md:grid-cols-2 md:divide-x md:divide-y-0 lg:grid-cols-4 [&>*:nth-child(n+3)]:border-t [&>*:nth-child(n+3)]:border-sand/14 lg:[&>*:nth-child(n+3)]:border-t-0">
-          {AMENITIES_DATA.map((amenity, index) => (
+          {data.rows.map((amenity) => (
             <AmenityCard
-              key={index}
+              key={amenity.stableId}
               name={amenity.name}
               type={amenity.type}
               description={amenity.description}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -15,6 +15,7 @@ import {
   AudioPortfolio,
   type PublishedAudioTrack,
 } from "@/components/audio-portfolio";
+import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import { TheSpace, type GalleryPhoto } from "@/components/the-space";
 import { useScrollAndReveal } from "@/hooks/use-scroll-and-reveal";
 import {
@@ -45,6 +46,8 @@ interface HomepageShellProps {
   readonly photos: GalleryPhoto[] | null | undefined;
   /** Published (or preview) audio portfolio; empty array hides the section. */
   readonly audioTracks: PublishedAudioTrack[] | null | undefined;
+  /** When set (e.g. preview), skips live public subscription for amenities. */
+  readonly amenities?: PublishedAmenitiesNearby | null | undefined;
   readonly banner?: React.ReactNode;
 }
 
@@ -54,6 +57,7 @@ export function HomepageShell({
   gear,
   photos,
   audioTracks,
+  amenities,
   banner,
 }: HomepageShellProps) {
   const { scrollY, containerRef } = useScrollAndReveal();
@@ -112,7 +116,7 @@ export function HomepageShell({
           marketingFeatureFlags={marketing ?? null}
           isPreviewRoute={isPreview}
         />
-        <AmenitiesNearby />
+        <AmenitiesNearby amenities={amenities} />
         <FAQ />
         <ArtistInquiries />
       </main>

--- a/src/components/ui/amenity-card.tsx
+++ b/src/components/ui/amenity-card.tsx
@@ -2,8 +2,12 @@ interface AmenityCardProps {
   readonly name: string;
   readonly type: string;
   readonly description: string;
+  /** When empty, the card renders as static content (no outer link). */
   readonly website: string;
 }
+
+const cardClassName =
+  "group flex h-full flex-col justify-between gap-8 p-8 transition-colors duration-500 md:p-10";
 
 /**
  * Editorial amenity entry.
@@ -17,13 +21,9 @@ export function AmenityCard({
   description,
   website,
 }: AmenityCardProps) {
-  return (
-    <a
-      href={website}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex h-full flex-col justify-between gap-8 p-8 transition-colors duration-500 md:p-10"
-    >
+  const href = website.trim();
+  const body = (
+    <>
       <div>
         <p className="eyebrow mb-4 text-ivory/68 transition-colors duration-500 group-hover:text-sand/90">
           {type}
@@ -38,23 +38,40 @@ export function AmenityCard({
         {description}
       </p>
 
-      <span className="label-text inline-flex items-center gap-2 text-[10px] text-sand/75 transition-colors duration-500 group-hover:text-sand">
-        Visit
-        <svg
-          className="size-3 transition-transform duration-500 group-hover:translate-x-1"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.25}
-            d="M17 8l4 4m0 0l-4 4m4-4H3"
-          />
-        </svg>
-      </span>
+      {href.length > 0 ? (
+        <span className="label-text inline-flex items-center gap-2 text-[10px] text-sand/75 transition-colors duration-500 group-hover:text-sand">
+          Visit
+          <svg
+            className="size-3 transition-transform duration-500 group-hover:translate-x-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.25}
+              d="M17 8l4 4m0 0l-4 4m4-4H3"
+            />
+          </svg>
+        </span>
+      ) : null}
+    </>
+  );
+
+  if (href.length === 0) {
+    return <div className={cardClassName}>{body}</div>;
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cardClassName}
+    >
+      {body}
     </a>
   );
 }

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -11,6 +11,7 @@ describe("ADMIN_MANAGE_NAV_ITEMS", () => {
       "/admin/videos",
       "/admin/audio",
       "/admin/about",
+      "/admin/amenities-nearby",
       "/admin/settings",
     ]);
   });

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -7,6 +7,7 @@ import {
   Music,
   User,
   Settings,
+  MapPin,
 } from "lucide-react";
 
 /** Shared routes for admin sidebar and dashboard cards (excludes /admin root). */
@@ -53,6 +54,12 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Studio bio & story",
   },
   {
+    title: "Amenities nearby",
+    href: "/admin/amenities-nearby",
+    icon: MapPin,
+    description: "Local favorites on the homepage",
+  },
+  {
     title: "Settings",
     href: "/admin/settings",
     icon: Settings,
@@ -70,6 +77,7 @@ export type PendingDraftKey =
   | "pricing"
   | "about"
   | "recordings"
+  | "amenitiesNearby"
   | "gear"
   | "photos";
 
@@ -85,6 +93,10 @@ export const PENDING_SECTION_NAV: Record<
   pricing: { href: "/admin/pricing", label: "Pricing" },
   about: { href: "/admin/about", label: "About" },
   recordings: { href: "/admin/audio", label: "Audio" },
+  amenitiesNearby: {
+    href: "/admin/amenities-nearby",
+    label: "Amenities nearby",
+  },
   gear: { href: "/admin/gear", label: "Gear" },
   photos: { href: "/admin/photos", label: "Photos" },
 };
@@ -94,6 +106,7 @@ export const PENDING_SECTION_ORDER: readonly PendingDraftKey[] = [
   "settings",
   "pricing",
   "about",
+  "amenitiesNearby",
   "gear",
   "photos",
   "recordings",

--- a/src/lib/amenities-url.ts
+++ b/src/lib/amenities-url.ts
@@ -1,6 +1,6 @@
 /**
- * Client-side URL normalization for the amenities editor (mirrors
- * `convex/lib/amenitiesUrl.ts`).
+ * Normalize user-entered URLs for amenities (editor + Convex save path).
+ * Returns `null` when the value should be treated as "no link" (empty / invalid).
  */
 export function normalizeAmenitiesWebsiteInput(raw: string): string | null {
   const t = raw.trim();
@@ -30,6 +30,7 @@ export function normalizeAmenitiesWebsiteInput(raw: string): string | null {
   }
 }
 
+/** Prefer https for storage when the URL parses as http. */
 export function websiteForStorage(normalized: string): string {
   try {
     const u = new URL(normalized);

--- a/src/lib/amenities-url.ts
+++ b/src/lib/amenities-url.ts
@@ -1,0 +1,44 @@
+/**
+ * Client-side URL normalization for the amenities editor (mirrors
+ * `convex/lib/amenitiesUrl.ts`).
+ */
+export function normalizeAmenitiesWebsiteInput(raw: string): string | null {
+  const t = raw.trim();
+  if (t.length === 0) return null;
+
+  let candidate = t;
+  if (!/^[a-zA-Z][a-zA-Z+.-]*:/.test(candidate)) {
+    candidate = `https://${candidate.replace(/^\/+/, "")}`;
+  }
+
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return null;
+    }
+    if (u.username || u.password) {
+      return null;
+    }
+    const host = u.hostname;
+    if (!host || host === "localhost") {
+      return null;
+    }
+    const out = u.toString();
+    return out.length > 2048 ? null : out;
+  } catch {
+    return null;
+  }
+}
+
+export function websiteForStorage(normalized: string): string {
+  try {
+    const u = new URL(normalized);
+    if (u.protocol === "http:") {
+      u.protocol = "https:";
+      return u.toString();
+    }
+    return normalized;
+  } catch {
+    return normalized;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements INF-122: homepage “Local Favorites / amenities nearby” is backed by Convex with the same draft/publish/discard model as other `cmsSections`, plus optional section chrome (eyebrow, heading, intro).

**Merged latest `main`** (FAQ CMS, recordings/audio metadata updates, etc.) and resolved conflicts so both **FAQ** and **amenitiesNearby** coexist: combined `cmsSectionValidator`, `cmsSnapshotValidator`, schema tables, publish/discard/seed paths, `HomepageShell` + preview wiring, and admin nav.

## Testing

- `bun run lint`
- `bun run build`
- `bun test`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-122](https://linear.app/only-football-fans/issue/INF-122/lls-amenities-nearby-content-model-convex-draftpublish)

<div><a href="https://cursor.com/agents/bc-c21e5ff7-dbd0-47d3-b5d9-1cb6ba6f709d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c21e5ff7-dbd0-47d3-b5d9-1cb6ba6f709d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

