### PR TITLE
Load homepage FAQ and amenities from CMS

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -3,6 +3,7 @@
 import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import type { GalleryPhoto } from "@/components/the-space";
 import type { FaqCategoryProps } from "@/components/faq";
 import type { MarketingFeatureFlags } from "@/lib/site-settings";
@@ -13,6 +14,9 @@ type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos> | 
 type PreloadedFaq = Preloaded<typeof api.public.getPublishedFaq> | null;
 type PreloadedMarketing =
   | Preloaded<typeof api.public.getPublishedMarketingFeatureFlags>
+  | null;
+type PreloadedAmenities =
+  | Preloaded<typeof api.public.getPublishedAmenitiesNearby>
   | null;
 
 type PublishedFaqPayload = { categories: readonly FaqCategoryProps[] };
@@ -126,18 +130,63 @@ function MarketingLive({
   return <>{children(marketing)}</>;
 }
 
+function AmenitiesData({
+  preloaded,
+  children,
+}: {
+  preloaded: PreloadedAmenities;
+  children: (
+    amenities: PublishedAmenitiesNearby | null | undefined,
+  ) => React.ReactNode;
+}) {
+  if (preloaded) {
+    return (
+      <AmenitiesFromPreload preloaded={preloaded}>
+        {children}
+      </AmenitiesFromPreload>
+    );
+  }
+  return <AmenitiesLive>{children}</AmenitiesLive>;
+}
+
+function AmenitiesFromPreload({
+  preloaded,
+  children,
+}: {
+  preloaded: NonNullable<PreloadedAmenities>;
+  children: (
+    amenities: PublishedAmenitiesNearby | null | undefined,
+  ) => React.ReactNode;
+}) {
+  const amenities = usePreloadedQuery(preloaded);
+  return <>{children(amenities)}</>;
+}
+
+function AmenitiesLive({
+  children,
+}: {
+  children: (
+    amenities: PublishedAmenitiesNearby | null | undefined,
+  ) => React.ReactNode;
+}) {
+  const amenities = useQuery(api.public.getPublishedAmenitiesNearby);
+  return <>{children(amenities)}</>;
+}
+
 function BothPreloaded({
   preloadedPricing,
   preloadedGear,
   photos,
   faq,
   marketing,
+  amenities,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
   faq: PublishedFaqPayload | undefined;
   marketing: MarketingFeatureFlags | null | undefined;
+  amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = usePreloadedQuery(preloadedGear);
@@ -148,6 +197,7 @@ function BothPreloaded({
       gear={gear}
       photos={photos}
       faqCategories={faq?.categories}
+      amenities={amenities}
     />
   );
 }
@@ -157,11 +207,13 @@ function PricingPreloadedGearLive({
   photos,
   faq,
   marketing,
+  amenities,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   photos: GalleryPhoto[] | undefined;
   faq: PublishedFaqPayload | undefined;
   marketing: MarketingFeatureFlags | null | undefined;
+  amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
   const pricingFlags = usePreloadedQuery(preloadedPricing);
   const gear = useQuery(api.public.getPublishedGear);
@@ -172,6 +224,7 @@ function PricingPreloadedGearLive({
       gear={gear}
       photos={photos}
       faqCategories={faq?.categories}
+      amenities={amenities}
     />
   );
 }
@@ -181,11 +234,13 @@ function PricingLiveGearPreloaded({
   photos,
   faq,
   marketing,
+  amenities,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
   photos: GalleryPhoto[] | undefined;
   faq: PublishedFaqPayload | undefined;
   marketing: MarketingFeatureFlags | null | undefined;
+  amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = usePreloadedQuery(preloadedGear);
@@ -196,6 +251,7 @@ function PricingLiveGearPreloaded({
       gear={gear}
       photos={photos}
       faqCategories={faq?.categories}
+      amenities={amenities}
     />
   );
 }
@@ -204,10 +260,12 @@ function BothLive({
   photos,
   faq,
   marketing,
+  amenities,
 }: {
   photos: GalleryPhoto[] | undefined;
   faq: PublishedFaqPayload | undefined;
   marketing: MarketingFeatureFlags | null | undefined;
+  amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
   const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
   const gear = useQuery(api.public.getPublishedGear);
@@ -218,6 +276,7 @@ function BothLive({
       gear={gear}
       photos={photos}
       faqCategories={faq?.categories}
+      amenities={amenities}
     />
   );
 }
@@ -228,12 +287,14 @@ export function HomeClient({
   preloadedPhotos,
   preloadedFaq,
   preloadedMarketing,
+  preloadedAmenities,
 }: {
   preloadedPricing: PreloadedPricing;
   preloadedGear: PreloadedGear;
   preloadedPhotos: PreloadedPhotos;
   preloadedFaq: PreloadedFaq;
   preloadedMarketing: PreloadedMarketing;
+  preloadedAmenities: PreloadedAmenities;
 }) {
   return (
     <MarketingData preloaded={preloadedMarketing}>
@@ -241,46 +302,54 @@ export function HomeClient({
         <PhotosData preloaded={preloadedPhotos}>
           {(photos) => (
             <FaqData preloaded={preloadedFaq}>
-              {(faq) => {
-                if (preloadedPricing && preloadedGear) {
-                  return (
-                    <BothPreloaded
-                      preloadedPricing={preloadedPricing}
-                      preloadedGear={preloadedGear}
-                      photos={photos}
-                      faq={faq}
-                      marketing={marketing}
-                    />
-                  );
-                }
-                if (preloadedPricing) {
-                  return (
-                    <PricingPreloadedGearLive
-                      preloadedPricing={preloadedPricing}
-                      photos={photos}
-                      faq={faq}
-                      marketing={marketing}
-                    />
-                  );
-                }
-                if (preloadedGear) {
-                  return (
-                    <PricingLiveGearPreloaded
-                      preloadedGear={preloadedGear}
-                      photos={photos}
-                      faq={faq}
-                      marketing={marketing}
-                    />
-                  );
-                }
-                return (
-                  <BothLive
-                    photos={photos}
-                    faq={faq}
-                    marketing={marketing}
-                  />
-                );
-              }}
+              {(faq) => (
+                <AmenitiesData preloaded={preloadedAmenities}>
+                  {(amenities) => {
+                    if (preloadedPricing && preloadedGear) {
+                      return (
+                        <BothPreloaded
+                          preloadedPricing={preloadedPricing}
+                          preloadedGear={preloadedGear}
+                          photos={photos}
+                          faq={faq}
+                          marketing={marketing}
+                          amenities={amenities}
+                        />
+                      );
+                    }
+                    if (preloadedPricing) {
+                      return (
+                        <PricingPreloadedGearLive
+                          preloadedPricing={preloadedPricing}
+                          photos={photos}
+                          faq={faq}
+                          marketing={marketing}
+                          amenities={amenities}
+                        />
+                      );
+                    }
+                    if (preloadedGear) {
+                      return (
+                        <PricingLiveGearPreloaded
+                          preloadedGear={preloadedGear}
+                          photos={photos}
+                          faq={faq}
+                          marketing={marketing}
+                          amenities={amenities}
+                        />
+                      );
+                    }
+                    return (
+                      <BothLive
+                        photos={photos}
+                        faq={faq}
+                        marketing={marketing}
+                        amenities={amenities}
+                      />
+                    );
+                  }}
+                </AmenitiesData>
+              )}
             </FaqData>
           )}
         </PhotosData>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,12 +11,14 @@ export default async function Home() {
       photosSettled,
       faqSettled,
       marketingSettled,
+      amenitiesSettled,
     ] = await Promise.allSettled([
       preloadQuery(api.public.getPublishedPricingFlags),
       preloadQuery(api.public.getPublishedGear),
       preloadQuery(api.public.getPublishedGalleryPhotos),
       preloadQuery(api.public.getPublishedFaq),
       preloadQuery(api.public.getPublishedMarketingFeatureFlags),
+      preloadQuery(api.public.getPublishedAmenitiesNearby),
     ]);
     const preloadedPricing =
       pricingSettled.status === "fulfilled" ? pricingSettled.value : null;
@@ -28,12 +30,15 @@ export default async function Home() {
       faqSettled.status === "fulfilled" ? faqSettled.value : null;
     const preloadedMarketing =
       marketingSettled.status === "fulfilled" ? marketingSettled.value : null;
+    const preloadedAmenities =
+      amenitiesSettled.status === "fulfilled" ? amenitiesSettled.value : null;
     if (
       preloadedPricing === null &&
       preloadedGear === null &&
       preloadedPhotos === null &&
       preloadedFaq === null &&
-      preloadedMarketing === null
+      preloadedMarketing === null &&
+      preloadedAmenities === null
     ) {
       return (
         <HomepageShell
@@ -42,6 +47,7 @@ export default async function Home() {
           gear={null}
           photos={null}
           faqCategories={null}
+          amenities={null}
         />
       );
     }
@@ -52,6 +58,7 @@ export default async function Home() {
         preloadedPhotos={preloadedPhotos}
         preloadedFaq={preloadedFaq}
         preloadedMarketing={preloadedMarketing}
+        preloadedAmenities={preloadedAmenities}
       />
     );
   } catch {
@@ -62,6 +69,7 @@ export default async function Home() {
         gear={null}
         photos={null}
         faqCategories={null}
+        amenities={null}
       />
     );
   }

--- a/src/components/amenities-nearby.tsx
+++ b/src/components/amenities-nearby.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useQuery } from "convex/react";
-import { api } from "../../convex/_generated/api";
 import { AmenityCard } from "./ui/amenity-card";
 
 const STATIC_EYEBROW = "Local Favorites";
@@ -22,19 +20,12 @@ export type PublishedAmenitiesNearby = {
 };
 
 type AmenitiesNearbyProps = {
-  /** When provided (e.g. preview), skips the public Convex subscription. */
+  /** Published (or owner preview) amenities payload from Convex. */
   readonly amenities?: PublishedAmenitiesNearby | null | undefined;
 };
 
-export function AmenitiesNearby({ amenities: amenitiesFromProps }: AmenitiesNearbyProps) {
-  const live = useQuery(
-    api.public.getPublishedAmenitiesNearby,
-    amenitiesFromProps !== undefined ? "skip" : {},
-  );
-  const data =
-    amenitiesFromProps !== undefined ? amenitiesFromProps : live;
-
-  if (data === undefined) {
+export function AmenitiesNearby({ amenities }: AmenitiesNearbyProps) {
+  if (amenities === undefined) {
     return (
       <section
         id="local-favorites"
@@ -48,17 +39,17 @@ export function AmenitiesNearby({ amenities: amenitiesFromProps }: AmenitiesNear
     );
   }
 
-  if (data === null) {
+  if (amenities === null) {
     return null;
   }
 
-  if (!data.isEnabled || data.rows.length === 0) {
+  if (!amenities.isEnabled || amenities.rows.length === 0) {
     return null;
   }
 
-  const eyebrow = data.eyebrow?.trim() || STATIC_EYEBROW;
-  const heading = data.heading?.trim() || STATIC_HEADING;
-  const intro = data.intro?.trim();
+  const eyebrow = amenities.eyebrow?.trim() || STATIC_EYEBROW;
+  const heading = amenities.heading?.trim() || STATIC_HEADING;
+  const intro = amenities.intro?.trim();
 
   return (
     <section
@@ -82,7 +73,7 @@ export function AmenitiesNearby({ amenities: amenitiesFromProps }: AmenitiesNear
         </div>
 
         <div className="reveal reveal-delay-2 grid grid-cols-1 divide-y divide-sand/14 border-y border-sand/14 md:grid-cols-2 md:divide-x md:divide-y-0 lg:grid-cols-4 [&>*:nth-child(n+3)]:border-t [&>*:nth-child(n+3)]:border-sand/14 lg:[&>*:nth-child(n+3)]:border-t-0">
-          {data.rows.map((amenity) => (
+          {amenities.rows.map((amenity) => (
             <AmenityCard
               key={amenity.stableId}
               name={amenity.name}

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/accordion";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { DEFAULT_FAQ_CATEGORIES } from "../../convex/faqSeedData";
 
 export type FaqQuestionProps = {
   stableId: string;
@@ -25,14 +24,13 @@ export type FaqCategoryProps = {
 };
 
 export type FaqProps = {
-  categories?: readonly FaqCategoryProps[];
+  categories?: readonly FaqCategoryProps[] | null;
 };
 
 export function FAQ({ categories }: FaqProps) {
-  const data =
-    categories && categories.length > 0
-      ? categories
-      : DEFAULT_FAQ_CATEGORIES;
+  if (categories === null || categories?.length === 0) {
+    return null;
+  }
 
   return (
     <section
@@ -67,30 +65,38 @@ export function FAQ({ categories }: FaqProps) {
           </p>
         </div>
 
-        <div className="reveal reveal-delay-2 space-y-16">
-          {data.map((category) => (
-            <div key={category.stableId}>
-              <h3 className="eyebrow mb-8 border-b border-sand/22 pb-4 text-sand">
-                {category.title}
-              </h3>
+        {categories === undefined ? (
+          <div className="reveal reveal-delay-2 space-y-10">
+            <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
+            <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
+            <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
+          </div>
+        ) : (
+          <div className="reveal reveal-delay-2 space-y-16">
+            {categories.map((category) => (
+              <div key={category.stableId}>
+                <h3 className="eyebrow mb-8 border-b border-sand/22 pb-4 text-sand">
+                  {category.title}
+                </h3>
 
-              <Accordion multiple>
-                {category.questions.map((faq) => (
-                  <AccordionItem key={faq.stableId} value={faq.stableId}>
-                    <AccordionTrigger>
-                      <span className="body-text text-base text-warm-white">
-                        {faq.question}
-                      </span>
-                    </AccordionTrigger>
-                    <AccordionPanel>
-                      <p className="body-text text-ivory/84">{faq.answer}</p>
-                    </AccordionPanel>
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            </div>
-          ))}
-        </div>
+                <Accordion multiple>
+                  {category.questions.map((faq) => (
+                    <AccordionItem key={faq.stableId} value={faq.stableId}>
+                      <AccordionTrigger>
+                        <span className="body-text text-base text-warm-white">
+                          {faq.question}
+                        </span>
+                      </AccordionTrigger>
+                      <AccordionPanel>
+                        <p className="body-text text-ivory/84">{faq.answer}</p>
+                      </AccordionPanel>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
+              </div>
+            ))}
+          </div>
+        )}
 
         <div className="reveal reveal-delay-3 mt-24 border-t border-sand/15 pt-16 text-center">
           <p className="eyebrow mb-5 text-sand/78">Contact</p>

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -40,9 +40,9 @@ interface HomepageShellProps {
   readonly gear: GearPayload | null | undefined;
   /** Published (or preview) gallery payload. */
   readonly photos: GalleryPhoto[] | null | undefined;
-  /** FAQ categories from Convex; omit to use client fallback defaults. */
+  /** FAQ categories from Convex; `undefined` renders the loading state. */
   readonly faqCategories?: readonly FaqCategoryProps[] | null | undefined;
-  /** When set (e.g. preview), skips live public subscription for amenities. */
+  /** Amenities payload from Convex; `undefined` renders the loading state. */
   readonly amenities?: PublishedAmenitiesNearby | null | undefined;
   readonly banner?: React.ReactNode;
 }
@@ -111,13 +111,7 @@ export function HomepageShell({
           isPreviewRoute={isPreview}
         />
         <AmenitiesNearby amenities={amenities} />
-        <FAQ
-          categories={
-            faqCategories === undefined || faqCategories === null
-              ? undefined
-              : faqCategories
-          }
-        />
+        <FAQ categories={faqCategories} />
         <ArtistInquiries />
       </main>
 

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -5,14 +5,14 @@ describe("ADMIN_MANAGE_NAV_ITEMS", () => {
   test("includes every CMS admin destination expected by the sidebar", () => {
     const hrefs = ADMIN_MANAGE_NAV_ITEMS.map((i) => i.href);
     expect(hrefs).toEqual([
-      "/admin/pricing",
-      "/admin/gear",
-      "/admin/photos",
-      "/admin/videos",
-      "/admin/audio",
       "/admin/about",
-      "/admin/faq",
+      "/admin/photos",
+      "/admin/gear",
+      "/admin/audio",
+      "/admin/pricing",
       "/admin/amenities-nearby",
+      "/admin/faq",
+      "/admin/videos",
       "/admin/settings",
     ]);
   });

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -19,16 +19,10 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
   description: string;
 }[] = [
   {
-    title: "Pricing",
-    href: "/admin/pricing",
-    icon: DollarSign,
-    description: "Manage packages & rates",
-  },
-  {
-    title: "Gear",
-    href: "/admin/gear",
-    icon: Wrench,
-    description: "Equipment inventory",
+    title: "About",
+    href: "/admin/about",
+    icon: User,
+    description: "Studio bio & story",
   },
   {
     title: "Photos",
@@ -37,10 +31,10 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Gallery management",
   },
   {
-    title: "Videos",
-    href: "/admin/videos",
-    icon: Video,
-    description: "Video portfolio",
+    title: "Gear",
+    href: "/admin/gear",
+    icon: Wrench,
+    description: "Equipment inventory",
   },
   {
     title: "Audio",
@@ -49,10 +43,16 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Audio samples",
   },
   {
-    title: "About",
-    href: "/admin/about",
-    icon: User,
-    description: "Studio bio & story",
+    title: "Pricing",
+    href: "/admin/pricing",
+    icon: DollarSign,
+    description: "Manage packages & rates",
+  },
+  {
+    title: "Amenities nearby",
+    href: "/admin/amenities-nearby",
+    icon: MapPin,
+    description: "Local favorites on the homepage",
   },
   {
     title: "FAQ",
@@ -61,10 +61,10 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
     description: "Homepage questions & answers",
   },
   {
-    title: "Amenities nearby",
-    href: "/admin/amenities-nearby",
-    icon: MapPin,
-    description: "Local favorites on the homepage",
+    title: "Videos",
+    href: "/admin/videos",
+    icon: Video,
+    description: "Video portfolio",
   },
   {
     title: "Settings",


### PR DESCRIPTION
## Summary
- Preload published amenities content alongside existing homepage CMS data.
- Thread published FAQ and amenities payloads into the homepage sections.
- Keep FAQ and amenities loading/empty states safe without anonymous draft reads.

## Test plan
- bun run lint
- bun run build


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the homepage data-loading pipeline to preload and thread through new CMS-backed FAQ/amenities payloads, which could affect homepage rendering and loading/empty-state behavior if Convex responses differ or fail.
> 
> **Overview**
> The homepage now preloads and hydrates an additional published `amenities` payload alongside existing CMS-driven sections, and threads it through `HomeClient` into `HomepageShell`.
> 
> `AmenitiesNearby` is converted to a pure presentational component (no direct Convex subscription), relying on passed `amenities` with explicit loading (`undefined`) and empty (`null`/disabled) states.
> 
> FAQ rendering is adjusted to be CMS-driven as well: the client-side default seed fallback is removed, `FAQ` now returns `null` when categories are `null`/empty, and shows a skeleton only while categories are still `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2271a94ca4e18fa06c86c012175576ca2c90cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->