### PR TITLE
feat(gallery): public gallery page + shared PageHeader

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -47,6 +47,7 @@ import type * as mediaStorage from "../mediaStorage.js";
 import type * as migrations_amenitiesNearbyPublishedIfEmpty from "../migrations/amenitiesNearbyPublishedIfEmpty.js";
 import type * as migrations_gearFromEquipmentSpecs from "../migrations/gearFromEquipmentSpecs.js";
 import type * as observability from "../observability.js";
+import type * as photosCmsFlags from "../photosCmsFlags.js";
 import type * as photosPreviewDraft from "../photosPreviewDraft.js";
 import type * as pricingPreviewDraft from "../pricingPreviewDraft.js";
 import type * as pricingTree from "../pricingTree.js";
@@ -103,6 +104,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/amenitiesNearbyPublishedIfEmpty": typeof migrations_amenitiesNearbyPublishedIfEmpty;
   "migrations/gearFromEquipmentSpecs": typeof migrations_gearFromEquipmentSpecs;
   observability: typeof observability;
+  photosCmsFlags: typeof photosCmsFlags;
   photosPreviewDraft: typeof photosPreviewDraft;
   pricingPreviewDraft: typeof pricingPreviewDraft;
   pricingTree: typeof pricingTree;

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query, type MutationCtx } from "../_generated/server";
+import { internalMutation, mutation, query, type MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import {
   ALLOWED_GALLERY_IMAGE_TYPES,
@@ -20,6 +20,7 @@ import {
 } from "../galleryPhotos";
 import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
 import { requireCmsOwner } from "../lib/auth";
+import { promoteGalleryPageCmsFlag } from "../photosCmsFlags";
 
 const MAX_ALT_LENGTH = 240;
 const MAX_CAPTION_LENGTH = 600;
@@ -291,11 +292,16 @@ export const listDraftPhotos = query({
   handler: async (ctx) => {
     await requireCmsOwner(ctx);
     const rows = await loadGalleryPhotos(ctx, "draft");
-    const meta = await ctx.db
-      .query("galleryPhotoMeta")
-      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
-      .unique();
-
+    const [meta, photosCms] = await Promise.all([
+      ctx.db
+        .query("galleryPhotoMeta")
+        .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+        .unique(),
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_section", (q) => q.eq("section", "photos"))
+        .unique(),
+    ]);
     return {
       photos: await materializeGalleryPhotos(ctx, rows),
       hasDraftChanges: meta?.hasDraftChanges ?? false,
@@ -303,6 +309,10 @@ export const listDraftPhotos = query({
       publishedBy: meta?.publishedBy ?? null,
       updatedAt: meta?.updatedAt ?? null,
       updatedBy: meta?.updatedBy ?? null,
+      galleryPage: {
+        isEnabledPublished: photosCms?.isEnabled,
+        isEnabledDraft: photosCms?.isEnabledDraft,
+      },
       limits: {
         maxPhotos: MAX_GALLERY_PHOTOS,
         maxImageBytes: MAX_GALLERY_IMAGE_BYTES,
@@ -329,6 +339,8 @@ export const saveUploadedPhoto = mutation({
     height: v.optional(v.union(v.number(), v.null())),
     originalFileName: v.optional(v.union(v.string(), v.null())),
     categories: v.optional(v.union(v.array(v.string()), v.null())),
+    showInCarousel: v.optional(v.boolean()),
+    showInGallery: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
@@ -353,6 +365,8 @@ export const saveUploadedPhoto = mutation({
       const height = normalizeDimension(args.height, "height");
       const originalFileName = normalizeFileName(args.originalFileName);
       const categories = normalizeCategoriesInput(args.categories);
+      const showInCarousel = args.showInCarousel ?? true;
+      const showInGallery = args.showInGallery ?? true;
 
       const sortOrder =
         draft.length === 0
@@ -372,6 +386,9 @@ export const saveUploadedPhoto = mutation({
         sizeBytes: storage.size,
         ...(originalFileName !== undefined ? { originalFileName } : {}),
         ...(categories !== undefined ? { categories } : {}),
+        ...(showInCarousel !== true || showInGallery !== true
+          ? { showInCarousel, showInGallery }
+          : {}),
       });
     } catch (error) {
       await deleteStorageIfUnreferenced(ctx, args.storageId);
@@ -395,6 +412,8 @@ export const updateDraftPhotoMetadata = mutation({
      * been redeployed still work unchanged.
      */
     categories: v.optional(v.union(v.array(v.string()), v.null())),
+    showInCarousel: v.optional(v.boolean()),
+    showInGallery: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
@@ -407,6 +426,8 @@ export const updateDraftPhotoMetadata = mutation({
       alt: string;
       caption: string | undefined;
       categories?: string[] | undefined;
+      showInCarousel?: boolean;
+      showInGallery?: boolean;
     } = {
       alt: normalizeAlt(args.alt),
       caption: normalizeCaption(args.caption),
@@ -414,6 +435,12 @@ export const updateDraftPhotoMetadata = mutation({
 
     if (args.categories !== undefined) {
       patch.categories = normalizeCategoriesInput(args.categories);
+    }
+    if (args.showInCarousel !== undefined) {
+      patch.showInCarousel = args.showInCarousel;
+    }
+    if (args.showInGallery !== undefined) {
+      patch.showInGallery = args.showInGallery;
     }
 
     await ctx.db.patch(row._id, patch);
@@ -514,6 +541,8 @@ export async function publishGalleryDraftCore(
     updatedBy,
   });
 
+  await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy });
+
   return {
     ok: true as const,
     kind: "published" as const,
@@ -521,6 +550,34 @@ export async function publishGalleryDraftCore(
     publishedBy: userId,
   };
 }
+
+/**
+ * One-shot: set `showInCarousel` / `showInGallery` to `true` where missing so
+ * existing rows behave like before surface flags existed.
+ *
+ * `bunx convex run admin/photos:backfillGallerySurfaceFlags`
+ */
+export const backfillGallerySurfaceFlags = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("galleryPhotos").collect();
+    let updated = 0;
+    for (const row of rows) {
+      if (
+        row.showInCarousel !== undefined &&
+        row.showInGallery !== undefined
+      ) {
+        continue;
+      }
+      await ctx.db.patch(row._id, {
+        ...(row.showInCarousel === undefined ? { showInCarousel: true } : {}),
+        ...(row.showInGallery === undefined ? { showInGallery: true } : {}),
+      });
+      updated++;
+    }
+    return { ok: true as const, updated };
+  },
+});
 
 export const publishPhotos = mutation({
   args: {},

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -517,8 +517,9 @@ export async function publishGalleryDraftCore(
 ): Promise<{
   ok: true;
   kind: "published";
-  publishedAt: number;
-  publishedBy: string;
+  /** Matches `galleryPhotoMeta.publishedAt` (may stay null when photos already matched published). */
+  publishedAt: number | null;
+  publishedBy: string | undefined;
 }> {
   const { userId, updatedBy } = args;
   const draft = await loadGalleryPhotos(ctx, "draft");
@@ -555,11 +556,15 @@ export async function publishGalleryDraftCore(
 
   await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy });
 
+  const metaFinal = await ctx.db.get(metaId);
+  const publishedAt = metaFinal?.publishedAt ?? null;
+  const publishedBy = metaFinal?.publishedBy;
+
   return {
     ok: true as const,
     kind: "published" as const,
-    publishedAt: now,
-    publishedBy: userId,
+    publishedAt,
+    publishedBy,
   };
 }
 

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -548,22 +548,14 @@ export async function publishGalleryDraftCore(
 
   if (!photosMatch) {
     await replaceGalleryScope(ctx, "draft", "published");
-    await ctx.db.patch(metaId, {
-      hasDraftChanges: false,
-      publishedAt: now,
-      publishedBy: userId,
-      updatedAt: now,
-      updatedBy,
-    });
-  } else {
-    await ctx.db.patch(metaId, {
-      hasDraftChanges: false,
-      publishedAt: now,
-      publishedBy: userId,
-      updatedAt: now,
-      updatedBy,
-    });
   }
+  await ctx.db.patch(metaId, {
+    hasDraftChanges: false,
+    publishedAt: now,
+    publishedBy: userId,
+    updatedAt: now,
+    updatedBy,
+  });
 
   await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy, publishedAt: now });
 
@@ -599,7 +591,10 @@ export async function publishGalleryDraftCore(
 export const backfillGallerySurfaceFlags = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const rows = await ctx.db.query("galleryPhotos").collect();
+    const rows = await ctx.db
+      .query("galleryPhotos")
+      .withIndex("by_scope_and_sort", (q) => q.eq("scope", "draft"))
+      .collect();
     let updated = 0;
     for (const row of rows) {
       if (
@@ -630,21 +625,28 @@ export const discardDraftPhotos = mutation({
   args: {},
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
-    await ensureGalleryMeta(ctx);
+    const { row: metaBefore } = await ensureGalleryMeta(ctx);
 
     const draft = await loadGalleryPhotos(ctx, "draft");
     const published = await loadGalleryPhotos(ctx, "published");
-    if (!galleryDraftMatchesPublished(draft, published)) {
-      await replaceGalleryScope(ctx, "published", "draft");
-    }
-
-    await patchGalleryMetaAfterDraftChange(ctx, updatedBy);
+    const photosMismatch = !galleryDraftMatchesPublished(draft, published);
 
     const cmsRow = await getSectionMetaRow(ctx, "photos");
-    if (
-      cmsRow &&
-      (cmsRow.hasDraftChanges || typeof cmsRow.isEnabledDraft === "boolean")
-    ) {
+    const needsCmsPatch =
+      cmsRow !== null &&
+      (cmsRow.hasDraftChanges || typeof cmsRow.isEnabledDraft === "boolean");
+    if (!metaBefore.hasDraftChanges && !photosMismatch && !needsCmsPatch) {
+      return { ok: true as const, discarded: false };
+    }
+
+    if (photosMismatch) {
+      await replaceGalleryScope(ctx, "published", "draft");
+    }
+    if (photosMismatch || metaBefore.hasDraftChanges) {
+      await patchGalleryMetaAfterDraftChange(ctx, updatedBy);
+    }
+
+    if (needsCmsPatch && cmsRow) {
       const now = Date.now();
       await ctx.db.patch(cmsRow._id, {
         isEnabledDraft: undefined,

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -3,6 +3,7 @@ import { mutation, query, type MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import {
   ALLOWED_GALLERY_IMAGE_TYPES,
+  GALLERY_CATEGORY_SLUGS,
   MAX_GALLERY_IMAGE_BYTES,
   MAX_GALLERY_PHOTOS,
   type GalleryPhotoDoc,
@@ -10,8 +11,10 @@ import {
   deleteStorageIfUnreferenced,
   ensureGalleryMeta,
   getStorageMetadata,
+  isGalleryCategorySlug,
   loadGalleryPhotos,
   materializeGalleryPhotos,
+  normalizeGalleryCategories,
   patchGalleryMetaAfterDraftChange,
   replaceGalleryScope,
 } from "../galleryPhotos";
@@ -79,6 +82,28 @@ function normalizeFileName(raw?: string | null): string | undefined {
     );
   }
   return value;
+}
+
+function normalizeCategoriesInput(
+  raw: readonly string[] | null | undefined,
+): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (raw.length === 0) return undefined;
+  for (const value of raw) {
+    if (typeof value !== "string") {
+      cmsValidationError("Category values must be strings.", "categories");
+    }
+    const slug = value.trim().toLowerCase();
+    if (slug.length === 0) continue;
+    if (!isGalleryCategorySlug(slug)) {
+      cmsValidationError(
+        `Unknown gallery category: ${value}. Allowed: ${GALLERY_CATEGORY_SLUGS.join(", ")}.`,
+        "categories",
+      );
+    }
+  }
+  // Re-use the public normaliser to dedupe + canonicalise the order.
+  return normalizeGalleryCategories(raw);
 }
 
 function normalizeDimension(
@@ -182,6 +207,17 @@ function collectPhotoIssues(
       });
     } else {
       stableIds.add(row.stableId);
+    }
+
+    if (row.categories !== undefined) {
+      for (const category of row.categories) {
+        if (!isGalleryCategorySlug(category)) {
+          issues.push({
+            path: `${base}.categories`,
+            message: `Unknown category: ${category}. Allowed: ${GALLERY_CATEGORY_SLUGS.join(", ")}.`,
+          });
+        }
+      }
     }
 
     const storage = storageById.get(row.storageId) ?? null;
@@ -292,6 +328,7 @@ export const saveUploadedPhoto = mutation({
     width: v.optional(v.union(v.number(), v.null())),
     height: v.optional(v.union(v.number(), v.null())),
     originalFileName: v.optional(v.union(v.string(), v.null())),
+    categories: v.optional(v.union(v.array(v.string()), v.null())),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
@@ -315,6 +352,7 @@ export const saveUploadedPhoto = mutation({
       const width = normalizeDimension(args.width, "width");
       const height = normalizeDimension(args.height, "height");
       const originalFileName = normalizeFileName(args.originalFileName);
+      const categories = normalizeCategoriesInput(args.categories);
 
       const sortOrder =
         draft.length === 0
@@ -333,6 +371,7 @@ export const saveUploadedPhoto = mutation({
         contentType,
         sizeBytes: storage.size,
         ...(originalFileName !== undefined ? { originalFileName } : {}),
+        ...(categories !== undefined ? { categories } : {}),
       });
     } catch (error) {
       await deleteStorageIfUnreferenced(ctx, args.storageId);
@@ -349,6 +388,13 @@ export const updateDraftPhotoMetadata = mutation({
     stableId: v.string(),
     alt: v.string(),
     caption: v.optional(v.union(v.string(), v.null())),
+    /**
+     * INF-47 — full replacement of the photo's category tags. Pass `[]`
+     * (or `null`) to clear all categories. Field omitted = leave the
+     * existing categories untouched, so old admin clients that haven't
+     * been redeployed still work unchanged.
+     */
+    categories: v.optional(v.union(v.array(v.string()), v.null())),
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
@@ -357,10 +403,20 @@ export const updateDraftPhotoMetadata = mutation({
       cmsNotFound("galleryPhoto", args.stableId);
     }
 
-    await ctx.db.patch(row._id, {
+    const patch: {
+      alt: string;
+      caption: string | undefined;
+      categories?: string[] | undefined;
+    } = {
       alt: normalizeAlt(args.alt),
       caption: normalizeCaption(args.caption),
-    });
+    };
+
+    if (args.categories !== undefined) {
+      patch.categories = normalizeCategoriesInput(args.categories);
+    }
+
+    await ctx.db.patch(row._id, patch);
 
     await patchGalleryMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const };

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -299,16 +299,25 @@ export const listDraftPhotos = query({
         .query("galleryPhotoMeta")
         .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
         .unique(),
-      ctx.db
-        .query("cmsSections")
-        .withIndex("by_section", (q) => q.eq("section", "photos"))
-        .unique(),
+      getSectionMetaRow(ctx, "photos"),
     ]);
+    const metaAt = meta?.publishedAt ?? null;
+    const cmsAt = photosCms?.publishedAt ?? null;
+    const publishedAt =
+      metaAt !== null && cmsAt !== null
+        ? Math.max(metaAt, cmsAt)
+        : (metaAt ?? cmsAt);
+    const publishedBy =
+      metaAt !== null && cmsAt !== null
+        ? (metaAt >= cmsAt
+            ? meta?.publishedBy
+            : photosCms?.publishedBy)
+        : (metaAt !== null ? meta?.publishedBy : photosCms?.publishedBy);
     return {
       photos: await materializeGalleryPhotos(ctx, rows),
       hasDraftChanges: meta?.hasDraftChanges ?? false,
-      publishedAt: meta?.publishedAt ?? null,
-      publishedBy: meta?.publishedBy ?? null,
+      publishedAt,
+      publishedBy: publishedBy ?? null,
       updatedAt: meta?.updatedAt ?? null,
       updatedBy: meta?.updatedBy ?? null,
       galleryPage: {
@@ -517,7 +526,7 @@ export async function publishGalleryDraftCore(
 ): Promise<{
   ok: true;
   kind: "published";
-  /** Matches `galleryPhotoMeta.publishedAt` (may stay null when photos already matched published). */
+  /** Latest publish stamp across gallery photos and gallery-page CMS flag. */
   publishedAt: number | null;
   publishedBy: string | undefined;
 }> {
@@ -557,8 +566,19 @@ export async function publishGalleryDraftCore(
   await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy });
 
   const metaFinal = await ctx.db.get(metaId);
-  const publishedAt = metaFinal?.publishedAt ?? null;
-  const publishedBy = metaFinal?.publishedBy;
+  const photosCmsFinal = await getSectionMetaRow(ctx, "photos");
+  const metaAt = metaFinal?.publishedAt ?? null;
+  const cmsAt = photosCmsFinal?.publishedAt ?? null;
+  const publishedAt =
+    metaAt !== null && cmsAt !== null
+      ? Math.max(metaAt, cmsAt)
+      : (metaAt ?? cmsAt);
+  const publishedBy =
+    metaAt !== null && cmsAt !== null
+      ? (metaAt >= cmsAt
+          ? metaFinal?.publishedBy
+          : photosCmsFinal?.publishedBy)
+      : (metaAt !== null ? metaFinal?.publishedBy : photosCmsFinal?.publishedBy);
 
   return {
     ok: true as const,

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -19,7 +19,7 @@ import {
   patchGalleryMetaAfterDraftChange,
   replaceGalleryScope,
 } from "../galleryPhotos";
-import { getSectionMetaRow } from "../cmsMeta";
+import { getSectionMetaRow, recomputeSectionHasDraftChanges } from "../cmsMeta";
 import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
 import { requireCmsOwner } from "../lib/auth";
 import { promoteGalleryPageCmsFlag } from "../photosCmsFlags";
@@ -626,10 +626,10 @@ export const discardDraftPhotos = mutation({
       const now = Date.now();
       await ctx.db.patch(cmsRow._id, {
         isEnabledDraft: undefined,
-        hasDraftChanges: false,
         updatedAt: now,
         updatedBy,
       });
+      await recomputeSectionHasDraftChanges(ctx, "photos", updatedBy);
     }
 
     return { ok: true as const, discarded: true };

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -558,12 +558,14 @@ export async function publishGalleryDraftCore(
   } else {
     await ctx.db.patch(metaId, {
       hasDraftChanges: false,
+      publishedAt: now,
+      publishedBy: userId,
       updatedAt: now,
       updatedBy,
     });
   }
 
-  await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy });
+  await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy, publishedAt: now });
 
   const metaFinal = await ctx.db.get(metaId);
   const photosCmsFinal = await getSectionMetaRow(ctx, "photos");

--- a/convex/admin/photos.ts
+++ b/convex/admin/photos.ts
@@ -10,6 +10,7 @@ import {
   type GalleryPublishIssue,
   deleteStorageIfUnreferenced,
   ensureGalleryMeta,
+  galleryDraftMatchesPublished,
   getStorageMetadata,
   isGalleryCategorySlug,
   loadGalleryPhotos,
@@ -18,6 +19,7 @@ import {
   patchGalleryMetaAfterDraftChange,
   replaceGalleryScope,
 } from "../galleryPhotos";
+import { getSectionMetaRow } from "../cmsMeta";
 import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
 import { requireCmsOwner } from "../lib/auth";
 import { promoteGalleryPageCmsFlag } from "../photosCmsFlags";
@@ -520,6 +522,7 @@ export async function publishGalleryDraftCore(
 }> {
   const { userId, updatedBy } = args;
   const draft = await loadGalleryPhotos(ctx, "draft");
+  const published = await loadGalleryPhotos(ctx, "published");
   const issues = await validateDraftForPublish(ctx, draft);
   if (issues.length > 0) {
     cmsPublishValidationFailed(
@@ -529,17 +532,26 @@ export async function publishGalleryDraftCore(
     );
   }
 
-  await replaceGalleryScope(ctx, "draft", "published");
-
+  const photosMatch = galleryDraftMatchesPublished(draft, published);
   const now = Date.now();
   const { id: metaId } = await ensureGalleryMeta(ctx);
-  await ctx.db.patch(metaId, {
-    hasDraftChanges: false,
-    publishedAt: now,
-    publishedBy: userId,
-    updatedAt: now,
-    updatedBy,
-  });
+
+  if (!photosMatch) {
+    await replaceGalleryScope(ctx, "draft", "published");
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      publishedAt: now,
+      publishedBy: userId,
+      updatedAt: now,
+      updatedBy,
+    });
+  } else {
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      updatedAt: now,
+      updatedBy,
+    });
+  }
 
   await promoteGalleryPageCmsFlag(ctx, { userId, updatedBy });
 
@@ -592,15 +604,28 @@ export const discardDraftPhotos = mutation({
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
     await ensureGalleryMeta(ctx);
-    await replaceGalleryScope(ctx, "published", "draft");
 
-    const now = Date.now();
-    const { id: metaId } = await ensureGalleryMeta(ctx);
-    await ctx.db.patch(metaId, {
-      hasDraftChanges: false,
-      updatedAt: now,
-      updatedBy,
-    });
+    const draft = await loadGalleryPhotos(ctx, "draft");
+    const published = await loadGalleryPhotos(ctx, "published");
+    if (!galleryDraftMatchesPublished(draft, published)) {
+      await replaceGalleryScope(ctx, "published", "draft");
+    }
+
+    await patchGalleryMetaAfterDraftChange(ctx, updatedBy);
+
+    const cmsRow = await getSectionMetaRow(ctx, "photos");
+    if (
+      cmsRow &&
+      (cmsRow.hasDraftChanges || typeof cmsRow.isEnabledDraft === "boolean")
+    ) {
+      const now = Date.now();
+      await ctx.db.patch(cmsRow._id, {
+        isEnabledDraft: undefined,
+        hasDraftChanges: false,
+        updatedAt: now,
+        updatedBy,
+      });
+    }
 
     return { ok: true as const, discarded: true };
   },

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -66,6 +66,8 @@ import {
 } from "./faqTree";
 import { cmsValidationError } from "./errors";
 
+const MARKETING_FLAG_SECTIONS = ["about", "recordings", "pricing"] as const;
+
 /**
  * Snapshot-shaped admin view of a section. Reads per-section scoped tables
  * and folds them back into the historical `publishedSnapshot` / `draftSnapshot`
@@ -315,12 +317,10 @@ export const listMarketingFlagsDraft = query({
       galleryPage: effectiveIsEnabled(photosRow, "photos"),
     };
 
-    const hasDraftChanges = anyMarketingFlagDraftPending(
-      aboutRow,
-      recordingsRow,
-      pricingRow,
-      photosRow,
-    );
+    const hasDraftChanges =
+      sectionHasPendingFlagDraft(aboutRow, "about") ||
+      sectionHasPendingFlagDraft(recordingsRow, "recordings") ||
+      sectionHasPendingFlagDraft(pricingRow, "pricing");
 
     // Expose per-section meta so the publish toolbar can disambiguate which
     // sections need the `publishSection` mutation to promote a flag draft.
@@ -328,13 +328,11 @@ export const listMarketingFlagsDraft = query({
       aboutRow?.publishedAt ?? null,
       recordingsRow?.publishedAt ?? null,
       pricingRow?.publishedAt ?? null,
-      photosRow?.publishedAt ?? null,
     ]);
     const updatedAt = latestNumber([
       aboutRow?.updatedAt ?? null,
       recordingsRow?.updatedAt ?? null,
       pricingRow?.updatedAt ?? null,
-      photosRow?.updatedAt ?? null,
     ]);
 
     return {
@@ -346,12 +344,10 @@ export const listMarketingFlagsDraft = query({
           aboutRow,
           recordingsRow,
           pricingRow,
-          photosRow,
         ]) ?? null,
       updatedAt,
       updatedBy:
-        mostRecentUpdatedBy([aboutRow, recordingsRow, pricingRow, photosRow]) ??
-        null,
+        mostRecentUpdatedBy([aboutRow, recordingsRow, pricingRow]) ?? null,
       perSection: {
         about: {
           isEnabled: publishedIsEnabled(aboutRow, "about"),
@@ -484,12 +480,7 @@ export const publishMarketingFlags = mutation({
     const published: Array<
       Awaited<ReturnType<typeof publishSectionCore>>
     > = [];
-    for (const section of [
-      "about",
-      "recordings",
-      "pricing",
-      "photos",
-    ] as const) {
+    for (const section of MARKETING_FLAG_SECTIONS) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || !sectionHasPendingFlagDraft(row, section)) continue;
       const result = await publishSectionCore(ctx, {
@@ -528,11 +519,7 @@ export const discardMarketingFlagsDraft = mutation({
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
     let discarded = false;
-    for (const section of [
-      "about",
-      "recordings",
-      "pricing",
-    ] as const) {
+    for (const section of MARKETING_FLAG_SECTIONS) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || row.isEnabledDraft === undefined) continue;
       await ctx.db.patch(row._id, {

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -178,11 +178,18 @@ export const saveDraft = mutation({
           "content",
         );
       }
-    } else {
+    } else if (args.section === "recordings") {
       cmsValidationError(
         "Recordings has no content; only the visibility flag is editable.",
         "section",
       );
+    } else if (args.section === "photos") {
+      cmsValidationError(
+        "Gallery photos are edited in the admin photos workspace, not via saveDraft.",
+        "section",
+      );
+    } else {
+      cmsValidationError("This section has no saveDraft content path.", "section");
     }
 
     await ensureSectionMetaRow(ctx, args.section, updatedBy);

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -288,7 +288,7 @@ export const listPendingDrafts = query({
     if (gearMeta?.hasDraftChanges) sections.push("gear");
     if (galleryMeta?.hasDraftChanges) sections.push("photos");
 
-    return { sections };
+    return { sections: [...new Set(sections)] };
   },
 });
 
@@ -521,6 +521,7 @@ export const publishMarketingFlags = mutation({
 /**
  * Discard marketing-flag drafts: clears `isEnabledDraft` on About /
  * Recordings / Pricing (without rewinding their content drafts).
+ * Gallery-page visibility drafts are discarded from `/admin/photos` only.
  */
 export const discardMarketingFlagsDraft = mutation({
   args: {},
@@ -531,7 +532,6 @@ export const discardMarketingFlagsDraft = mutation({
       "about",
       "recordings",
       "pricing",
-      "photos",
     ] as const) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || row.isEnabledDraft === undefined) continue;

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -294,22 +294,25 @@ export const listMarketingFlagsDraft = query({
   args: {},
   handler: async (ctx) => {
     await requireCmsOwner(ctx);
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all([
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all([
       getSectionMetaRow(ctx, "about"),
       getSectionMetaRow(ctx, "recordings"),
       getSectionMetaRow(ctx, "pricing"),
+      getSectionMetaRow(ctx, "photos"),
     ]);
 
     const flags = {
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
+      galleryPage: effectiveIsEnabled(photosRow, "photos"),
     };
 
     const hasDraftChanges = anyMarketingFlagDraftPending(
       aboutRow,
       recordingsRow,
       pricingRow,
+      photosRow,
     );
 
     // Expose per-section meta so the publish toolbar can disambiguate which
@@ -318,11 +321,13 @@ export const listMarketingFlagsDraft = query({
       aboutRow?.publishedAt ?? null,
       recordingsRow?.publishedAt ?? null,
       pricingRow?.publishedAt ?? null,
+      photosRow?.publishedAt ?? null,
     ]);
     const updatedAt = latestNumber([
       aboutRow?.updatedAt ?? null,
       recordingsRow?.updatedAt ?? null,
       pricingRow?.updatedAt ?? null,
+      photosRow?.updatedAt ?? null,
     ]);
 
     return {
@@ -330,10 +335,16 @@ export const listMarketingFlagsDraft = query({
       hasDraftChanges,
       publishedAt,
       publishedBy:
-        mostRecentPublishedBy([aboutRow, recordingsRow, pricingRow]) ?? null,
+        mostRecentPublishedBy([
+          aboutRow,
+          recordingsRow,
+          pricingRow,
+          photosRow,
+        ]) ?? null,
       updatedAt,
       updatedBy:
-        mostRecentUpdatedBy([aboutRow, recordingsRow, pricingRow]) ?? null,
+        mostRecentUpdatedBy([aboutRow, recordingsRow, pricingRow, photosRow]) ??
+        null,
       perSection: {
         about: {
           isEnabled: publishedIsEnabled(aboutRow, "about"),
@@ -358,6 +369,14 @@ export const listMarketingFlagsDraft = query({
             pricingRow.isEnabledDraft !==
               publishedIsEnabled(pricingRow, "pricing"),
         },
+        photos: {
+          isEnabled: publishedIsEnabled(photosRow, "photos"),
+          isEnabledDraft: photosRow?.isEnabledDraft ?? null,
+          hasPendingFlagChange:
+            photosRow?.isEnabledDraft !== undefined &&
+            photosRow.isEnabledDraft !==
+              publishedIsEnabled(photosRow, "photos"),
+        },
       },
     };
   },
@@ -378,22 +397,27 @@ export const getPreviewMarketingFeatureFlags = query({
       return null;
     }
 
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all([
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all([
       getSectionMetaRow(ctx, "about"),
       getSectionMetaRow(ctx, "recordings"),
       getSectionMetaRow(ctx, "pricing"),
+      getSectionMetaRow(ctx, "photos"),
     ]);
 
     const hasDraftChanges = anyMarketingFlagDraftPending(
       aboutRow,
       recordingsRow,
       pricingRow,
+      photosRow,
     );
 
     return {
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
+      galleryPage: effectiveIsEnabled(photosRow, "photos"),
+      /** Published-only; when `false`, public `/gallery` 404s unless draft changes this. */
+      galleryPagePublished: publishedIsEnabled(photosRow, "photos"),
       hasDraftChanges,
     };
   },
@@ -453,7 +477,12 @@ export const publishMarketingFlags = mutation({
     const published: Array<
       Awaited<ReturnType<typeof publishSectionCore>>
     > = [];
-    for (const section of ["about", "recordings", "pricing"] as const) {
+    for (const section of [
+      "about",
+      "recordings",
+      "pricing",
+      "photos",
+    ] as const) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || !sectionHasPendingFlagDraft(row, section)) continue;
       const result = await publishSectionCore(ctx, {
@@ -491,7 +520,12 @@ export const discardMarketingFlagsDraft = mutation({
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
     let discarded = false;
-    for (const section of ["about", "recordings", "pricing"] as const) {
+    for (const section of [
+      "about",
+      "recordings",
+      "pricing",
+      "photos",
+    ] as const) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || row.isEnabledDraft === undefined) continue;
       await ctx.db.patch(row._id, {
@@ -737,6 +771,10 @@ async function readSnapshotForAdmin(
   if (section === "amenitiesNearby") {
     const tree = await loadAmenitiesNearbyTree(ctx, scope);
     return snapshotFromAmenitiesTree(tree);
+  }
+
+  if (section === "photos") {
+    return defaultSnapshotForSection("photos");
   }
 
   // recordings — flag-only, no content. Return an empty about-shaped default

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -314,13 +314,15 @@ export const listMarketingFlagsDraft = query({
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
-      galleryPage: effectiveIsEnabled(photosRow, "photos"),
+      galleryPage: publishedIsEnabled(photosRow, "photos"),
     };
 
-    const hasDraftChanges =
-      sectionHasPendingFlagDraft(aboutRow, "about") ||
-      sectionHasPendingFlagDraft(recordingsRow, "recordings") ||
-      sectionHasPendingFlagDraft(pricingRow, "pricing");
+    const hasDraftChanges = anyMarketingFlagDraftPending(
+      aboutRow,
+      recordingsRow,
+      pricingRow,
+      photosRow,
+    );
 
     // Expose per-section meta so the publish toolbar can disambiguate which
     // sections need the `publishSection` mutation to promote a flag draft.

--- a/convex/cmsMeta.test.ts
+++ b/convex/cmsMeta.test.ts
@@ -40,6 +40,10 @@ describe("DEFAULT_IS_ENABLED", () => {
   test("amenities nearby ships on with the homepage", () => {
     expect(DEFAULT_IS_ENABLED.amenitiesNearby).toBe(true);
   });
+
+  test("public gallery page ships on by default", () => {
+    expect(DEFAULT_IS_ENABLED.photos).toBe(true);
+  });
 });
 
 describe("effectiveIsEnabled", () => {
@@ -114,14 +118,14 @@ describe("sectionHasPendingFlagDraft", () => {
 describe("anyMarketingFlagDraftPending", () => {
   test("false when no section has a flag draft", () => {
     expect(
-      anyMarketingFlagDraftPending(row(), row(), row()),
+      anyMarketingFlagDraftPending(row(), row(), row(), null),
     ).toBe(false);
   });
 
   test("true when about has a pending flag draft", () => {
     const about = row({ isEnabled: false, isEnabledDraft: true });
     expect(
-      anyMarketingFlagDraftPending(about, row(), row()),
+      anyMarketingFlagDraftPending(about, row(), row(), null),
     ).toBe(true);
   });
 
@@ -132,7 +136,7 @@ describe("anyMarketingFlagDraftPending", () => {
       isEnabledDraft: true,
     });
     expect(
-      anyMarketingFlagDraftPending(row(), recordings, row()),
+      anyMarketingFlagDraftPending(row(), recordings, row(), null),
     ).toBe(true);
   });
 
@@ -143,11 +147,22 @@ describe("anyMarketingFlagDraftPending", () => {
       isEnabledDraft: false,
     });
     expect(
-      anyMarketingFlagDraftPending(row(), row(), pricing),
+      anyMarketingFlagDraftPending(row(), row(), pricing, null),
+    ).toBe(true);
+  });
+
+  test("true when photos (gallery page) has a pending flag draft", () => {
+    const photos = row({
+      section: "photos",
+      isEnabled: true,
+      isEnabledDraft: false,
+    });
+    expect(
+      anyMarketingFlagDraftPending(row(), row(), row(), photos),
     ).toBe(true);
   });
 
   test("null rows are tolerated", () => {
-    expect(anyMarketingFlagDraftPending(null, null, null)).toBe(false);
+    expect(anyMarketingFlagDraftPending(null, null, null, null)).toBe(false);
   });
 });

--- a/convex/cmsMeta.ts
+++ b/convex/cmsMeta.ts
@@ -32,6 +32,8 @@ export const DEFAULT_IS_ENABLED: Record<CmsSection, boolean> = {
   recordings: false,
   faq: true,
   amenitiesNearby: true,
+  /** Public `/gallery` page + "Gallery" nav; carousel uses `showInCarousel` on each photo. */
+  photos: true,
 };
 
 export async function getSectionMetaRow(
@@ -123,6 +125,7 @@ export async function sectionHasContentDraftDiff(
   section: CmsSection,
 ): Promise<boolean> {
   if (section === "recordings") return false;
+  if (section === "photos") return false;
 
   if (section === "faq") {
     const draft = await loadFaqTree(ctx, "draft");
@@ -170,16 +173,18 @@ export function sectionHasPendingFlagDraft(
   return row.isEnabledDraft !== (row.isEnabled ?? DEFAULT_IS_ENABLED[section]);
 }
 
-/** True when about, recordings, or pricing has a pending `isEnabledDraft`. */
+/** True when any marketing-visibility or gallery-page section has a pending `isEnabledDraft`. */
 export function anyMarketingFlagDraftPending(
   aboutRow: Doc<"cmsSections"> | null,
   recordingsRow: Doc<"cmsSections"> | null,
   pricingRow: Doc<"cmsSections"> | null,
+  photosRow: Doc<"cmsSections"> | null = null,
 ): boolean {
   return (
     sectionHasPendingFlagDraft(aboutRow, "about") ||
     sectionHasPendingFlagDraft(recordingsRow, "recordings") ||
-    sectionHasPendingFlagDraft(pricingRow, "pricing")
+    sectionHasPendingFlagDraft(pricingRow, "pricing") ||
+    sectionHasPendingFlagDraft(photosRow, "photos")
   );
 }
 

--- a/convex/cmsShared.test.ts
+++ b/convex/cmsShared.test.ts
@@ -123,6 +123,7 @@ describe("defaultSnapshotForSection", () => {
     expect(defaultSnapshotForSection("about")).toEqual(ABOUT_DEFAULTS);
     expect(defaultSnapshotForSection("faq")).toEqual(FAQ_DEFAULTS);
     expect(defaultSnapshotForSection("amenitiesNearby")).toEqual({ rows: [] });
+    expect(defaultSnapshotForSection("photos")).toEqual({ rows: [] });
   });
 
   test("recordings returns an about-shaped placeholder (no content table)", () => {

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -249,6 +249,9 @@ export function defaultSnapshotForSection(section: CmsSection): CmsSnapshot {
       return FAQ_DEFAULTS;
     case "amenitiesNearby":
       return { rows: [] };
+    case "photos":
+      // No snapshot table for studio photos; placeholder for the legacy `saveDraft` union.
+      return { rows: [] };
   }
 }
 

--- a/convex/galleryPhotos.test.ts
+++ b/convex/galleryPhotos.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
   ALLOWED_GALLERY_IMAGE_TYPES,
+  GALLERY_CATEGORY_SLUGS,
   MAX_GALLERY_IMAGE_BYTES,
   MAX_GALLERY_PHOTOS,
   galleryDraftMatchesPublished,
+  isGalleryCategorySlug,
+  normalizeGalleryCategories,
 } from "./galleryPhotos";
 
 type Row = Doc<"galleryPhotos">;
@@ -95,5 +98,70 @@ describe("galleryDraftMatchesPublished", () => {
         [row({ storageId: "y" as unknown as Id<"_storage"> })],
       ),
     ).toBe(false);
+  });
+
+  test("different categories are not a match", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ categories: ["rooms"] })],
+        [row({ categories: ["gear"] })],
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined vs empty-array categories normalize to the same value", () => {
+    // Empty arrays serialize the same as `null` per `comparablePhoto`
+    // (both → `[]` ≠ `null`), so we explicitly check the undefined case
+    // to lock in the normalisation contract.
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ categories: undefined })],
+        [row({ categories: undefined })],
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isGalleryCategorySlug", () => {
+  test("accepts every catalogued slug", () => {
+    for (const slug of GALLERY_CATEGORY_SLUGS) {
+      expect(isGalleryCategorySlug(slug)).toBe(true);
+    }
+  });
+
+  test("rejects unknown values", () => {
+    expect(isGalleryCategorySlug("unknown")).toBe(false);
+    expect(isGalleryCategorySlug("Rooms")).toBe(false); // case-sensitive
+    expect(isGalleryCategorySlug("")).toBe(false);
+  });
+});
+
+describe("normalizeGalleryCategories", () => {
+  test("returns undefined for empty / nullish input", () => {
+    expect(normalizeGalleryCategories(undefined)).toBeUndefined();
+    expect(normalizeGalleryCategories(null)).toBeUndefined();
+    expect(normalizeGalleryCategories([])).toBeUndefined();
+  });
+
+  test("lower-cases and trims values, dropping invalid entries", () => {
+    expect(normalizeGalleryCategories(["  Rooms  ", "GEAR", "bogus"])).toEqual(
+      ["rooms", "gear"],
+    );
+  });
+
+  test("dedupes case-insensitively", () => {
+    expect(normalizeGalleryCategories(["rooms", "Rooms", "ROOMS"])).toEqual([
+      "rooms",
+    ]);
+  });
+
+  test("returns canonical catalogue order (rooms, gear, grounds)", () => {
+    expect(
+      normalizeGalleryCategories(["grounds", "rooms", "gear"]),
+    ).toEqual(["rooms", "gear", "grounds"]);
+  });
+
+  test("returns undefined when nothing in the input is valid", () => {
+    expect(normalizeGalleryCategories(["bogus", "  "])).toBeUndefined();
   });
 });

--- a/convex/galleryPhotos.test.ts
+++ b/convex/galleryPhotos.test.ts
@@ -109,6 +109,15 @@ describe("galleryDraftMatchesPublished", () => {
     ).toBe(false);
   });
 
+  test("different showInCarousel / showInGallery are not a match", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ showInCarousel: true, showInGallery: false })],
+        [row({ showInCarousel: false, showInGallery: true })],
+      ),
+    ).toBe(false);
+  });
+
   test("undefined vs empty-array categories normalize to the same value", () => {
     // Empty arrays serialize the same as `null` per `comparablePhoto`
     // (both → `[]` ≠ `null`), so we explicitly check the undefined case

--- a/convex/galleryPhotos.test.ts
+++ b/convex/galleryPhotos.test.ts
@@ -119,12 +119,15 @@ describe("galleryDraftMatchesPublished", () => {
   });
 
   test("undefined vs empty-array categories normalize to the same value", () => {
-    // Empty arrays serialize the same as `null` per `comparablePhoto`
-    // (both → `[]` ≠ `null`), so we explicitly check the undefined case
-    // to lock in the normalisation contract.
     expect(
       galleryDraftMatchesPublished(
         [row({ categories: undefined })],
+        [row({ categories: [] })],
+      ),
+    ).toBe(true);
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ categories: [] })],
         [row({ categories: undefined })],
       ),
     ).toBe(true);

--- a/convex/galleryPhotos.test.ts
+++ b/convex/galleryPhotos.test.ts
@@ -109,6 +109,15 @@ describe("galleryDraftMatchesPublished", () => {
     ).toBe(false);
   });
 
+  test("category order is canonicalized before comparing", () => {
+    expect(
+      galleryDraftMatchesPublished(
+        [row({ categories: ["rooms", "gear"] })],
+        [row({ categories: ["gear", "rooms"] })],
+      ),
+    ).toBe(true);
+  });
+
   test("different showInCarousel / showInGallery are not a match", () => {
     expect(
       galleryDraftMatchesPublished(

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -87,6 +87,8 @@ function comparablePhoto(row: GalleryPhotoDoc) {
     sizeBytes: row.sizeBytes,
     originalFileName: row.originalFileName ?? null,
     categories: row.categories ?? null,
+    showInCarousel: row.showInCarousel ?? null,
+    showInGallery: row.showInGallery ?? null,
   };
 }
 
@@ -187,6 +189,12 @@ export async function replaceGalleryScope(
       ...(row.categories !== undefined && row.categories.length > 0
         ? { categories: [...row.categories] }
         : {}),
+      ...(row.showInCarousel !== undefined
+        ? { showInCarousel: row.showInCarousel }
+        : {}),
+      ...(row.showInGallery !== undefined
+        ? { showInGallery: row.showInGallery }
+        : {}),
     });
   }
 
@@ -229,6 +237,8 @@ export async function materializeGalleryPhotos(
     sizeBytes: number;
     originalFileName: string | null;
     categories: GalleryCategorySlug[];
+    showInCarousel: boolean;
+    showInGallery: boolean;
   }>
 > {
   return await Promise.all(
@@ -245,6 +255,8 @@ export async function materializeGalleryPhotos(
       sizeBytes: row.sizeBytes,
       originalFileName: row.originalFileName ?? null,
       categories: normalizeGalleryCategories(row.categories) ?? [],
+      showInCarousel: row.showInCarousel !== false,
+      showInGallery: row.showInGallery !== false,
     })),
   );
 }

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -87,8 +87,8 @@ function comparablePhoto(row: GalleryPhotoDoc) {
     sizeBytes: row.sizeBytes,
     originalFileName: row.originalFileName ?? null,
     categories: row.categories ?? null,
-    showInCarousel: row.showInCarousel ?? null,
-    showInGallery: row.showInGallery ?? null,
+    showInCarousel: row.showInCarousel !== false,
+    showInGallery: row.showInGallery !== false,
   };
 }
 

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -39,6 +39,32 @@ export const GALLERY_CATEGORY_LABELS: Record<GalleryCategorySlug, string> = {
   grounds: "Grounds",
 };
 
+/**
+ * Admin checkbox copy for each catalogue slug. Single source for public pills
+ * (`GALLERY_CATEGORY_LABELS`) + editor UI.
+ */
+export const GALLERY_CATEGORY_ADMIN_OPTIONS: ReadonlyArray<{
+  readonly slug: GalleryCategorySlug;
+  readonly label: string;
+  readonly description: string;
+}> = [
+  {
+    slug: "rooms",
+    label: GALLERY_CATEGORY_LABELS.rooms,
+    description: "Live rooms, control room, iso booths.",
+  },
+  {
+    slug: "gear",
+    label: GALLERY_CATEGORY_LABELS.gear,
+    description: "Console, racks, mics, instruments.",
+  },
+  {
+    slug: "grounds",
+    label: GALLERY_CATEGORY_LABELS.grounds,
+    description: "Exteriors, hallway, residential wing.",
+  },
+];
+
 export function isGalleryCategorySlug(
   value: string,
 ): value is GalleryCategorySlug {
@@ -86,7 +112,8 @@ function comparablePhoto(row: GalleryPhotoDoc) {
     contentType: row.contentType,
     sizeBytes: row.sizeBytes,
     originalFileName: row.originalFileName ?? null,
-    categories: row.categories ?? null,
+    categories:
+      row.categories && row.categories.length > 0 ? row.categories : null,
     showInCarousel: row.showInCarousel !== false,
     showInGallery: row.showInGallery !== false,
   };

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -22,6 +22,53 @@ export const MAX_GALLERY_IMAGE_BYTES = 50 * 1024 * 1024;
 export const MAX_GALLERY_PHOTOS = 40;
 const GALLERY_QUERY_LIMIT = 128;
 
+/**
+ * INF-47 — controlled vocabulary for the `/gallery` page filter pills
+ * (Variant C header pattern). Stored on each photo as lower-case slugs.
+ * The implicit `"all"` filter never lives in the array; the public page
+ * derives it.
+ */
+export const GALLERY_CATEGORY_SLUGS = ["rooms", "gear", "grounds"] as const;
+
+export type GalleryCategorySlug = (typeof GALLERY_CATEGORY_SLUGS)[number];
+
+/** Display labels for the public filter pills. Order matches the design. */
+export const GALLERY_CATEGORY_LABELS: Record<GalleryCategorySlug, string> = {
+  rooms: "Rooms",
+  gear: "Gear",
+  grounds: "Grounds",
+};
+
+export function isGalleryCategorySlug(
+  value: string,
+): value is GalleryCategorySlug {
+  return (GALLERY_CATEGORY_SLUGS as readonly string[]).includes(value);
+}
+
+/**
+ * Normalise a raw categories array (already trimmed in the caller) by
+ * lower-casing, validating against the controlled vocabulary, and removing
+ * duplicates while preserving the catalogue order. Returns `undefined` when
+ * no valid categories remain so callers can omit the field on the
+ * underlying document.
+ */
+export function normalizeGalleryCategories(
+  raw: readonly string[] | null | undefined,
+): GalleryCategorySlug[] | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const seen = new Set<GalleryCategorySlug>();
+  for (const value of raw) {
+    if (typeof value !== "string") continue;
+    const slug = value.trim().toLowerCase();
+    if (slug.length === 0) continue;
+    if (isGalleryCategorySlug(slug)) {
+      seen.add(slug);
+    }
+  }
+  if (seen.size === 0) return undefined;
+  return GALLERY_CATEGORY_SLUGS.filter((slug) => seen.has(slug));
+}
+
 export type GalleryScope = Doc<"galleryPhotos">["scope"];
 export type GalleryPhotoDoc = Doc<"galleryPhotos">;
 export type GalleryMetaDoc = Doc<"galleryPhotoMeta">;
@@ -39,6 +86,7 @@ function comparablePhoto(row: GalleryPhotoDoc) {
     contentType: row.contentType,
     sizeBytes: row.sizeBytes,
     originalFileName: row.originalFileName ?? null,
+    categories: row.categories ?? null,
   };
 }
 
@@ -136,6 +184,9 @@ export async function replaceGalleryScope(
       ...(row.originalFileName !== undefined
         ? { originalFileName: row.originalFileName }
         : {}),
+      ...(row.categories !== undefined && row.categories.length > 0
+        ? { categories: [...row.categories] }
+        : {}),
     });
   }
 
@@ -177,6 +228,7 @@ export async function materializeGalleryPhotos(
     contentType: string;
     sizeBytes: number;
     originalFileName: string | null;
+    categories: GalleryCategorySlug[];
   }>
 > {
   return await Promise.all(
@@ -192,6 +244,7 @@ export async function materializeGalleryPhotos(
       contentType: row.contentType,
       sizeBytes: row.sizeBytes,
       originalFileName: row.originalFileName ?? null,
+      categories: normalizeGalleryCategories(row.categories) ?? [],
     })),
   );
 }

--- a/convex/galleryPhotos.ts
+++ b/convex/galleryPhotos.ts
@@ -113,7 +113,7 @@ function comparablePhoto(row: GalleryPhotoDoc) {
     sizeBytes: row.sizeBytes,
     originalFileName: row.originalFileName ?? null,
     categories:
-      row.categories && row.categories.length > 0 ? row.categories : null,
+      normalizeGalleryCategories(row.categories ?? null) ?? null,
     showInCarousel: row.showInCarousel !== false,
     showInGallery: row.showInGallery !== false,
   };
@@ -199,6 +199,7 @@ export async function replaceGalleryScope(
   }
 
   for (const row of source) {
+    const categories = normalizeGalleryCategories(row.categories);
     await ctx.db.insert("galleryPhotos", {
       scope: toScope,
       stableId: row.stableId,
@@ -213,9 +214,7 @@ export async function replaceGalleryScope(
       ...(row.originalFileName !== undefined
         ? { originalFileName: row.originalFileName }
         : {}),
-      ...(row.categories !== undefined && row.categories.length > 0
-        ? { categories: [...row.categories] }
-        : {}),
+      ...(categories !== undefined ? { categories } : {}),
       ...(row.showInCarousel !== undefined
         ? { showInCarousel: row.showInCarousel }
         : {}),

--- a/convex/marketingFeatureFlags.ts
+++ b/convex/marketingFeatureFlags.ts
@@ -90,12 +90,13 @@ export const listDraft = query({
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
-      galleryPage: effectiveIsEnabled(photosRow, "photos"),
+      galleryPage: publishedIsEnabled(photosRow, "photos"),
     };
     const hasDraftChanges = anyMarketingFlagDraftPending(
       aboutRow,
       recordingsRow,
       pricingRow,
+      photosRow,
     );
 
     const publishedAt = latestTimestamp([

--- a/convex/marketingFeatureFlags.ts
+++ b/convex/marketingFeatureFlags.ts
@@ -34,10 +34,11 @@ import { publishSectionCore } from "./cmsPublishHelpers";
 import { requireCmsOwner } from "./lib/auth";
 import type { CmsSection } from "./cmsShared";
 
-const SECTIONS: Array<"about" | "recordings" | "pricing"> = [
+const SECTIONS: Array<"about" | "recordings" | "pricing" | "photos"> = [
   "about",
   "recordings",
   "pricing",
+  "photos",
 ];
 
 function latestTimestamp(values: Array<number | null | undefined>): number | null {
@@ -56,13 +57,14 @@ function latestTimestamp(values: Array<number | null | undefined>): number | nul
 export const getPublishedMarketingFeatureFlags = query({
   args: {},
   handler: async (ctx) => {
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all(
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all(
       SECTIONS.map((section) => getSectionMetaRow(ctx, section)),
     );
     return {
       aboutPage: publishedIsEnabled(aboutRow, "about"),
       recordingsPage: publishedIsEnabled(recordingsRow, "recordings"),
       pricingSection: publishedIsEnabled(pricingRow, "pricing"),
+      galleryPage: publishedIsEnabled(photosRow, "photos"),
     };
   },
 });
@@ -76,29 +78,33 @@ export const listDraft = query({
   args: {},
   handler: async (ctx) => {
     await requireCmsOwner(ctx);
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all(
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all(
       SECTIONS.map((section) => getSectionMetaRow(ctx, section)),
     );
     const flags = {
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
+      galleryPage: effectiveIsEnabled(photosRow, "photos"),
     };
     const hasDraftChanges = anyMarketingFlagDraftPending(
       aboutRow,
       recordingsRow,
       pricingRow,
+      photosRow,
     );
 
     const publishedAt = latestTimestamp([
       aboutRow?.publishedAt ?? null,
       recordingsRow?.publishedAt ?? null,
       pricingRow?.publishedAt ?? null,
+      photosRow?.publishedAt ?? null,
     ]);
     const updatedAt = latestTimestamp([
       aboutRow?.updatedAt,
       recordingsRow?.updatedAt,
       pricingRow?.updatedAt,
+      photosRow?.updatedAt,
     ]);
 
     return {
@@ -109,12 +115,14 @@ export const listDraft = query({
         aboutRow?.publishedBy ??
         recordingsRow?.publishedBy ??
         pricingRow?.publishedBy ??
+        photosRow?.publishedBy ??
         null,
       updatedAt,
       updatedBy:
         aboutRow?.updatedBy ??
         recordingsRow?.updatedBy ??
         pricingRow?.updatedBy ??
+        photosRow?.updatedBy ??
         null,
     };
   },
@@ -136,19 +144,21 @@ export const getPreviewMarketingFeatureFlags = query({
       return null;
     }
 
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all(
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all(
       SECTIONS.map((section) => getSectionMetaRow(ctx, section)),
     );
     const hasDraftChanges = anyMarketingFlagDraftPending(
       aboutRow,
       recordingsRow,
       pricingRow,
+      photosRow,
     );
 
     return {
       aboutPage: effectiveIsEnabled(aboutRow, "about"),
       recordingsPage: effectiveIsEnabled(recordingsRow, "recordings"),
       pricingSection: effectiveIsEnabled(pricingRow, "pricing"),
+      galleryPage: effectiveIsEnabled(photosRow, "photos"),
       hasDraftChanges,
     };
   },

--- a/convex/marketingFeatureFlags.ts
+++ b/convex/marketingFeatureFlags.ts
@@ -40,6 +40,11 @@ const SECTIONS: Array<"about" | "recordings" | "pricing" | "photos"> = [
   "pricing",
   "photos",
 ];
+const MARKETING_FLAG_SECTIONS: Array<"about" | "recordings" | "pricing"> = [
+  "about",
+  "recordings",
+  "pricing",
+];
 
 function latestTimestamp(values: Array<number | null | undefined>): number | null {
   let out: number | null = null;
@@ -91,20 +96,17 @@ export const listDraft = query({
       aboutRow,
       recordingsRow,
       pricingRow,
-      photosRow,
     );
 
     const publishedAt = latestTimestamp([
       aboutRow?.publishedAt ?? null,
       recordingsRow?.publishedAt ?? null,
       pricingRow?.publishedAt ?? null,
-      photosRow?.publishedAt ?? null,
     ]);
     const updatedAt = latestTimestamp([
       aboutRow?.updatedAt,
       recordingsRow?.updatedAt,
       pricingRow?.updatedAt,
-      photosRow?.updatedAt,
     ]);
 
     return {
@@ -115,14 +117,12 @@ export const listDraft = query({
         aboutRow?.publishedBy ??
         recordingsRow?.publishedBy ??
         pricingRow?.publishedBy ??
-        photosRow?.publishedBy ??
         null,
       updatedAt,
       updatedBy:
         aboutRow?.updatedBy ??
         recordingsRow?.updatedBy ??
         pricingRow?.updatedBy ??
-        photosRow?.updatedBy ??
         null,
     };
   },
@@ -207,7 +207,7 @@ export const publishMarketingFeatureFlags = mutation({
     const published: Array<
       Awaited<ReturnType<typeof publishSectionCore>>
     > = [];
-    for (const section of SECTIONS) {
+    for (const section of MARKETING_FLAG_SECTIONS) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row) continue;
       const flagPending =
@@ -241,14 +241,15 @@ export const publishMarketingFeatureFlags = mutation({
 
 /**
  * Legacy `marketingFeatureFlags:discardMarketingFeatureFlagsDraft`. Clears
- * `isEnabledDraft` on every section without touching their content drafts.
+ * `isEnabledDraft` on legacy marketing sections without touching their
+ * content drafts. Gallery-page visibility drafts belong to `/admin/photos`.
  */
 export const discardMarketingFeatureFlagsDraft = mutation({
   args: {},
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
     let discarded = false;
-    for (const section of SECTIONS) {
+    for (const section of MARKETING_FLAG_SECTIONS) {
       const row = await getSectionMetaRow(ctx, section);
       if (!row || row.isEnabledDraft === undefined) continue;
       await ctx.db.patch(row._id, {

--- a/convex/photosCmsFlags.ts
+++ b/convex/photosCmsFlags.ts
@@ -1,5 +1,9 @@
 import type { MutationCtx } from "./_generated/server";
-import { ensureSectionMetaRow, recomputeSectionHasDraftChanges } from "./cmsMeta";
+import {
+  ensureSectionMetaRow,
+  recomputeSectionHasDraftChanges,
+  sectionHasPendingFlagDraft,
+} from "./cmsMeta";
 
 /**
  * Promote `cmsSections.photos.isEnabledDraft` → `isEnabled` (public gallery page + nav).
@@ -17,8 +21,19 @@ export async function promoteGalleryPageCmsFlag(
   if (typeof row.isEnabledDraft !== "boolean") {
     return;
   }
-  const nextIsEnabled = row.isEnabledDraft;
   const now = Date.now();
+
+  if (!sectionHasPendingFlagDraft(row, "photos")) {
+    await ctx.db.patch(id, {
+      isEnabledDraft: undefined,
+      updatedAt: now,
+      updatedBy: args.updatedBy,
+    });
+    await recomputeSectionHasDraftChanges(ctx, "photos", args.updatedBy);
+    return;
+  }
+
+  const nextIsEnabled = row.isEnabledDraft;
   await ctx.db.patch(id, {
     isEnabled: nextIsEnabled,
     isEnabledDraft: undefined,

--- a/convex/photosCmsFlags.ts
+++ b/convex/photosCmsFlags.ts
@@ -1,0 +1,32 @@
+import type { MutationCtx } from "./_generated/server";
+import { ensureSectionMetaRow, recomputeSectionHasDraftChanges } from "./cmsMeta";
+
+/**
+ * Promote `cmsSections.photos.isEnabledDraft` → `isEnabled` (public gallery page + nav).
+ * Call after `publishGalleryDraftCore` so one Publish button flips the gallery flag too.
+ * Idempotent when there is no pending flag draft.
+ */
+export async function promoteGalleryPageCmsFlag(
+  ctx: MutationCtx,
+  args: {
+    userId: string;
+    updatedBy: string | undefined;
+  },
+): Promise<void> {
+  const { id, row } = await ensureSectionMetaRow(ctx, "photos", args.updatedBy);
+  if (typeof row.isEnabledDraft !== "boolean") {
+    return;
+  }
+  const nextIsEnabled = row.isEnabledDraft;
+  const now = Date.now();
+  await ctx.db.patch(id, {
+    isEnabled: nextIsEnabled,
+    isEnabledDraft: undefined,
+    hasDraftChanges: false,
+    publishedAt: now,
+    publishedBy: args.userId,
+    updatedAt: now,
+    updatedBy: args.updatedBy,
+  });
+  await recomputeSectionHasDraftChanges(ctx, "photos", args.updatedBy);
+}

--- a/convex/photosCmsFlags.ts
+++ b/convex/photosCmsFlags.ts
@@ -15,17 +15,28 @@ export async function promoteGalleryPageCmsFlag(
   args: {
     userId: string;
     updatedBy: string | undefined;
+    publishedAt?: number;
   },
 ): Promise<void> {
   const { id, row } = await ensureSectionMetaRow(ctx, "photos", args.updatedBy);
+  const now = args.publishedAt ?? Date.now();
   if (typeof row.isEnabledDraft !== "boolean") {
+    await ctx.db.patch(id, {
+      hasDraftChanges: false,
+      publishedAt: now,
+      publishedBy: args.userId,
+      updatedAt: now,
+      updatedBy: args.updatedBy,
+    });
     return;
   }
-  const now = Date.now();
 
   if (!sectionHasPendingFlagDraft(row, "photos")) {
     await ctx.db.patch(id, {
       isEnabledDraft: undefined,
+      hasDraftChanges: false,
+      publishedAt: now,
+      publishedBy: args.userId,
       updatedAt: now,
       updatedBy: args.updatedBy,
     });

--- a/convex/photosPreviewDraft.ts
+++ b/convex/photosPreviewDraft.ts
@@ -32,9 +32,48 @@ export const getPreviewGalleryPhotos = query({
       hasDraftChanges ? "draft" : "published",
     );
     const photos = await materializeGalleryPhotos(ctx, rows);
+    return {
+      photos: photos.filter(
+        (photo) => photo.url !== null && photo.showInGallery !== false,
+      ),
+      hasDraftChanges,
+    };
+  },
+});
+
+/**
+ * Owner-only: draft/published images for the homepage carousel (`showInCarousel`).
+ */
+export const getPreviewCarouselPhotos = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+
+    try {
+      await requireCmsOwner(ctx);
+    } catch {
+      return null;
+    }
+
+    const meta = await ctx.db
+      .query("galleryPhotoMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+
+    const hasDraftChanges = meta?.hasDraftChanges ?? false;
+    const rows = await loadGalleryPhotos(
+      ctx,
+      hasDraftChanges ? "draft" : "published",
+    );
+    const photos = await materializeGalleryPhotos(ctx, rows);
 
     return {
-      photos: photos.filter((photo) => photo.url !== null),
+      photos: photos.filter(
+        (photo) => photo.url !== null && photo.showInCarousel !== false,
+      ),
       hasDraftChanges,
     };
   },

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -89,13 +89,30 @@ export const getPublishedAbout = query({
 
 /**
  * Published studio gallery photos only. Anonymous; reads `scope === "published"`.
+ * Excludes images with `showInGallery === false`.
  */
 export const getPublishedGalleryPhotos = query({
   args: {},
   handler: async (ctx) => {
     const rows = await loadGalleryPhotos(ctx, "published");
     const photos = await materializeGalleryPhotos(ctx, rows);
-    return photos.filter((photo) => photo.url !== null);
+    return photos.filter(
+      (photo) => photo.url !== null && photo.showInGallery !== false,
+    );
+  },
+});
+
+/**
+ * Images for the homepage "The Space" carousel — same table, filtered by `showInCarousel !== false`.
+ */
+export const getPublishedCarouselPhotos = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await loadGalleryPhotos(ctx, "published");
+    const photos = await materializeGalleryPhotos(ctx, rows);
+    return photos.filter(
+      (photo) => photo.url !== null && photo.showInCarousel !== false,
+    );
   },
 });
 
@@ -173,21 +190,22 @@ export const getPublishedFaq = query({
 
 /**
  * Marketing-site visibility flags. Reads each section's `cmsSections.isEnabled`
- * and returns the historical shape `{ aboutPage, recordingsPage, pricingSection }`
- * so the existing frontend consumers keep working without changes.
+ * and returns `{ aboutPage, recordingsPage, pricingSection, galleryPage }`.
  */
 export const getPublishedMarketingFeatureFlags = query({
   args: {},
   handler: async (ctx) => {
-    const [aboutRow, recordingsRow, pricingRow] = await Promise.all([
+    const [aboutRow, recordingsRow, pricingRow, photosRow] = await Promise.all([
       getSectionMetaRow(ctx, "about"),
       getSectionMetaRow(ctx, "recordings"),
       getSectionMetaRow(ctx, "pricing"),
+      getSectionMetaRow(ctx, "photos"),
     ]);
     return {
       aboutPage: publishedIsEnabled(aboutRow, "about"),
       recordingsPage: publishedIsEnabled(recordingsRow, "recordings"),
       pricingSection: publishedIsEnabled(pricingRow, "pricing"),
+      galleryPage: publishedIsEnabled(photosRow, "photos"),
     };
   },
 });

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -212,6 +212,7 @@ export const cmsSectionValidator = v.union(
   v.literal("recordings"),
   v.literal("faq"),
   v.literal("amenitiesNearby"),
+  v.literal("photos"),
 );
 
 /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -156,6 +156,14 @@ export default defineSchema({
     contentType: v.string(),
     sizeBytes: v.number(),
     originalFileName: v.optional(v.string()),
+    /**
+     * INF-47 — gallery filter tags. Lower-case slugs from
+     * `GALLERY_CATEGORY_SLUGS` (`rooms` / `gear` / `grounds`). Optional so
+     * existing rows keep validating; missing means "uncategorized" and the
+     * photo only appears under the implicit "All" filter on the public
+     * gallery page.
+     */
+    categories: v.optional(v.array(v.string())),
   })
     .index("by_scope_and_sort", ["scope", "sortOrder"])
     .index("by_scope_and_stableId", ["scope", "stableId"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -164,6 +164,12 @@ export default defineSchema({
      * gallery page.
      */
     categories: v.optional(v.array(v.string())),
+    /**
+     * Which surfaces show this image. Missing defaults to `true` for back-compat.
+     * Both can be `true` so one upload can power the homepage carousel and /gallery.
+     */
+    showInCarousel: v.optional(v.boolean()),
+    showInGallery: v.optional(v.boolean()),
   })
     .index("by_scope_and_sort", ["scope", "sortOrder"])
     .index("by_scope_and_stableId", ["scope", "stableId"])

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -10,6 +10,7 @@ import type {
   PublicAboutTeamMember,
 } from "../../../convex/cmsShared";
 import { Header } from "@/components/header";
+import { PageHeader } from "@/components/page-header";
 import { SiteFooter } from "@/components/site-footer";
 import { AboutBodyContent } from "./about-body-content";
 import { cn } from "@/lib/utils";
@@ -143,6 +144,7 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
   const aboutHref = isPreview ? "/preview/about" : "/about";
   const homeSectionBase = isPreview ? "/preview" : "/";
   const recordingsNavHref = isPreview ? "/preview/recordings" : "/recordings";
+  const backToHomeHref = isPreview ? "/preview" : "/";
 
   const team = data.teamMembers ?? [];
   // Variant A composition features exactly two circular headshots — owner +
@@ -174,8 +176,37 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
       />
 
       <main>
-        <section className="relative" aria-labelledby="about-hero-title">
-          <div className="relative h-[70vh] md:h-[85vh] overflow-hidden">
+        <PageHeader
+          eyebrow="About the studio"
+          title={data.heroTitle}
+          meta="Lookout Mountain, TN — Est. 2019"
+          backHref={backToHomeHref}
+          titleId="about-hero-title"
+        />
+
+        {data.heroSubtitle ? (
+          <section
+            className="bg-washed-black px-6 pb-16 md:px-16 md:pb-24"
+            aria-label="Studio introduction"
+          >
+            <div className="mx-auto max-w-3xl">
+              <p
+                className={cn(
+                  revealDelay(0),
+                  "editorial-lede text-balance text-ivory/75",
+                )}
+              >
+                {data.heroSubtitle}
+              </p>
+            </div>
+          </section>
+        ) : null}
+
+        <section
+          className="relative bg-deep-forest"
+          aria-label="Studio image"
+        >
+          <div className="relative h-[55vh] overflow-hidden md:h-[70vh]">
             <Image
               src={heroImageSrc}
               alt=""
@@ -188,40 +219,8 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
             />
             <div
               aria-hidden
-              className="absolute inset-0 bg-gradient-to-b from-deep-forest/60 via-deep-forest/30 to-deep-forest"
+              className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-deep-forest"
             />
-            <div className="absolute inset-0 flex items-end">
-              <div className="mx-auto w-full max-w-7xl px-6 pb-16 md:px-16 md:pb-24">
-                <nav aria-label="Breadcrumb" className={revealDelay(0)}>
-                  <Link
-                    href="/"
-                    className="label-text text-sand/60 hover:text-sand transition-colors text-[11px] tracking-[0.2em]"
-                  >
-                    ← Lula Lake Sound
-                  </Link>
-                </nav>
-                <h1
-                  id="about-hero-title"
-                  className={cn(
-                    revealDelay(2),
-                    "headline-primary text-warm-white leading-[1.05] mt-6 text-balance",
-                  )}
-                  style={{ fontSize: "clamp(2.5rem, 6vw, 5.5rem)" }}
-                >
-                  {data.heroTitle}
-                </h1>
-                {data.heroSubtitle ? (
-                  <p
-                    className={cn(
-                      revealDelay(3),
-                      "body-text text-ivory/75 mt-6 max-w-2xl text-lg md:text-xl leading-[1.6]",
-                    )}
-                  >
-                    {data.heroSubtitle}
-                  </p>
-                ) : null}
-              </div>
-            </div>
           </div>
         </section>
 

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -187,6 +187,7 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
           meta="Lookout Mountain, TN — Est. 2019"
           backHref={backToHomeHref}
           titleId="about-hero-title"
+          titleSize="about"
         />
 
         {data.heroSubtitle ? (

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -14,7 +14,10 @@ import { PageHeader } from "@/components/page-header";
 import { SiteFooter } from "@/components/site-footer";
 import { AboutBodyContent } from "./about-body-content";
 import { cn } from "@/lib/utils";
-import type { MarketingFeatureFlags } from "@/lib/site-settings";
+import {
+  isGalleryPageEnabled,
+  type MarketingFeatureFlags,
+} from "@/lib/site-settings";
 
 /**
  * Shared presentational layer for the public About page and the owner-only
@@ -145,6 +148,7 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
   const homeSectionBase = isPreview ? "/preview" : "/";
   const recordingsNavHref = isPreview ? "/preview/recordings" : "/recordings";
   const backToHomeHref = isPreview ? "/preview" : "/";
+  const showGallery = isGalleryPageEnabled(marketing);
 
   const team = data.teamMembers ?? [];
   // Variant A composition features exactly two circular headshots — owner +
@@ -171,6 +175,7 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
         showAbout={showAboutNav}
         aboutHref={aboutHref}
         showRecordings={showRecordings}
+        showGallery={showGallery}
         homeSectionBase={homeSectionBase}
         recordingsHref={recordingsNavHref}
       />

--- a/src/app/admin/photos/photos-editor.test.ts
+++ b/src/app/admin/photos/photos-editor.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  GALLERY_CATEGORY_OPTIONS,
   defaultAltFromFileName,
   formatBytes,
+  sameCategories,
   validatePhotoFields,
 } from "./photos-editor";
 
@@ -67,5 +69,40 @@ describe("validatePhotoFields", () => {
   test("valid alt + short caption passes", () => {
     expect(validatePhotoFields("cool studio", "")).toBeNull();
     expect(validatePhotoFields("cool studio", "A caption")).toBeNull();
+  });
+});
+
+describe("sameCategories", () => {
+  test("two empty arrays are equal", () => {
+    expect(sameCategories([], [])).toBe(true);
+  });
+
+  test("different lengths are not equal", () => {
+    expect(sameCategories(["rooms"], [])).toBe(false);
+    expect(sameCategories(["rooms"], ["rooms", "gear"])).toBe(false);
+  });
+
+  test("same items in same order are equal", () => {
+    expect(sameCategories(["rooms", "gear"], ["rooms", "gear"])).toBe(true);
+  });
+
+  test("same items in different order are not equal (canonical order matters)", () => {
+    expect(sameCategories(["rooms", "gear"], ["gear", "rooms"])).toBe(false);
+  });
+});
+
+describe("GALLERY_CATEGORY_OPTIONS", () => {
+  test("matches the public Convex catalogue (rooms, gear, grounds)", () => {
+    expect(GALLERY_CATEGORY_OPTIONS.map((option) => option.slug)).toEqual([
+      "rooms",
+      "gear",
+      "grounds",
+    ]);
+  });
+
+  test("every option carries a non-empty user-facing label", () => {
+    for (const option of GALLERY_CATEGORY_OPTIONS) {
+      expect(option.label.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -298,7 +298,6 @@ function PhotosEditorForm() {
   const saveSectionIsEnabledDraft = useMutation(
     api.cms.saveSectionIsEnabledDraft,
   );
-  const discardCmsSection = useMutation(api.cms.discardDraft);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
@@ -989,21 +988,12 @@ function PhotosEditorForm() {
 
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
-    if (data?.hasDraftChanges) {
+    if (data?.hasDraftChanges || hasGalleryPageFlagPending) {
       const outcome = await runAdminEffect(
         convexMutationEffect(() => discardDraftPhotos({})),
         { onErrorMessage: setInlineError },
       );
       if (outcome === undefined) {
-        return false;
-      }
-    }
-    if (hasGalleryPageFlagPending) {
-      const flagOutcome = await runAdminEffect(
-        convexMutationEffect(() => discardCmsSection({ section: "photos" })),
-        { onErrorMessage: setInlineError },
-      );
-      if (flagOutcome === undefined) {
         return false;
       }
     }
@@ -1017,7 +1007,6 @@ function PhotosEditorForm() {
     return true;
   }, [
     data?.hasDraftChanges,
-    discardCmsSection,
     discardDraftPhotos,
     hasGalleryPageFlagPending,
   ]);

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -320,8 +320,8 @@ function PhotosEditorForm() {
     position: "before" | "after";
   } | null>(null);
 
-  const [surfaceTab, setSurfaceTab] = useState<"carousel" | "gallery">(
-    "carousel",
+  const [surfaceTab, setSurfaceTab] = useState<"all" | "carousel" | "gallery">(
+    "all",
   );
 
   const photos = useMemo(
@@ -329,14 +329,23 @@ function PhotosEditorForm() {
     [data?.photos],
   );
 
+  /**
+   * Filter uses *edited* values so toggling a surface off immediately removes
+   * the card from that surface's tab — matching the mental model that the
+   * tab is a live filter on per-photo flags. The "All photos" tab is the
+   * recovery surface: it always shows everything, including orphans (both
+   * flags off) and pending changes.
+   */
   const visiblePhotos = useMemo(
     () =>
-      photos.filter((photo) =>
-        surfaceTab === "carousel"
-          ? photo.showInCarousel !== false
-          : photo.showInGallery !== false,
-      ),
-    [photos, surfaceTab],
+      photos.filter((photo) => {
+        if (surfaceTab === "all") return true;
+        const e = edits[photo.stableId];
+        const carousel = e?.showInCarousel ?? photo.showInCarousel;
+        const gallery = e?.showInGallery ?? photo.showInGallery;
+        return surfaceTab === "carousel" ? carousel !== false : gallery !== false;
+      }),
+    [edits, photos, surfaceTab],
   );
 
   const canReorder = visiblePhotos.length === photos.length && photos.length > 0;
@@ -375,6 +384,23 @@ function PhotosEditorForm() {
     const d = data.galleryPage.isEnabledDraft;
     return typeof d === "boolean" && d !== published;
   }, [data?.galleryPage]);
+
+  /**
+   * Per-surface counts use *edited* values so the tab labels reflect the
+   * pending shape of each surface as the user toggles. This is the most
+   * informative number to put on the filter chips — it answers "how many
+   * photos will be on Carousel after I publish?".
+   */
+  const surfaceCounts = useMemo(() => {
+    let carousel = 0;
+    let gallery = 0;
+    for (const photo of photos) {
+      const e = edits[photo.stableId];
+      if ((e?.showInCarousel ?? photo.showInCarousel) !== false) carousel += 1;
+      if ((e?.showInGallery ?? photo.showInGallery) !== false) gallery += 1;
+    }
+    return { all: photos.length, carousel, gallery };
+  }, [edits, photos]);
 
   const hasDraftOnServer =
     (data?.hasDraftChanges ?? false) || hasGalleryPageFlagPending;
@@ -823,8 +849,8 @@ function PhotosEditorForm() {
               width: dimensions?.width ?? null,
               height: dimensions?.height ?? null,
               originalFileName: file.name,
-              showInCarousel: surfaceTab === "carousel",
-              showInGallery: surfaceTab === "gallery",
+              showInCarousel: surfaceTab === "all" || surfaceTab === "carousel",
+              showInGallery: surfaceTab === "all" || surfaceTab === "gallery",
             }),
           ),
           { onErrorMessage: setInlineError },
@@ -1037,7 +1063,7 @@ function PhotosEditorForm() {
     busy,
     autosaveStatus: "idle",
     inlineError,
-    previewHref: surfaceTab === "carousel" ? "/preview" : "/preview/gallery",
+    previewHref: surfaceTab === "gallery" ? "/preview/gallery" : "/preview",
     onPublish: handleToolbarPublish,
     onDiscardConfirm: handleDiscardConfirm,
     // No `flush` — dirty local edits trigger the nav-guard confirm dialog
@@ -1095,42 +1121,63 @@ function PhotosEditorForm() {
               Studio gallery
             </h2>
             <p className="body-text-small max-w-2xl text-foreground/85">
-              Use the <span className="font-medium">Carousel</span> and{" "}
-              <span className="font-medium">Gallery</span> tabs to choose where
-              new uploads go and to set whether each image appears in the
-              homepage “The Space” carousel, the public Gallery page, or both.
-              Gallery categories (Rooms, Gear, Grounds) only apply to the
-              Gallery surface. Uploads are saved as draft; Publish pushes order,
-              per-surface flags, and the public Gallery page visibility to the
-              live site.
+              Each photo can appear on the homepage{" "}
+              <span className="font-medium">“The Space”</span> carousel, the
+              public <span className="font-medium">Gallery</span> page, or
+              both — choose per photo inside its card. The tabs below filter
+              the list by surface; uploads default to the active surface.
+              Gallery categories (Rooms, Gear, Grounds) apply to the Gallery
+              surface only. Publish pushes order, per-surface flags, and
+              Gallery page visibility live.
             </p>
-            <div className="flex flex-wrap items-center gap-2 pt-1">
+            <div
+              className="flex flex-wrap items-center gap-2 pt-1"
+              role="tablist"
+              aria-label="Filter photos by surface"
+            >
               <div className="inline-flex rounded-lg border border-border bg-muted/30 p-0.5">
                 {(
                   [
-                    ["carousel", "Homepage carousel"] as const,
-                    ["gallery", "Gallery page"] as const,
+                    ["all", "All photos", surfaceCounts.all] as const,
+                    ["carousel", "Homepage carousel", surfaceCounts.carousel] as const,
+                    ["gallery", "Gallery page", surfaceCounts.gallery] as const,
                   ] as const
-                ).map(([id, label]) => (
-                  <Button
-                    key={id}
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className={cn(
-                      "rounded-md px-3",
-                      surfaceTab === id
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground",
-                    )}
-                    onClick={() => setSurfaceTab(id)}
-                  >
-                    {label}
-                  </Button>
-                ))}
+                ).map(([id, label, count]) => {
+                  const isActive = surfaceTab === id;
+                  return (
+                    <Button
+                      key={id}
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      role="tab"
+                      aria-selected={isActive}
+                      className={cn(
+                        "rounded-md px-3 transition-colors",
+                        isActive
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                      onClick={() => setSurfaceTab(id)}
+                    >
+                      <span>{label}</span>
+                      <span
+                        className={cn(
+                          "ml-2 inline-flex h-4 min-w-[1.25rem] items-center justify-center rounded-sm px-1 text-[10px] font-medium tabular-nums",
+                          isActive
+                            ? "bg-muted text-foreground/85"
+                            : "bg-muted/60 text-muted-foreground",
+                        )}
+                        aria-hidden
+                      >
+                        {count}
+                      </span>
+                    </Button>
+                  );
+                })}
               </div>
             </div>
-            {surfaceTab === "gallery" ? (
+            {surfaceTab !== "carousel" ? (
               <div className="flex flex-col gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm font-medium text-foreground">
@@ -1263,10 +1310,20 @@ function PhotosEditorForm() {
           </p>
         </div>
       ) : visiblePhotos.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
+        <div className="space-y-2 rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
           <p className="body-text text-foreground/80">
-            No photos in this surface yet. Upload or use &quot;Also show
-            on…&quot; on a photo in the other tab.
+            No photos on this surface yet.
+          </p>
+          <p className="body-text-small text-foreground/70">
+            Switch to{" "}
+            <button
+              type="button"
+              onClick={() => setSurfaceTab("all")}
+              className="underline-offset-2 hover:underline"
+            >
+              All photos
+            </button>{" "}
+            to add an existing photo to this surface, or upload a new one.
           </p>
         </div>
       ) : (
@@ -1454,34 +1511,99 @@ function PhotosEditorForm() {
                       />
                     </label>
 
-                    <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
-                      <label
-                        htmlFor={`also-${photo.stableId}`}
-                        className="text-[11px] text-foreground/90"
-                      >
-                        {surfaceTab === "carousel"
-                          ? "Also show on Gallery page"
-                          : "Also show in homepage carousel"}
-                      </label>
-                      <Switch
-                        id={`also-${photo.stableId}`}
-                        checked={
-                          surfaceTab === "carousel"
-                            ? fields.showInGallery
-                            : fields.showInCarousel
-                        }
-                        onCheckedChange={(v) => {
-                          if (surfaceTab === "carousel") {
-                            updatePhotoEdit(photo, { showInGallery: v });
-                          } else {
-                            updatePhotoEdit(photo, { showInCarousel: v });
-                          }
-                        }}
-                        disabled={busy !== null || isRowBusy}
-                      />
-                    </div>
+                    <fieldset className="space-y-1.5 rounded-md border border-border/60 bg-muted/20 px-2.5 py-2">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <legend className="px-0.5 text-[10px] font-semibold uppercase tracking-wider text-foreground/70">
+                          Where it shows
+                        </legend>
+                        {!fields.showInCarousel && !fields.showInGallery ? (
+                          <span className="rounded-sm bg-amber-100/90 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-900 dark:bg-amber-500/20 dark:text-amber-200">
+                            Hidden everywhere
+                          </span>
+                        ) : null}
+                      </div>
+                      <ul className="space-y-1">
+                        {(
+                          [
+                            {
+                              key: "carousel",
+                              label: "Homepage carousel",
+                              edited: fields.showInCarousel,
+                              saved: photo.showInCarousel,
+                            },
+                            {
+                              key: "gallery",
+                              label: "Gallery page",
+                              edited: fields.showInGallery,
+                              saved: photo.showInGallery,
+                            },
+                          ] as const
+                        ).map(({ key, label, edited, saved }) => {
+                          const willChange = edited !== saved;
+                          const inputId = `surface-${key}-${photo.stableId}`;
+                          return (
+                            <li
+                              key={key}
+                              className="flex items-center justify-between gap-2 rounded-sm bg-background/60 px-1.5 py-1"
+                            >
+                              <label
+                                htmlFor={inputId}
+                                className="flex min-w-0 items-center gap-2 text-[11px] text-foreground/95"
+                              >
+                                <span
+                                  aria-hidden
+                                  className={cn(
+                                    "size-1.5 shrink-0 rounded-full transition-colors",
+                                    edited
+                                      ? "bg-emerald-500"
+                                      : "bg-muted-foreground/40",
+                                  )}
+                                />
+                                <span className="truncate">{label}</span>
+                                {willChange ? (
+                                  <span
+                                    className={cn(
+                                      "shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wider",
+                                      edited
+                                        ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-500/20 dark:text-emerald-200"
+                                        : "bg-amber-100 text-amber-900 dark:bg-amber-500/20 dark:text-amber-200",
+                                    )}
+                                  >
+                                    {edited ? "Will appear" : "Will hide"}
+                                  </span>
+                                ) : null}
+                              </label>
+                              <Switch
+                                id={inputId}
+                                size="sm"
+                                checked={edited}
+                                onCheckedChange={(v) => {
+                                  if (key === "carousel") {
+                                    updatePhotoEdit(photo, {
+                                      showInCarousel: v,
+                                    });
+                                  } else {
+                                    updatePhotoEdit(photo, {
+                                      showInGallery: v,
+                                    });
+                                  }
+                                }}
+                                disabled={busy !== null || isRowBusy}
+                              />
+                            </li>
+                          );
+                        })}
+                      </ul>
+                      {!fields.showInCarousel && !fields.showInGallery ? (
+                        <p className="text-[11px] leading-snug text-amber-900/90 dark:text-amber-200/90">
+                          With both surfaces off this photo won&apos;t appear
+                          anywhere on the public site after publish. Consider
+                          deleting it instead.
+                        </p>
+                      ) : null}
+                    </fieldset>
 
-                    {surfaceTab === "gallery" ? (
+                    {fields.showInGallery ? (
                     <fieldset className="min-w-0 space-y-1">
                       <legend className="text-[11px] font-medium leading-none text-foreground/90">
                         Gallery categories

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -1037,7 +1037,8 @@ function PhotosEditorForm() {
     busy,
     autosaveStatus: "idle",
     inlineError,
-    previewHref: surfaceTab === "gallery" ? "/preview/gallery" : "/preview",
+    previewHref:
+      surfaceTab === "gallery" ? "/preview/gallery" : "/preview#the-space",
     onPublish: handleToolbarPublish,
     onDiscardConfirm: handleDiscardConfirm,
     // No `flush` — dirty local edits trigger the nav-guard confirm dialog

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -12,6 +12,10 @@ import { useUser } from "@clerk/nextjs";
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
 import {
+  GALLERY_CATEGORY_ADMIN_OPTIONS,
+  type GalleryCategorySlug,
+} from "../../../../convex/galleryPhotos";
+import {
   useCallback,
   useMemo,
   useRef,
@@ -60,27 +64,8 @@ const MAX_CAPTION_LENGTH = 600;
  */
 const REORDER_MIME = "application/x-lls-photo-reorder";
 
-/**
- * Controlled vocabulary for the public `/gallery` filter pills (INF-47).
- * Mirrors `GALLERY_CATEGORY_SLUGS` / `GALLERY_CATEGORY_LABELS` in
- * `convex/galleryPhotos.ts` — kept in lock-step so admin checkboxes can't
- * write a slug that the Convex normaliser will silently drop.
- */
-export const GALLERY_CATEGORY_OPTIONS: ReadonlyArray<{
-  readonly slug: "rooms" | "gear" | "grounds";
-  readonly label: string;
-  readonly description: string;
-}> = [
-  { slug: "rooms", label: "Rooms", description: "Live rooms, control room, iso booths." },
-  { slug: "gear", label: "Gear", description: "Console, racks, mics, instruments." },
-  {
-    slug: "grounds",
-    label: "Grounds",
-    description: "Exteriors, hallway, residential wing.",
-  },
-];
-
-type GalleryCategorySlug = (typeof GALLERY_CATEGORY_OPTIONS)[number]["slug"];
+/** Re-export for tests; canonical definitions live in `convex/galleryPhotos.ts`. */
+export const GALLERY_CATEGORY_OPTIONS = GALLERY_CATEGORY_ADMIN_OPTIONS;
 
 type PhotoItem = {
   stableId: string;

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -59,6 +59,28 @@ const MAX_CAPTION_LENGTH = 600;
  */
 const REORDER_MIME = "application/x-lls-photo-reorder";
 
+/**
+ * Controlled vocabulary for the public `/gallery` filter pills (INF-47).
+ * Mirrors `GALLERY_CATEGORY_SLUGS` / `GALLERY_CATEGORY_LABELS` in
+ * `convex/galleryPhotos.ts` — kept in lock-step so admin checkboxes can't
+ * write a slug that the Convex normaliser will silently drop.
+ */
+export const GALLERY_CATEGORY_OPTIONS: ReadonlyArray<{
+  readonly slug: "rooms" | "gear" | "grounds";
+  readonly label: string;
+  readonly description: string;
+}> = [
+  { slug: "rooms", label: "Rooms", description: "Live rooms, control room, iso booths." },
+  { slug: "gear", label: "Gear", description: "Console, racks, mics, instruments." },
+  {
+    slug: "grounds",
+    label: "Grounds",
+    description: "Exteriors, hallway, residential wing.",
+  },
+];
+
+type GalleryCategorySlug = (typeof GALLERY_CATEGORY_OPTIONS)[number]["slug"];
+
 type PhotoItem = {
   stableId: string;
   storageId: Id<"_storage">;
@@ -71,6 +93,7 @@ type PhotoItem = {
   contentType: string;
   sizeBytes: number;
   originalFileName: string | null;
+  categories: readonly string[];
 };
 
 type PhotoEdits = Record<
@@ -78,6 +101,7 @@ type PhotoEdits = Record<
   {
     alt: string;
     caption: string;
+    categories: readonly GalleryCategorySlug[];
   }
 >;
 
@@ -125,6 +149,33 @@ export function validatePhotoFields(alt: string, caption: string): string | null
     return `Caption must be at most ${MAX_CAPTION_LENGTH} characters.`;
   }
   return null;
+}
+
+/**
+ * Equality on category arrays. Order matters for storage (we always write
+ * canonical order from the convex helper) so the published rows and draft
+ * rows compare cleanly with `JSON.stringify`. The admin UI also writes
+ * canonical order via `selectedSlugs`, so a string-equal compare is enough
+ * to detect "no change".
+ */
+export function sameCategories(
+  a: readonly string[],
+  b: readonly string[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** Canonical order matching `GALLERY_CATEGORY_OPTIONS` for predictable diffs. */
+function canonicaliseCategories(
+  selected: ReadonlySet<GalleryCategorySlug>,
+): GalleryCategorySlug[] {
+  return GALLERY_CATEGORY_OPTIONS.filter((option) => selected.has(option.slug)).map(
+    (option) => option.slug,
+  );
 }
 
 function sequentialEffects(
@@ -300,37 +351,76 @@ function PhotosEditorForm() {
     data?.publishedBy && user?.id === data.publishedBy ? "You" : undefined;
 
   const getEditableFields = useCallback(
-    (photo: PhotoItem) => ({
-      alt: edits[photo.stableId]?.alt ?? photo.alt,
-      caption: edits[photo.stableId]?.caption ?? (photo.caption ?? ""),
-    }),
+    (photo: PhotoItem) => {
+      const photoCategories = (photo.categories ?? []).filter((slug) =>
+        GALLERY_CATEGORY_OPTIONS.some((option) => option.slug === slug),
+      ) as readonly GalleryCategorySlug[];
+      return {
+        alt: edits[photo.stableId]?.alt ?? photo.alt,
+        caption: edits[photo.stableId]?.caption ?? (photo.caption ?? ""),
+        categories:
+          edits[photo.stableId]?.categories ?? photoCategories,
+      };
+    },
     [edits],
   );
 
-  const updatePhotoEdit = useCallback((photo: PhotoItem, patch: Partial<{ alt: string; caption: string }>) => {
-    setEdits((current) => {
-      const base = {
-        alt: current[photo.stableId]?.alt ?? photo.alt,
-        caption: current[photo.stableId]?.caption ?? (photo.caption ?? ""),
-      };
-      const next = {
-        alt: patch.alt ?? base.alt,
-        caption: patch.caption ?? base.caption,
-      };
-      if (
-        next.alt === photo.alt &&
-        next.caption === (photo.caption ?? "")
-      ) {
-        const rest = { ...current };
-        delete rest[photo.stableId];
-        return rest;
+  const updatePhotoEdit = useCallback(
+    (
+      photo: PhotoItem,
+      patch: Partial<{
+        alt: string;
+        caption: string;
+        categories: readonly GalleryCategorySlug[];
+      }>,
+    ) => {
+      setEdits((current) => {
+        const photoCategories = (photo.categories ?? []).filter((slug) =>
+          GALLERY_CATEGORY_OPTIONS.some((option) => option.slug === slug),
+        ) as readonly GalleryCategorySlug[];
+        const base = {
+          alt: current[photo.stableId]?.alt ?? photo.alt,
+          caption:
+            current[photo.stableId]?.caption ?? (photo.caption ?? ""),
+          categories:
+            current[photo.stableId]?.categories ?? photoCategories,
+        };
+        const next = {
+          alt: patch.alt ?? base.alt,
+          caption: patch.caption ?? base.caption,
+          categories: patch.categories ?? base.categories,
+        };
+        if (
+          next.alt === photo.alt &&
+          next.caption === (photo.caption ?? "") &&
+          sameCategories(next.categories, photoCategories)
+        ) {
+          const rest = { ...current };
+          delete rest[photo.stableId];
+          return rest;
+        }
+        return {
+          ...current,
+          [photo.stableId]: next,
+        };
+      });
+    },
+    [],
+  );
+
+  const togglePhotoCategory = useCallback(
+    (photo: PhotoItem, slug: GalleryCategorySlug) => {
+      const fields = getEditableFields(photo);
+      const selected = new Set<GalleryCategorySlug>(fields.categories);
+      if (selected.has(slug)) {
+        selected.delete(slug);
+      } else {
+        selected.add(slug);
       }
-      return {
-        ...current,
-        [photo.stableId]: next,
-      };
-    });
-  }, []);
+      updatePhotoEdit(photo, { categories: canonicaliseCategories(selected) });
+    },
+    [getEditableFields, updatePhotoEdit],
+  );
 
   const clearPhotoEdit = useCallback((stableId: string) => {
     setEdits((current) => {
@@ -359,6 +449,8 @@ function PhotosEditorForm() {
             alt: fields.alt.trim(),
             caption:
               fields.caption.trim().length > 0 ? fields.caption.trim() : null,
+            categories:
+              fields.categories.length > 0 ? [...fields.categories] : [],
           }),
         ),
         { onErrorMessage: setInlineError },
@@ -406,6 +498,8 @@ function PhotosEditorForm() {
           stableId: photo.stableId,
           alt: fields.alt.trim(),
           caption: fields.caption.trim().length > 0 ? fields.caption.trim() : null,
+          categories:
+            fields.categories.length > 0 ? [...fields.categories] : [],
         }),
       );
     });
@@ -850,7 +944,7 @@ function PhotosEditorForm() {
     busy,
     autosaveStatus: "idle",
     inlineError,
-    previewHref: "/preview#the-space",
+    previewHref: "/preview/gallery",
     onPublish: handleToolbarPublish,
     onDiscardConfirm: handleDiscardConfirm,
     // No `flush` — dirty local edits trigger the nav-guard confirm dialog
@@ -903,10 +997,14 @@ function PhotosEditorForm() {
               Studio gallery
             </h2>
             <p className="body-text-small max-w-2xl text-foreground/85">
-              Upload and arrange the photos shown in the “The Space” section.
-              Drag and drop images onto this page to upload, or drag a card by
-              its handle to reorder. Uploads land in draft first; publish makes
-              the new order and metadata live.
+              Upload and arrange the photos shown in the “The Space” homepage
+              carousel and the public <span className="font-medium">Gallery</span>{" "}
+              page (<code className="font-mono text-xs">/gallery</code>). Drag
+              and drop images here to upload, or drag a card by its handle to
+              reorder. Tag each photo with the categories it belongs to —
+              Rooms, Gear, or Grounds — so the Gallery filter pills work.
+              Uploads land in draft first; publish makes the new order,
+              metadata, and category tags live.
             </p>
           </div>
 
@@ -1192,6 +1290,46 @@ function PhotosEditorForm() {
                         className="min-h-[2.5rem] max-h-24 resize-y py-1.5 text-sm [field-sizing:fixed]"
                       />
                     </label>
+
+                    <fieldset className="min-w-0 space-y-1">
+                      <legend className="text-[11px] font-medium leading-none text-foreground/90">
+                        Gallery categories
+                      </legend>
+                      <p className="text-[11px] leading-tight text-muted-foreground">
+                        Drives the public Gallery filter pills. Photos with no
+                        categories still appear under <span className="font-medium">All</span>.
+                      </p>
+                      <div className="flex flex-wrap gap-1.5 pt-0.5">
+                        {GALLERY_CATEGORY_OPTIONS.map((option) => {
+                          const isChecked = fields.categories.includes(
+                            option.slug,
+                          );
+                          return (
+                            <button
+                              key={option.slug}
+                              type="button"
+                              role="checkbox"
+                              aria-checked={isChecked}
+                              title={option.description}
+                              disabled={busy !== null || isRowBusy}
+                              onClick={() =>
+                                togglePhotoCategory(photo, option.slug)
+                              }
+                              className={cn(
+                                "rounded-sm border px-2 py-0.5 text-[11px] transition-colors",
+                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                                isChecked
+                                  ? "border-primary bg-primary/15 text-foreground"
+                                  : "border-border bg-background text-muted-foreground hover:border-primary/60 hover:text-foreground",
+                                "disabled:cursor-not-allowed disabled:opacity-60",
+                              )}
+                            >
+                              {option.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </fieldset>
                   </div>
 
                   <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-1.5">

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Card } from "@/components/ui/card";
 import {
@@ -94,6 +95,8 @@ type PhotoItem = {
   sizeBytes: number;
   originalFileName: string | null;
   categories: readonly string[];
+  showInCarousel: boolean;
+  showInGallery: boolean;
 };
 
 type PhotoEdits = Record<
@@ -102,6 +105,8 @@ type PhotoEdits = Record<
     alt: string;
     caption: string;
     categories: readonly GalleryCategorySlug[];
+    showInCarousel: boolean;
+    showInGallery: boolean;
   }
 >;
 
@@ -290,6 +295,10 @@ function PhotosEditorForm() {
   const removeDraftPhoto = useMutation(api.admin.photos.removeDraftPhoto);
   const publishPhotos = useMutation(api.admin.photos.publishPhotos);
   const discardDraftPhotos = useMutation(api.admin.photos.discardDraftPhotos);
+  const saveSectionIsEnabledDraft = useMutation(
+    api.cms.saveSectionIsEnabledDraft,
+  );
+  const discardCmsSection = useMutation(api.cms.discardDraft);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
@@ -311,10 +320,26 @@ function PhotosEditorForm() {
     position: "before" | "after";
   } | null>(null);
 
+  const [surfaceTab, setSurfaceTab] = useState<"carousel" | "gallery">(
+    "carousel",
+  );
+
   const photos = useMemo(
     () => (data?.photos ?? []) as PhotoItem[],
-    [data],
+    [data?.photos],
   );
+
+  const visiblePhotos = useMemo(
+    () =>
+      photos.filter((photo) =>
+        surfaceTab === "carousel"
+          ? photo.showInCarousel !== false
+          : photo.showInGallery !== false,
+      ),
+    [photos, surfaceTab],
+  );
+
+  const canReorder = visiblePhotos.length === photos.length && photos.length > 0;
 
   const setRowAction = useCallback(
     (stableId: string, action: RowAction | undefined) => {
@@ -344,7 +369,15 @@ function PhotosEditorForm() {
     [],
   );
 
-  const hasDraftOnServer = data?.hasDraftChanges ?? false;
+  const hasGalleryPageFlagPending = useMemo(() => {
+    if (!data?.galleryPage) return false;
+    const published = data.galleryPage.isEnabledPublished !== false;
+    const d = data.galleryPage.isEnabledDraft;
+    return typeof d === "boolean" && d !== published;
+  }, [data?.galleryPage]);
+
+  const hasDraftOnServer =
+    (data?.hasDraftChanges ?? false) || hasGalleryPageFlagPending;
   const hasLocalEdits = Object.keys(edits).length > 0;
 
   const publishedByLabel =
@@ -360,6 +393,10 @@ function PhotosEditorForm() {
         caption: edits[photo.stableId]?.caption ?? (photo.caption ?? ""),
         categories:
           edits[photo.stableId]?.categories ?? photoCategories,
+        showInCarousel:
+          edits[photo.stableId]?.showInCarousel ?? photo.showInCarousel,
+        showInGallery:
+          edits[photo.stableId]?.showInGallery ?? photo.showInGallery,
       };
     },
     [edits],
@@ -372,6 +409,8 @@ function PhotosEditorForm() {
         alt: string;
         caption: string;
         categories: readonly GalleryCategorySlug[];
+        showInCarousel: boolean;
+        showInGallery: boolean;
       }>,
     ) => {
       setEdits((current) => {
@@ -384,16 +423,24 @@ function PhotosEditorForm() {
             current[photo.stableId]?.caption ?? (photo.caption ?? ""),
           categories:
             current[photo.stableId]?.categories ?? photoCategories,
+          showInCarousel:
+            current[photo.stableId]?.showInCarousel ?? photo.showInCarousel,
+          showInGallery:
+            current[photo.stableId]?.showInGallery ?? photo.showInGallery,
         };
         const next = {
           alt: patch.alt ?? base.alt,
           caption: patch.caption ?? base.caption,
           categories: patch.categories ?? base.categories,
+          showInCarousel: patch.showInCarousel ?? base.showInCarousel,
+          showInGallery: patch.showInGallery ?? base.showInGallery,
         };
         if (
           next.alt === photo.alt &&
           next.caption === (photo.caption ?? "") &&
-          sameCategories(next.categories, photoCategories)
+          sameCategories(next.categories, photoCategories) &&
+          next.showInCarousel === photo.showInCarousel &&
+          next.showInGallery === photo.showInGallery
         ) {
           const rest = { ...current };
           delete rest[photo.stableId];
@@ -451,6 +498,8 @@ function PhotosEditorForm() {
               fields.caption.trim().length > 0 ? fields.caption.trim() : null,
             categories:
               fields.categories.length > 0 ? [...fields.categories] : [],
+            showInCarousel: fields.showInCarousel,
+            showInGallery: fields.showInGallery,
           }),
         ),
         { onErrorMessage: setInlineError },
@@ -500,6 +549,8 @@ function PhotosEditorForm() {
           caption: fields.caption.trim().length > 0 ? fields.caption.trim() : null,
           categories:
             fields.categories.length > 0 ? [...fields.categories] : [],
+          showInCarousel: fields.showInCarousel,
+          showInGallery: fields.showInGallery,
         }),
       );
     });
@@ -529,6 +580,9 @@ function PhotosEditorForm() {
 
   const movePhoto = useCallback(
     async (stableId: string, direction: -1 | 1) => {
+      if (!canReorder) {
+        return;
+      }
       const index = photos.findIndex((photo) => photo.stableId === stableId);
       if (index === -1) return;
       const target = index + direction;
@@ -543,7 +597,7 @@ function PhotosEditorForm() {
         toast.success("Photo order updated.");
       }
     },
-    [persistOrder, photos],
+    [canReorder, persistOrder, photos],
   );
 
   // --- Drag-reorder handlers (native HTML5) -------------------------------
@@ -551,7 +605,7 @@ function PhotosEditorForm() {
   const handleRowDragStart = useCallback(
     (event: ReactDragEvent<HTMLDivElement>, stableId: string) => {
       // Don't allow reorder while another action is in flight.
-      if (busy !== null) {
+      if (busy !== null || !canReorder) {
         event.preventDefault();
         return;
       }
@@ -561,7 +615,7 @@ function PhotosEditorForm() {
       event.dataTransfer.setData("text/plain", stableId);
       setDraggingStableId(stableId);
     },
-    [busy],
+    [busy, canReorder],
   );
 
   const handleRowDragOver = useCallback(
@@ -600,6 +654,10 @@ function PhotosEditorForm() {
       setDraggingStableId(null);
       setReorderTarget(null);
 
+      if (!canReorder) {
+        return;
+      }
+
       if (!sourceId || sourceId === overStableId) return;
 
       const sourceIndex = photos.findIndex((p) => p.stableId === sourceId);
@@ -630,7 +688,7 @@ function PhotosEditorForm() {
         toast.success("Photo order updated.");
       }
     },
-    [persistOrder, photos, reorderTarget],
+    [canReorder, persistOrder, photos, reorderTarget],
   );
 
   const handleRowDragEnd = useCallback(() => {
@@ -765,6 +823,8 @@ function PhotosEditorForm() {
               width: dimensions?.width ?? null,
               height: dimensions?.height ?? null,
               originalFileName: file.name,
+              showInCarousel: surfaceTab === "carousel",
+              showInGallery: surfaceTab === "gallery",
             }),
           ),
           { onErrorMessage: setInlineError },
@@ -801,7 +861,14 @@ function PhotosEditorForm() {
         );
       }, 2500);
     },
-    [data, generateUploadUrl, photos.length, saveUploadedPhoto, updateUploadEntry],
+    [
+      data,
+      generateUploadUrl,
+      photos.length,
+      saveUploadedPhoto,
+      surfaceTab,
+      updateUploadEntry,
+    ],
   );
 
   const handleFileSelection = useCallback(
@@ -896,7 +963,7 @@ function PhotosEditorForm() {
 
   const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
     setInlineError(null);
-    if (hasDraftOnServer) {
+    if (data?.hasDraftChanges) {
       const outcome = await runAdminEffect(
         convexMutationEffect(() => discardDraftPhotos({})),
         { onErrorMessage: setInlineError },
@@ -905,15 +972,29 @@ function PhotosEditorForm() {
         return false;
       }
     }
+    if (hasGalleryPageFlagPending) {
+      const flagOutcome = await runAdminEffect(
+        convexMutationEffect(() => discardCmsSection({ section: "photos" })),
+        { onErrorMessage: setInlineError },
+      );
+      if (flagOutcome === undefined) {
+        return false;
+      }
+    }
 
     setEdits({});
     toast.success(
-      hasDraftOnServer
+      data?.hasDraftChanges || hasGalleryPageFlagPending
         ? "Draft discarded. The editor now matches the published site."
         : "Unsaved changes discarded.",
     );
     return true;
-  }, [discardDraftPhotos, hasDraftOnServer]);
+  }, [
+    data?.hasDraftChanges,
+    discardCmsSection,
+    discardDraftPhotos,
+    hasGalleryPageFlagPending,
+  ]);
 
   const handlePublish = useCallback(async () => {
     const saved = await savePendingEdits();
@@ -934,6 +1015,18 @@ function PhotosEditorForm() {
     void handlePublish();
   }, [handlePublish]);
 
+  const setGalleryPageVisible = useCallback(
+    (enabled: boolean) => {
+      void runAdminEffect(
+        convexMutationEffect(() =>
+          saveSectionIsEnabledDraft({ section: "photos", isEnabled: enabled }),
+        ),
+        { onErrorMessage: setInlineError },
+      );
+    },
+    [saveSectionIsEnabledDraft],
+  );
+
   const { toolbarPortal, editorRef } = useRegisterCmsEditor({
     section: "photos",
     sectionLabel: "Studio gallery",
@@ -944,7 +1037,7 @@ function PhotosEditorForm() {
     busy,
     autosaveStatus: "idle",
     inlineError,
-    previewHref: "/preview/gallery",
+    previewHref: surfaceTab === "carousel" ? "/preview" : "/preview/gallery",
     onPublish: handleToolbarPublish,
     onDiscardConfirm: handleDiscardConfirm,
     // No `flush` — dirty local edits trigger the nav-guard confirm dialog
@@ -954,6 +1047,11 @@ function PhotosEditorForm() {
   if (data === undefined) {
     return <p className="body-text text-foreground/80">Loading photos…</p>;
   }
+
+  const galleryPageEffective =
+    data.galleryPage?.isEnabledDraft !== undefined
+      ? data.galleryPage.isEnabledDraft
+      : data.galleryPage?.isEnabledPublished !== false;
 
   const anyUploading = uploadQueue.some(
     (entry) => entry.status === "uploading" || entry.status === "saving",
@@ -997,15 +1095,68 @@ function PhotosEditorForm() {
               Studio gallery
             </h2>
             <p className="body-text-small max-w-2xl text-foreground/85">
-              Upload and arrange the photos shown in the “The Space” homepage
-              carousel and the public <span className="font-medium">Gallery</span>{" "}
-              page (<code className="font-mono text-xs">/gallery</code>). Drag
-              and drop images here to upload, or drag a card by its handle to
-              reorder. Tag each photo with the categories it belongs to —
-              Rooms, Gear, or Grounds — so the Gallery filter pills work.
-              Uploads land in draft first; publish makes the new order,
-              metadata, and category tags live.
+              Use the <span className="font-medium">Carousel</span> and{" "}
+              <span className="font-medium">Gallery</span> tabs to choose where
+              new uploads go and to set whether each image appears in the
+              homepage “The Space” carousel, the public Gallery page, or both.
+              Gallery categories (Rooms, Gear, Grounds) only apply to the
+              Gallery surface. Uploads are saved as draft; Publish pushes order,
+              per-surface flags, and the public Gallery page visibility to the
+              live site.
             </p>
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <div className="inline-flex rounded-lg border border-border bg-muted/30 p-0.5">
+                {(
+                  [
+                    ["carousel", "Homepage carousel"] as const,
+                    ["gallery", "Gallery page"] as const,
+                  ] as const
+                ).map(([id, label]) => (
+                  <Button
+                    key={id}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      "rounded-md px-3",
+                      surfaceTab === id
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground",
+                    )}
+                    onClick={() => setSurfaceTab(id)}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            {surfaceTab === "gallery" ? (
+              <div className="flex flex-col gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    Gallery page visibility
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    When off, <code className="font-mono">/gallery</code> 404s
+                    and the Gallery nav link is hidden. Publish to apply.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="gallery-page-visible"
+                    checked={galleryPageEffective}
+                    onCheckedChange={setGalleryPageVisible}
+                    disabled={busy !== null}
+                  />
+                  <label
+                    htmlFor="gallery-page-visible"
+                    className="text-sm text-foreground/90"
+                  >
+                    {galleryPageEffective ? "Visible" : "Hidden"}
+                  </label>
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="flex flex-col gap-2 sm:items-end">
@@ -1108,12 +1259,19 @@ function PhotosEditorForm() {
         <div className="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
           <p className="body-text text-foreground/80">
             No gallery photos yet. Drop images here or use the Upload button to
-            start the carousel.
+            add images.
+          </p>
+        </div>
+      ) : visiblePhotos.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
+          <p className="body-text text-foreground/80">
+            No photos in this surface yet. Upload or use &quot;Also show
+            on…&quot; on a photo in the other tab.
           </p>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {photos.map((photo, index) => {
+          {visiblePhotos.map((photo, index) => {
             const fields = getEditableFields(photo);
             const isDirty = edits[photo.stableId] !== undefined;
             const rowAction = rowBusy[photo.stableId];
@@ -1139,7 +1297,7 @@ function PhotosEditorForm() {
                     "shadow-[0_2px_0_0_var(--color-primary)]",
                   isRowBusy && "pointer-events-none",
                 )}
-                draggable={busy === null}
+                draggable={busy === null && canReorder}
                 onDragStart={(event) =>
                   handleRowDragStart(event, photo.stableId)
                 }
@@ -1148,12 +1306,14 @@ function PhotosEditorForm() {
                 onDragEnd={handleRowDragEnd}
               >
                 <div className="relative overflow-hidden rounded-lg border border-border bg-muted/30">
-                  <div
-                    className="pointer-events-none absolute left-1.5 top-1.5 z-10 text-muted-foreground/70"
-                    aria-hidden
-                  >
-                    <GripVertical className="size-4" />
-                  </div>
+                  {canReorder ? (
+                    <div
+                      className="pointer-events-none absolute left-1.5 top-1.5 z-10 text-muted-foreground/70"
+                      aria-hidden
+                    >
+                      <GripVertical className="size-4" />
+                    </div>
+                  ) : null}
                   <div className="absolute right-1 top-1 z-10 flex gap-0.5 rounded-md border border-border/60 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm dark:bg-background/80">
                     <Button
                       type="button"
@@ -1161,7 +1321,9 @@ function PhotosEditorForm() {
                       size="icon-sm"
                       className="bg-transparent text-foreground hover:bg-muted/70 hover:text-foreground hover:no-underline disabled:text-foreground/35"
                       aria-label="Move photo up"
-                      disabled={index === 0 || busy !== null || isRowBusy}
+                      disabled={
+                        index === 0 || !canReorder || busy !== null || isRowBusy
+                      }
                       onClick={() => void movePhoto(photo.stableId, -1)}
                     >
                       <ArrowUp className="size-4 stroke-[2.25]" aria-hidden />
@@ -1173,7 +1335,8 @@ function PhotosEditorForm() {
                       className="bg-transparent text-foreground hover:bg-muted/70 hover:text-foreground hover:no-underline disabled:text-foreground/35"
                       aria-label="Move photo down"
                       disabled={
-                        index === photos.length - 1 ||
+                        index === visiblePhotos.length - 1 ||
+                        !canReorder ||
                         busy !== null ||
                         isRowBusy
                       }
@@ -1291,6 +1454,34 @@ function PhotosEditorForm() {
                       />
                     </label>
 
+                    <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+                      <label
+                        htmlFor={`also-${photo.stableId}`}
+                        className="text-[11px] text-foreground/90"
+                      >
+                        {surfaceTab === "carousel"
+                          ? "Also show on Gallery page"
+                          : "Also show in homepage carousel"}
+                      </label>
+                      <Switch
+                        id={`also-${photo.stableId}`}
+                        checked={
+                          surfaceTab === "carousel"
+                            ? fields.showInGallery
+                            : fields.showInCarousel
+                        }
+                        onCheckedChange={(v) => {
+                          if (surfaceTab === "carousel") {
+                            updatePhotoEdit(photo, { showInGallery: v });
+                          } else {
+                            updatePhotoEdit(photo, { showInCarousel: v });
+                          }
+                        }}
+                        disabled={busy !== null || isRowBusy}
+                      />
+                    </div>
+
+                    {surfaceTab === "gallery" ? (
                     <fieldset className="min-w-0 space-y-1">
                       <legend className="text-[11px] font-medium leading-none text-foreground/90">
                         Gallery categories
@@ -1330,6 +1521,7 @@ function PhotosEditorForm() {
                         })}
                       </div>
                     </fieldset>
+                    ) : null}
                   </div>
 
                   <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-1.5">

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -12,6 +12,7 @@ import type { GalleryPhoto } from "@/components/the-space";
 import { useScrollAndReveal } from "@/hooks/use-scroll-and-reveal";
 import { revealDelay } from "@/lib/reveal-delay";
 import {
+  isGalleryPageEnabled,
   isHomepagePricingSectionEnabled,
   type MarketingFeatureFlags,
 } from "@/lib/site-settings";
@@ -127,6 +128,7 @@ export function GalleryClient({
   const showPricing = isHomepagePricingSectionEnabled(marketing);
   const showAbout = marketing.aboutPage === true;
   const showRecordings = marketing.recordingsPage === true;
+  const showGallery = isGalleryPageEnabled(marketing);
 
   const items = useMemo(() => toGalleryItems(photos), [photos]);
   const [filter, setFilter] = useState<FilterId>("all");
@@ -241,6 +243,7 @@ export function GalleryClient({
         showAbout={showAbout}
         aboutHref={aboutHref}
         showRecordings={showRecordings}
+        showGallery={showGallery}
         homeSectionBase={homeSectionBase}
         recordingsHref={recordingsNavHref}
       />

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -3,8 +3,18 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
+import {
+  GALLERY_CATEGORY_LABELS,
+  GALLERY_CATEGORY_SLUGS,
+} from "@convex/galleryPhotos";
 import { Header } from "@/components/header";
 import { PageHeader } from "@/components/page-header";
 import { SiteFooter } from "@/components/site-footer";
@@ -37,10 +47,11 @@ import { cn } from "@/lib/utils";
  */
 
 const FILTER_PILLS = [
-  { id: "all", label: "All" },
-  { id: "rooms", label: "Rooms" },
-  { id: "gear", label: "Gear" },
-  { id: "grounds", label: "Grounds" },
+  { id: "all" as const, label: "All" },
+  ...GALLERY_CATEGORY_SLUGS.map((slug) => ({
+    id: slug,
+    label: GALLERY_CATEGORY_LABELS[slug],
+  })),
 ] as const;
 
 type FilterId = (typeof FILTER_PILLS)[number]["id"];
@@ -142,6 +153,8 @@ export function GalleryClient({
   /** Pathname when the overlay mounted — skip scroll/focus restore after navigation away. */
   const lightboxOpenedPathnameRef = useRef<string | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const isOpen = activeIndex !== null;
@@ -166,48 +179,47 @@ export function GalleryClient({
     });
   }, [visibleItems.length]);
 
-  // Ref-callback for the overlay handles three concerns without `useEffect`:
-  //   1. lock body scroll while the lightbox is open (and pin the page so
-  //      iOS doesn't bounce-scroll behind the overlay),
-  //   2. move focus into the overlay so screen readers + keyboard users
-  //      land in the dialog,
-  //   3. restore focus + scroll position on close.
-  const overlayRefCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      overlayRef.current = node;
-      if (typeof document === "undefined") return;
-      if (node) {
-        lightboxOpenedPathnameRef.current = pathname;
-        previousFocusRef.current =
-          (document.activeElement as HTMLElement | null) ?? null;
-        const offsetY = window.scrollY;
-        lockedScrollYRef.current = offsetY;
-        document.body.style.position = "fixed";
-        document.body.style.top = `-${offsetY}px`;
-        document.body.style.left = "0";
-        document.body.style.right = "0";
-        document.body.style.width = "100%";
-        node.focus({ preventScroll: true });
-      } else {
-        document.body.style.position = "";
-        document.body.style.top = "";
-        document.body.style.left = "";
-        document.body.style.right = "";
-        document.body.style.width = "";
-        const openedAt = lightboxOpenedPathnameRef.current;
-        lightboxOpenedPathnameRef.current = null;
-        const stillOnSameDocumentPath =
-          openedAt !== null && window.location.pathname === openedAt;
-        if (stillOnSameDocumentPath) {
-          window.scrollTo(0, lockedScrollYRef.current);
-          if (previousFocusRef.current) {
-            previousFocusRef.current.focus({ preventScroll: true });
-          }
+  // `useLayoutEffect` keeps body lock + scroll restore stable when `pathname`
+  // updates mid-mount (e.g. shallow routing); a ref-callback would re-run with
+  // `null` then the node again and overwrite `lockedScrollYRef` while fixed.
+  // Intentionally depends only on `isOpen`: including `activeItem` would run
+  // cleanup on prev/next and unlock the body mid-lightbox.
+  useLayoutEffect(() => {
+    if (!isOpen || !activeItem) return undefined;
+    const node = overlayRef.current;
+    if (!node || typeof document === "undefined") return undefined;
+
+    lightboxOpenedPathnameRef.current = pathnameRef.current;
+    previousFocusRef.current =
+      (document.activeElement as HTMLElement | null) ?? null;
+    const offsetY = window.scrollY;
+    lockedScrollYRef.current = offsetY;
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${offsetY}px`;
+    document.body.style.left = "0";
+    document.body.style.right = "0";
+    document.body.style.width = "100%";
+    node.focus({ preventScroll: true });
+
+    return () => {
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.left = "";
+      document.body.style.right = "";
+      document.body.style.width = "";
+      const openedAt = lightboxOpenedPathnameRef.current;
+      lightboxOpenedPathnameRef.current = null;
+      const stillOnSameDocumentPath =
+        openedAt !== null && window.location.pathname === openedAt;
+      if (stillOnSameDocumentPath) {
+        window.scrollTo(0, lockedScrollYRef.current);
+        if (previousFocusRef.current) {
+          previousFocusRef.current.focus({ preventScroll: true });
         }
       }
-    },
-    [pathname],
-  );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `activeItem` is only a guard; adding it would unlock the body on prev/next.
+  }, [isOpen]);
 
   const handleOverlayKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -346,7 +358,7 @@ export function GalleryClient({
 
       {isOpen && activeItem ? (
         <div
-          ref={overlayRefCallback}
+          ref={overlayRef}
           role="dialog"
           aria-modal="true"
           aria-label={activeItem.alt || "Gallery image"}

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -135,7 +135,8 @@ export function GalleryClient({
   // Lightbox state — `activeIndex` indexes into `visibleItems` so prev/next
   // honors the current filter.
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  const [scrollYAtOpen, setScrollYAtOpen] = useState<number>(0);
+  /** Scroll Y captured when the lightbox opens; ref avoids ref-callback ↔ state loops. */
+  const lockedScrollYRef = useRef(0);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
@@ -175,7 +176,7 @@ export function GalleryClient({
         previousFocusRef.current =
           (document.activeElement as HTMLElement | null) ?? null;
         const offsetY = window.scrollY;
-        setScrollYAtOpen(offsetY);
+        lockedScrollYRef.current = offsetY;
         document.body.style.position = "fixed";
         document.body.style.top = `-${offsetY}px`;
         document.body.style.left = "0";
@@ -188,13 +189,13 @@ export function GalleryClient({
         document.body.style.left = "";
         document.body.style.right = "";
         document.body.style.width = "";
-        window.scrollTo(0, scrollYAtOpen);
+        window.scrollTo(0, lockedScrollYRef.current);
         if (previousFocusRef.current) {
           previousFocusRef.current.focus({ preventScroll: true });
         }
       }
     },
-    [scrollYAtOpen],
+    [],
   );
 
   const handleOverlayKeyDown = useCallback(

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -139,6 +139,8 @@ export function GalleryClient({
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   /** Scroll Y captured when the lightbox opens; ref avoids ref-callback ↔ state loops. */
   const lockedScrollYRef = useRef(0);
+  /** Pathname when the overlay mounted — skip scroll/focus restore after navigation away. */
+  const lightboxOpenedPathnameRef = useRef<string | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
@@ -175,6 +177,7 @@ export function GalleryClient({
       overlayRef.current = node;
       if (typeof document === "undefined") return;
       if (node) {
+        lightboxOpenedPathnameRef.current = pathname;
         previousFocusRef.current =
           (document.activeElement as HTMLElement | null) ?? null;
         const offsetY = window.scrollY;
@@ -191,13 +194,19 @@ export function GalleryClient({
         document.body.style.left = "";
         document.body.style.right = "";
         document.body.style.width = "";
-        window.scrollTo(0, lockedScrollYRef.current);
-        if (previousFocusRef.current) {
-          previousFocusRef.current.focus({ preventScroll: true });
+        const openedAt = lightboxOpenedPathnameRef.current;
+        lightboxOpenedPathnameRef.current = null;
+        const stillOnSameDocumentPath =
+          openedAt !== null && window.location.pathname === openedAt;
+        if (stillOnSameDocumentPath) {
+          window.scrollTo(0, lockedScrollYRef.current);
+          if (previousFocusRef.current) {
+            previousFocusRef.current.focus({ preventScroll: true });
+          }
         }
       }
     },
-    [],
+    [pathname],
   );
 
   const handleOverlayKeyDown = useCallback(

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -158,6 +158,10 @@ export function GalleryClient({
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const isOpen = activeIndex !== null;
+  const hasActiveLightboxItem =
+    activeIndex !== null &&
+    activeIndex >= 0 &&
+    activeIndex < visibleItems.length;
   const activeItem =
     activeIndex !== null ? (visibleItems[activeIndex] ?? null) : null;
 
@@ -165,9 +169,21 @@ export function GalleryClient({
     setActiveIndex(null);
   }, []);
 
+  useLayoutEffect(() => {
+    if (activeIndex === null) return;
+    if (visibleItems.length === 0) {
+      setActiveIndex(null);
+      return;
+    }
+    if (activeIndex >= visibleItems.length) {
+      setActiveIndex(null);
+    }
+  }, [activeIndex, visibleItems.length]);
+
   const showPrev = useCallback(() => {
     setActiveIndex((current) => {
       if (current === null) return current;
+      if (visibleItems.length === 0) return null;
       return current > 0 ? current - 1 : visibleItems.length - 1;
     });
   }, [visibleItems.length]);
@@ -175,6 +191,7 @@ export function GalleryClient({
   const showNext = useCallback(() => {
     setActiveIndex((current) => {
       if (current === null) return current;
+      if (visibleItems.length === 0) return null;
       return (current + 1) % visibleItems.length;
     });
   }, [visibleItems.length]);
@@ -182,10 +199,10 @@ export function GalleryClient({
   // `useLayoutEffect` keeps body lock + scroll restore stable when `pathname`
   // updates mid-mount (e.g. shallow routing); a ref-callback would re-run with
   // `null` then the node again and overwrite `lockedScrollYRef` while fixed.
-  // Intentionally depends only on `isOpen`: including `activeItem` would run
-  // cleanup on prev/next and unlock the body mid-lightbox.
+  // Depends on `hasActiveLightboxItem` (not `activeItem`) so prev/next does not
+  // unlock mid-lightbox, while live data shrinking the list still runs cleanup.
   useLayoutEffect(() => {
-    if (!isOpen || !activeItem) return undefined;
+    if (!hasActiveLightboxItem) return undefined;
     const node = overlayRef.current;
     if (!node || typeof document === "undefined") return undefined;
 
@@ -218,8 +235,7 @@ export function GalleryClient({
         }
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- `activeItem` is only a guard; adding it would unlock the body on prev/next.
-  }, [isOpen]);
+  }, [hasActiveLightboxItem]);
 
   const handleOverlayKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -1,0 +1,748 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { Header } from "@/components/header";
+import { PageHeader } from "@/components/page-header";
+import { SiteFooter } from "@/components/site-footer";
+import type { GalleryPhoto } from "@/components/the-space";
+import { useScrollAndReveal } from "@/hooks/use-scroll-and-reveal";
+import { revealDelay } from "@/lib/reveal-delay";
+import {
+  isHomepagePricingSectionEnabled,
+  type MarketingFeatureFlags,
+} from "@/lib/site-settings";
+import { cn } from "@/lib/utils";
+
+/**
+ * Public Gallery page (INF-47).
+ *
+ * Variant A "Cinematic Editorial" masonry grid + lightbox combined with the
+ * Variant C header pattern (eyebrow + title + category filter pills).
+ *
+ * Background normalization: Variant A's gallery sits on `bg-deep-forest`
+ * while the Variant C header bar uses `bg-charcoal`. We pick a single
+ * coherent treatment — `bg-deep-forest` for the section, with the filter
+ * pills sitting in a `bg-charcoal/60` capsule so the segmented control
+ * still reads cleanly against the forest ground.
+ *
+ * Media: the data model and lightbox both anticipate video items
+ * (`item.kind === "video"`) so a future admin upload tray for video files
+ * (HTML5 `<video>` with poster + controls) drops in without changing this
+ * component. Today only images are uploaded from `/admin/photos`.
+ */
+
+const FILTER_PILLS = [
+  { id: "all", label: "All" },
+  { id: "rooms", label: "Rooms" },
+  { id: "gear", label: "Gear" },
+  { id: "grounds", label: "Grounds" },
+] as const;
+
+type FilterId = (typeof FILTER_PILLS)[number]["id"];
+
+type GalleryItem = {
+  readonly id: string;
+  readonly kind: "image" | "video";
+  /** Resolved HTTPS URL for the asset (`null` when storage blob is missing). */
+  readonly src: string | null;
+  /** Optional poster URL for `kind === "video"`. */
+  readonly poster: string | null;
+  readonly alt: string;
+  readonly caption: string | null;
+  readonly width: number | null;
+  readonly height: number | null;
+  /** Lower-case category slugs the photo opted into; empty = uncategorized. */
+  readonly categories: readonly string[];
+  readonly contentType: string;
+};
+
+/**
+ * Variant A masonry grid spans. Repeats every 9 cells so a long gallery
+ * still varies in rhythm without authoring a per-image span. The first
+ * slot is the largest (LCP candidate); columns fall back to 1×1 on small
+ * viewports.
+ */
+const GRID_PATTERN: ReadonlyArray<{ span: string }> = [
+  { span: "md:col-span-2 md:row-span-2" },
+  { span: "md:col-span-1 md:row-span-1" },
+  { span: "md:col-span-1 md:row-span-1" },
+  { span: "md:col-span-1 md:row-span-2" },
+  { span: "md:col-span-2 md:row-span-1" },
+  { span: "md:col-span-1 md:row-span-1" },
+  { span: "md:col-span-2 md:row-span-1" },
+  { span: "md:col-span-1 md:row-span-1" },
+  { span: "md:col-span-1 md:row-span-1" },
+];
+
+function classifyKind(contentType: string): "image" | "video" {
+  return contentType.startsWith("video/") ? "video" : "image";
+}
+
+function toGalleryItems(photos: readonly GalleryPhoto[]): GalleryItem[] {
+  return photos.map((photo) => ({
+    id: photo.stableId,
+    kind: classifyKind(photo.contentType),
+    src: photo.url,
+    poster: null,
+    alt: photo.alt,
+    caption: photo.caption,
+    width: photo.width,
+    height: photo.height,
+    categories: photo.categories ?? [],
+    contentType: photo.contentType,
+  }));
+}
+
+function filterItems(
+  items: readonly GalleryItem[],
+  filter: FilterId,
+): GalleryItem[] {
+  if (filter === "all") return [...items];
+  return items.filter((item) => item.categories.includes(filter));
+}
+
+interface GalleryClientProps {
+  readonly photos: readonly GalleryPhoto[];
+  readonly marketing: MarketingFeatureFlags;
+  /** Optional banner slot (preview routes), aligned with `HomepageShell`. */
+  readonly banner?: React.ReactNode;
+}
+
+export function GalleryClient({
+  photos,
+  marketing,
+  banner,
+}: GalleryClientProps) {
+  const { scrollY, containerRef } = useScrollAndReveal();
+  const pathname = usePathname();
+  const isPreview =
+    pathname === "/preview" || pathname.startsWith("/preview/");
+  const aboutHref = isPreview ? "/preview/about" : "/about";
+  const homeSectionBase = isPreview ? "/preview" : "/";
+  const recordingsNavHref = isPreview ? "/preview/recordings" : "/recordings";
+  const showPricing = isHomepagePricingSectionEnabled(marketing);
+  const showAbout = marketing.aboutPage === true;
+  const showRecordings = marketing.recordingsPage === true;
+
+  const items = useMemo(() => toGalleryItems(photos), [photos]);
+  const [filter, setFilter] = useState<FilterId>("all");
+  const visibleItems = useMemo(() => filterItems(items, filter), [items, filter]);
+
+  // Lightbox state — `activeIndex` indexes into `visibleItems` so prev/next
+  // honors the current filter.
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [scrollYAtOpen, setScrollYAtOpen] = useState<number>(0);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const isOpen = activeIndex !== null;
+  const activeItem =
+    activeIndex !== null ? (visibleItems[activeIndex] ?? null) : null;
+
+  const closeLightbox = useCallback(() => {
+    setActiveIndex(null);
+  }, []);
+
+  const showPrev = useCallback(() => {
+    setActiveIndex((current) => {
+      if (current === null) return current;
+      return current > 0 ? current - 1 : visibleItems.length - 1;
+    });
+  }, [visibleItems.length]);
+
+  const showNext = useCallback(() => {
+    setActiveIndex((current) => {
+      if (current === null) return current;
+      return (current + 1) % visibleItems.length;
+    });
+  }, [visibleItems.length]);
+
+  // Ref-callback for the overlay handles three concerns without `useEffect`:
+  //   1. lock body scroll while the lightbox is open (and pin the page so
+  //      iOS doesn't bounce-scroll behind the overlay),
+  //   2. move focus into the overlay so screen readers + keyboard users
+  //      land in the dialog,
+  //   3. restore focus + scroll position on close.
+  const overlayRefCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      overlayRef.current = node;
+      if (typeof document === "undefined") return;
+      if (node) {
+        previousFocusRef.current =
+          (document.activeElement as HTMLElement | null) ?? null;
+        const offsetY = window.scrollY;
+        setScrollYAtOpen(offsetY);
+        document.body.style.position = "fixed";
+        document.body.style.top = `-${offsetY}px`;
+        document.body.style.left = "0";
+        document.body.style.right = "0";
+        document.body.style.width = "100%";
+        node.focus({ preventScroll: true });
+      } else {
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.left = "";
+        document.body.style.right = "";
+        document.body.style.width = "";
+        window.scrollTo(0, scrollYAtOpen);
+        if (previousFocusRef.current) {
+          previousFocusRef.current.focus({ preventScroll: true });
+        }
+      }
+    },
+    [scrollYAtOpen],
+  );
+
+  const handleOverlayKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!isOpen) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeLightbox();
+        return;
+      }
+      if (visibleItems.length <= 1) return;
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        showNext();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        showPrev();
+      }
+    },
+    [closeLightbox, isOpen, showNext, showPrev, visibleItems.length],
+  );
+
+  const handleSelectFilter = useCallback((next: FilterId) => {
+    setFilter(next);
+    // Filter changes invalidate the active index — close the lightbox so we
+    // never end up displaying an item that's no longer visible.
+    setActiveIndex(null);
+  }, []);
+
+  const handleOpenAt = useCallback((index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="dark relative min-h-screen bg-deep-forest text-ivory grain-overlay"
+    >
+      {banner}
+      <Header
+        scrollY={scrollY}
+        showPricing={showPricing}
+        showAbout={showAbout}
+        aboutHref={aboutHref}
+        showRecordings={showRecordings}
+        homeSectionBase={homeSectionBase}
+        recordingsHref={recordingsNavHref}
+      />
+
+      <main>
+        <PageHeader
+          eyebrow="Gallery"
+          title="The Facility"
+          meta="Rooms · Gear · Grounds"
+          backHref={isPreview ? "/preview" : "/"}
+          titleId="gallery-title"
+          aside={
+            <CategoryFilter filter={filter} onChange={handleSelectFilter} />
+          }
+        />
+
+        <section
+          className="relative bg-deep-forest px-6 pb-20 pt-10 md:px-16 md:pb-32 md:pt-12"
+          aria-label="Gallery grid"
+        >
+          <div className="mx-auto max-w-7xl">
+            <GalleryCount count={visibleItems.length} />
+            {visibleItems.length === 0 ? (
+              <EmptyState
+                hasAnyPhotos={items.length > 0}
+                filterLabel={
+                  FILTER_PILLS.find((pill) => pill.id === filter)?.label ?? null
+                }
+                onClearFilter={() => handleSelectFilter("all")}
+              />
+            ) : (
+              <MasonryGrid items={visibleItems} onOpenAt={handleOpenAt} />
+            )}
+          </div>
+        </section>
+
+        <section
+          className="bg-deep-forest px-6 py-24 md:px-16 md:py-32"
+          aria-label="Visit the studio"
+        >
+          <div className="mx-auto max-w-3xl border-t border-sand/10 pt-16 text-center">
+            <p
+              className={cn(
+                revealDelay(0),
+                "label-text mb-4 text-[11px] tracking-[0.2em] text-sand/60",
+              )}
+            >
+              Come visit
+            </p>
+            <h2
+              className={cn(
+                revealDelay(1),
+                "headline-primary text-balance text-3xl leading-[1.1] text-warm-white md:text-5xl",
+              )}
+            >
+              See it in person
+            </h2>
+            <p
+              className={cn(
+                revealDelay(2),
+                "body-text mt-6 text-lg leading-[1.7] text-ivory/70",
+              )}
+            >
+              Photographs only go so far. Schedule a tour or book a tracking
+              day and let the room speak for itself.
+            </p>
+            <div
+              className={cn(
+                revealDelay(3),
+                "mt-10 flex flex-wrap items-center justify-center gap-6",
+              )}
+            >
+              <Link
+                href={`${isPreview ? "/preview" : "/"}#artist-inquiries`}
+                className="label-text border-b border-sand/60 pb-1 text-[11px] tracking-[0.2em] text-sand transition-colors hover:border-warm-white hover:text-warm-white"
+              >
+                Start a conversation
+              </Link>
+              <Link
+                href={`${isPreview ? "/preview" : "/"}#equipment-specs`}
+                className="label-text border-b border-ivory/20 pb-1 text-[11px] tracking-[0.2em] text-ivory/60 transition-colors hover:border-sand/50 hover:text-sand"
+              >
+                View gear list
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+
+      {isOpen && activeItem ? (
+        <div
+          ref={overlayRefCallback}
+          role="dialog"
+          aria-modal="true"
+          aria-label={activeItem.alt || "Gallery image"}
+          tabIndex={-1}
+          onClick={closeLightbox}
+          onKeyDown={handleOverlayKeyDown}
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-deep-forest/95 p-4 outline-none backdrop-blur-xl md:p-12"
+        >
+          <button
+            type="button"
+            aria-label="Close gallery"
+            onClick={(event) => {
+              event.stopPropagation();
+              closeLightbox();
+            }}
+            className="absolute right-4 top-4 text-ivory/55 transition-colors hover:text-warm-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand/60 md:right-6 md:top-6"
+          >
+            <svg
+              className="size-7 md:size-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.25}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+
+          <div
+            className="relative flex w-full items-center justify-center gap-2 md:gap-6"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {visibleItems.length > 1 ? (
+              <button
+                type="button"
+                aria-label="Previous gallery item"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  showPrev();
+                }}
+                className="flex-shrink-0 text-ivory/45 transition-colors hover:text-sand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand/60"
+              >
+                <svg
+                  className="size-9 md:size-10"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1}
+                    d="M15 19l-7-7 7-7"
+                  />
+                </svg>
+              </button>
+            ) : null}
+
+            <div className="flex min-w-0 max-w-5xl flex-1 items-center justify-center">
+              <LightboxMedia item={activeItem} />
+            </div>
+
+            {visibleItems.length > 1 ? (
+              <button
+                type="button"
+                aria-label="Next gallery item"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  showNext();
+                }}
+                className="flex-shrink-0 text-ivory/45 transition-colors hover:text-sand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand/60"
+              >
+                <svg
+                  className="size-9 md:size-10"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            ) : null}
+          </div>
+
+          <div className="absolute bottom-6 left-0 right-0 flex flex-col items-center gap-2 px-6 text-center">
+            {activeItem.caption ? (
+              <p className="body-text-small max-w-xl text-ivory/70">
+                {activeItem.caption}
+              </p>
+            ) : null}
+            <p className="label-text text-[10px] tracking-[0.2em] text-ivory/35">
+              {(activeIndex ?? 0) + 1} / {visibleItems.length}
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface CategoryFilterProps {
+  readonly filter: FilterId;
+  readonly onChange: (next: FilterId) => void;
+}
+
+function CategoryFilter({ filter, onChange }: CategoryFilterProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter gallery by category"
+      className={cn(
+        revealDelay(2),
+        "inline-flex flex-wrap items-center gap-1 rounded-sm bg-charcoal/60 p-1",
+      )}
+    >
+      {FILTER_PILLS.map((pill) => {
+        const isActive = pill.id === filter;
+        return (
+          <button
+            key={pill.id}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => onChange(pill.id)}
+            className={cn(
+              "label-text rounded-sm px-3 py-2 text-[10px] tracking-[0.2em] transition-colors duration-300",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand/60",
+              isActive
+                ? "bg-sand/15 text-sand"
+                : "text-ivory/45 hover:text-ivory/75",
+            )}
+          >
+            {pill.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface GalleryCountProps {
+  readonly count: number;
+}
+
+/**
+ * Live status line announcing how many gallery items match the current
+ * filter. Rendered as an editorial footnote above the grid (right-aligned
+ * on desktop) so it sits near the filter pills it relates to without
+ * forcing the `PageHeader` aside slot to a multi-row layout.
+ */
+function GalleryCount({ count }: GalleryCountProps) {
+  return (
+    <p
+      aria-live="polite"
+      className="label-text text-[10px] tracking-[0.15em] text-ivory/35 md:text-right"
+    >
+      {count} {count === 1 ? "item" : "items"}
+    </p>
+  );
+}
+
+interface MasonryGridProps {
+  readonly items: readonly GalleryItem[];
+  readonly onOpenAt: (index: number) => void;
+}
+
+function MasonryGrid({ items, onOpenAt }: MasonryGridProps) {
+  return (
+    // No `.reveal` on the grid container or its tiles. The page-level
+    // `IntersectionObserver` in `useScrollAndReveal` only observes nodes
+    // that exist at first mount, so any `.reveal` ancestor we add here
+    // stays at `opacity: 0` forever after the user toggles a filter that
+    // unmounts the grid (e.g. a category with zero results) and toggles
+    // back. Page chrome above already provides the editorial fade-in.
+    //
+    // `grid-flow-row-dense` lets the browser back-fill gaps left by wide
+    // / tall tiles. Without it, a `col-span-2` item that lands when only
+    // one column is free skips that slot, producing a visible blank cell
+    // on the right edge.
+    <ul
+      className={cn(
+        "mt-12 grid list-none auto-rows-[200px] grid-cols-1 gap-2 md:mt-16 md:auto-rows-[220px] md:grid-cols-4 md:grid-flow-row-dense",
+      )}
+    >
+      {items.map((item, index) => {
+        const span = GRID_PATTERN[index % GRID_PATTERN.length]?.span ?? "";
+        // Per-tile `.reveal` is intentionally omitted: the parent container
+        // already fades the whole grid in once via `revealDelay(3)`, and
+        // the page-level `IntersectionObserver` only observes nodes that
+        // exist at mount. If we re-applied `.reveal` here, switching
+        // filters would mount fresh `<li>` nodes the observer never sees,
+        // leaving them stuck at `opacity: 0` until a hard refresh.
+        return (
+          <li
+            key={item.id}
+            className={cn("group relative overflow-hidden", span)}
+          >
+            <GridTile item={item} index={index} onOpen={onOpenAt} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+interface GridTileProps {
+  readonly item: GalleryItem;
+  readonly index: number;
+  readonly onOpen: (index: number) => void;
+}
+
+function GridTile({ item, index, onOpen }: GridTileProps) {
+  const sharedClasses =
+    "relative block h-full w-full overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand/60";
+
+  // First tile is the LCP candidate at desktop spans 2×2 — prioritise it.
+  const priority = index === 0;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(index)}
+      aria-label={
+        item.kind === "video"
+          ? `Open video: ${item.alt}`
+          : `Open image: ${item.alt}`
+      }
+      className={sharedClasses}
+    >
+      {item.kind === "video" ? (
+        <VideoTile item={item} priority={priority} />
+      ) : (
+        <ImageTile item={item} priority={priority} />
+      )}
+      <span className="pointer-events-none absolute inset-0 bg-deep-forest/0 transition-colors duration-500 group-hover:bg-deep-forest/40" />
+      <span className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-full p-3 text-left transition-transform duration-500 group-hover:translate-y-0">
+        <span className="body-text-small block text-xs text-warm-white/90">
+          {item.caption ?? item.alt}
+        </span>
+      </span>
+      {item.kind === "video" ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 rounded-sm bg-washed-black/70 px-2 py-1 text-[9px] uppercase tracking-[0.2em] text-warm-white/85"
+        >
+          Video
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function ImageTile({
+  item,
+  priority,
+}: {
+  readonly item: GalleryItem;
+  readonly priority: boolean;
+}) {
+  if (!item.src) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-charcoal/60 text-ivory/45">
+        <span className="body-text-small text-xs">Image unavailable</span>
+      </div>
+    );
+  }
+  return (
+    <Image
+      src={item.src}
+      alt={item.alt}
+      fill
+      sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+      className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+      quality={75}
+      priority={priority}
+      loading={priority ? "eager" : "lazy"}
+    />
+  );
+}
+
+function VideoTile({
+  item,
+  priority,
+}: {
+  readonly item: GalleryItem;
+  readonly priority: boolean;
+}) {
+  if (!item.src) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-charcoal/60 text-ivory/45">
+        <span className="body-text-small text-xs">Video unavailable</span>
+      </div>
+    );
+  }
+  return item.poster ? (
+    <Image
+      src={item.poster}
+      alt={item.alt}
+      fill
+      sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+      className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+      quality={75}
+      priority={priority}
+      loading={priority ? "eager" : "lazy"}
+    />
+  ) : (
+    // Browsers won't autoplay a video without a poster on mobile; rendering
+    // a non-autoplaying `<video preload="metadata">` is sufficient as a
+    // thumbnail and complies with the "no annoying autoplay audio" rule.
+    <video
+      src={item.src}
+      muted
+      playsInline
+      preload="metadata"
+      aria-label={item.alt}
+      className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+    />
+  );
+}
+
+function LightboxMedia({ item }: { readonly item: GalleryItem }) {
+  if (!item.src) {
+    return (
+      <div className="flex aspect-[16/10] w-full items-center justify-center bg-charcoal/60 text-ivory/55">
+        <span className="body-text-small">Media unavailable</span>
+      </div>
+    );
+  }
+
+  if (item.kind === "video") {
+    return (
+      <video
+        src={item.src}
+        controls
+        playsInline
+        preload="metadata"
+        poster={item.poster ?? undefined}
+        className="max-h-[80vh] w-full max-w-5xl bg-washed-black"
+        aria-label={item.alt}
+      />
+    );
+  }
+
+  return (
+    <div className="relative aspect-[16/10] w-full">
+      <Image
+        src={item.src}
+        alt={item.alt}
+        fill
+        className="object-contain"
+        quality={90}
+        sizes="(max-width: 768px) 100vw, 90vw"
+        priority
+      />
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  readonly hasAnyPhotos: boolean;
+  readonly filterLabel: string | null;
+  readonly onClearFilter: () => void;
+}
+
+function EmptyState({
+  hasAnyPhotos,
+  filterLabel,
+  onClearFilter,
+}: EmptyStateProps) {
+  if (!hasAnyPhotos) {
+    return (
+      <div className="mt-16 border border-dashed border-sand/15 px-8 py-20 text-center">
+        <p className="label-text text-[11px] tracking-[0.2em] text-sand/50">
+          Gallery coming soon
+        </p>
+        <p className="body-text-small mx-auto mt-4 max-w-md text-ivory/55">
+          We&rsquo;re finalising the first round of room, gear, and grounds
+          photography. Check back shortly.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-16 border border-dashed border-sand/15 px-8 py-16 text-center">
+      <p className="label-text text-[11px] tracking-[0.2em] text-sand/50">
+        Nothing tagged {filterLabel?.toLowerCase()} yet
+      </p>
+      <p className="body-text-small mx-auto mt-4 max-w-md text-ivory/55">
+        Try another filter, or view every photo at once.
+      </p>
+      <button
+        type="button"
+        onClick={onClearFilter}
+        className="label-text mt-6 border-b border-sand/60 pb-1 text-[11px] tracking-[0.2em] text-sand transition-colors hover:border-warm-white hover:text-warm-white"
+      >
+        Show all
+      </button>
+    </div>
+  );
+}

--- a/src/app/gallery/gallery-page-client.tsx
+++ b/src/app/gallery/gallery-page-client.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePreloadedQuery, type Preloaded } from "convex/react";
+
+import { api } from "../../../convex/_generated/api";
+import type { GalleryPhoto } from "@/components/the-space";
+import { GalleryClient } from "./gallery-client";
+import type { MarketingFeatureFlags } from "@/lib/site-settings";
+
+type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos>;
+type PreloadedMarketing = Preloaded<
+  typeof api.public.getPublishedMarketingFeatureFlags
+>;
+
+/**
+ * Resolves preloaded published gallery photos + marketing flags and hands
+ * plain data to the shared {@link GalleryClient} layout. Subscribing keeps
+ * Convex storage URLs fresh across navigations.
+ */
+export function GalleryPageClient({
+  photosPreloaded,
+  marketingPreloaded,
+}: {
+  readonly photosPreloaded: PreloadedPhotos;
+  readonly marketingPreloaded: PreloadedMarketing;
+}) {
+  const photos = usePreloadedQuery(photosPreloaded) as GalleryPhoto[];
+  const marketing: MarketingFeatureFlags =
+    usePreloadedQuery(marketingPreloaded);
+
+  return <GalleryClient photos={photos} marketing={marketing} />;
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,55 @@
+import { preloadQuery } from "convex/nextjs";
+import type { Metadata } from "next";
+import { cache } from "react";
+import { api } from "../../../convex/_generated/api";
+import { GalleryPageClient } from "./gallery-page-client";
+
+/**
+ * Public `/gallery` route (INF-47).
+ *
+ * Variant A "Cinematic Editorial" masonry grid + lightbox combined with the
+ * Variant C header pattern (eyebrow + title + category filter pills). The
+ * gallery is sourced from the same `galleryPhotos` table the homepage
+ * carousel uses; categories live on each photo as lower-case slugs and are
+ * authored from `/admin/photos`.
+ *
+ * The page is always reachable — there is no `cmsSections.gallery`
+ * visibility flag — but the empty-state copy renders gracefully when
+ * nothing has been published yet.
+ */
+
+const preloadPublishedGallery = cache(() =>
+  preloadQuery(api.public.getPublishedGalleryPhotos),
+);
+
+const preloadMarketingForGallery = cache(() =>
+  preloadQuery(api.public.getPublishedMarketingFeatureFlags),
+);
+
+export const metadata: Metadata = {
+  title: "Gallery — Lula Lake Sound",
+  description:
+    "Tour the rooms, gear, and grounds of Lula Lake Sound on Lookout Mountain — a curated photo gallery of the recording studio.",
+  alternates: { canonical: "/gallery" },
+  openGraph: {
+    title: "Gallery — Lula Lake Sound",
+    description:
+      "Tour the rooms, gear, and grounds of Lula Lake Sound on Lookout Mountain — a curated photo gallery of the recording studio.",
+    type: "website",
+    url: "/gallery",
+    siteName: "Lula Lake Sound",
+  },
+};
+
+export default async function GalleryPage() {
+  const [photosPreloaded, marketingPreloaded] = await Promise.all([
+    preloadPublishedGallery(),
+    preloadMarketingForGallery(),
+  ]);
+  return (
+    <GalleryPageClient
+      photosPreloaded={photosPreloaded}
+      marketingPreloaded={marketingPreloaded}
+    />
+  );
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,21 +1,14 @@
-import { preloadQuery } from "convex/nextjs";
+import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { cache } from "react";
 import { api } from "../../../convex/_generated/api";
 import { GalleryPageClient } from "./gallery-page-client";
+import { isGalleryPageEnabled } from "@/lib/site-settings";
 
 /**
- * Public `/gallery` route (INF-47).
- *
- * Variant A "Cinematic Editorial" masonry grid + lightbox combined with the
- * Variant C header pattern (eyebrow + title + category filter pills). The
- * gallery is sourced from the same `galleryPhotos` table the homepage
- * carousel uses; categories live on each photo as lower-case slugs and are
- * authored from `/admin/photos`.
- *
- * The page is always reachable — there is no `cmsSections.gallery`
- * visibility flag — but the empty-state copy renders gracefully when
- * nothing has been published yet.
+ * Public `/gallery` route (INF-47). When `cmsSections.photos.isEnabled` is
+ * off (published), this route returns 404 — same pattern as `/recordings`.
  */
 
 const preloadPublishedGallery = cache(() =>
@@ -26,26 +19,37 @@ const preloadMarketingForGallery = cache(() =>
   preloadQuery(api.public.getPublishedMarketingFeatureFlags),
 );
 
-export const metadata: Metadata = {
-  title: "Gallery — Lula Lake Sound",
-  description:
-    "Tour the rooms, gear, and grounds of Lula Lake Sound on Lookout Mountain — a curated photo gallery of the recording studio.",
-  alternates: { canonical: "/gallery" },
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  const preloaded = await preloadMarketingForGallery();
+  const data = preloadedQueryResult(preloaded);
+  if (!isGalleryPageEnabled(data)) {
+    return { title: "Gallery" };
+  }
+  return {
     title: "Gallery — Lula Lake Sound",
     description:
       "Tour the rooms, gear, and grounds of Lula Lake Sound on Lookout Mountain — a curated photo gallery of the recording studio.",
-    type: "website",
-    url: "/gallery",
-    siteName: "Lula Lake Sound",
-  },
-};
+    alternates: { canonical: "/gallery" },
+    openGraph: {
+      title: "Gallery — Lula Lake Sound",
+      description:
+        "Tour the rooms, gear, and grounds of Lula Lake Sound on Lookout Mountain — a curated photo gallery of the recording studio.",
+      type: "website",
+      url: "/gallery",
+      siteName: "Lula Lake Sound",
+    },
+  };
+}
 
 export default async function GalleryPage() {
   const [photosPreloaded, marketingPreloaded] = await Promise.all([
     preloadPublishedGallery(),
     preloadMarketingForGallery(),
   ]);
+  const marketing = preloadedQueryResult(marketingPreloaded);
+  if (!isGalleryPageEnabled(marketing)) {
+    notFound();
+  }
   return (
     <GalleryPageClient
       photosPreloaded={photosPreloaded}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -10,7 +10,7 @@ import type { MarketingFeatureFlags } from "@/lib/site-settings";
 
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
 type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
-type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos> | null;
+type PreloadedPhotos = Preloaded<typeof api.public.getPublishedCarouselPhotos> | null;
 type PreloadedFaq = Preloaded<typeof api.public.getPublishedFaq> | null;
 type PreloadedMarketing =
   | Preloaded<typeof api.public.getPublishedMarketingFeatureFlags>
@@ -50,7 +50,7 @@ function PhotosLive({
 }: {
   children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
 }) {
-  const photos = useQuery(api.public.getPublishedGalleryPhotos);
+  const photos = useQuery(api.public.getPublishedCarouselPhotos);
   return <>{children(photos)}</>;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ export default async function Home() {
     ] = await Promise.allSettled([
       preloadQuery(api.public.getPublishedPricingFlags),
       preloadQuery(api.public.getPublishedGear),
-      preloadQuery(api.public.getPublishedGalleryPhotos),
+      preloadQuery(api.public.getPublishedCarouselPhotos),
       preloadQuery(api.public.getPublishedFaq),
       preloadQuery(api.public.getPublishedMarketingFeatureFlags),
       preloadQuery(api.public.getPublishedAmenitiesNearby),

--- a/src/app/preview/about/page.tsx
+++ b/src/app/preview/about/page.tsx
@@ -60,6 +60,7 @@ function AboutPreviewContent() {
         aboutPage: marketing.aboutPage,
         recordingsPage: marketing.recordingsPage,
         pricingSection: marketing.pricingSection,
+        galleryPage: marketing.galleryPage,
       }}
       banner={<PreviewBanner hasDraftChanges={hasDraftChanges} />}
     />

--- a/src/app/preview/gallery/page.tsx
+++ b/src/app/preview/gallery/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { GalleryClient } from "../../gallery/gallery-client";
+import { PreviewBanner } from "@/components/preview-banner";
+
+/**
+ * Owner-only preview of the public Gallery page using draft photos. Mirrors
+ * `/preview/about` — non-owners get a friendly notice; the underlying
+ * `getPreviewGalleryPhotos` query returns `null` for unauthenticated /
+ * non-owner callers so drafts never leak.
+ */
+function GalleryPreviewContent() {
+  const photoPreview = useQuery(
+    api.photosPreviewDraft.getPreviewGalleryPhotos,
+  );
+  const marketing = useQuery(api.cms.getPreviewMarketingFeatureFlags);
+
+  if (photoPreview === undefined || marketing === undefined) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+        <p className="text-ivory/60">Loading preview…</p>
+      </div>
+    );
+  }
+
+  if (photoPreview === null || marketing === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+        <p className="text-ivory/60">
+          Preview is not available. You may not have permission to view draft
+          content.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <GalleryClient
+      photos={photoPreview.photos}
+      marketing={{
+        aboutPage: marketing.aboutPage,
+        recordingsPage: marketing.recordingsPage,
+        pricingSection: marketing.pricingSection,
+      }}
+      banner={<PreviewBanner hasDraftChanges={photoPreview.hasDraftChanges} />}
+    />
+  );
+}
+
+export default function GalleryPreviewPage() {
+  return (
+    <>
+      <AuthLoading>
+        <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+          <p className="text-ivory/60">Authenticating…</p>
+        </div>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <div className="flex min-h-screen items-center justify-center bg-deep-forest">
+          <p className="text-ivory/60">
+            Sign in required to preview draft content.
+          </p>
+        </div>
+      </Unauthenticated>
+
+      <Authenticated>
+        <GalleryPreviewContent />
+      </Authenticated>
+    </>
+  );
+}

--- a/src/app/preview/gallery/page.tsx
+++ b/src/app/preview/gallery/page.tsx
@@ -41,6 +41,8 @@ function GalleryPreviewContent() {
     );
   }
 
+  const publicGalleryDisabled = !marketing.galleryPagePublished;
+
   return (
     <GalleryClient
       photos={photoPreview.photos}
@@ -48,8 +50,25 @@ function GalleryPreviewContent() {
         aboutPage: marketing.aboutPage,
         recordingsPage: marketing.recordingsPage,
         pricingSection: marketing.pricingSection,
+        galleryPage: marketing.galleryPage,
       }}
-      banner={<PreviewBanner hasDraftChanges={photoPreview.hasDraftChanges} />}
+      banner={
+        <>
+          <PreviewBanner hasDraftChanges={photoPreview.hasDraftChanges} />
+          {publicGalleryDisabled ? (
+            <div
+              className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-3 text-center text-sm text-amber-100"
+              role="status"
+            >
+              The public Gallery page and nav link are currently{" "}
+              <span className="font-medium">hidden</span> for visitors. Turn
+              on &quot;Gallery page visibility&quot; in{" "}
+              <span className="font-mono">/admin/photos</span> (Gallery tab) and
+              publish to go live.
+            </div>
+          ) : null}
+        </>
+      }
     />
   );
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -12,7 +12,7 @@ function PreviewContent() {
     api.pricingPreviewDraft.getPreviewPricingFlags,
   );
   const gearPreview = useQuery(api.gearPreviewDraft.getPreviewGear);
-  const photoPreview = useQuery(api.photosPreviewDraft.getPreviewGalleryPhotos);
+  const photoPreview = useQuery(api.photosPreviewDraft.getPreviewCarouselPhotos);
   const audioPreview = useQuery(api.audioPreviewDraft.getPreviewAudioTracks);
   // Tracks whether the About section has unpublished draft content so the
   // preview banner can reflect it. Owner-only — returns `null` for non-owners.

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -87,6 +87,7 @@ function PreviewContent() {
         aboutPage: marketingPreview.aboutPage,
         recordingsPage: marketingPreview.recordingsPage,
         pricingSection: marketingPreview.pricingSection,
+        galleryPage: marketingPreview.galleryPage,
       }}
       gear={{ categories: gearPreview.categories }}
       photos={photoPreview.photos}

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { useRef, useState, type ReactNode } from "react";
 
 import { Header } from "@/components/header";
+import { PageHeader } from "@/components/page-header";
 import { SiteFooter } from "@/components/site-footer";
 import { useScrollAndReveal } from "@/hooks/use-scroll-and-reveal";
 import { MAX_REVEAL_DELAY, revealDelay } from "@/lib/reveal-delay";
@@ -639,41 +640,23 @@ export function RecordingsClient({
       />
 
       <main>
+        <PageHeader
+          eyebrow="Recordings"
+          title="Selected Recordings"
+          meta="Tracked · Mixed · Mastered"
+          backHref={backToHomeHref}
+          titleId="recordings-title"
+        />
+
         <section
-          className="relative bg-washed-black px-6 pb-24 pt-36 md:px-16 md:pb-36 md:pt-44"
-          aria-labelledby="recordings-title"
+          className="relative bg-washed-black px-6 pb-24 md:px-16 md:pb-36"
+          aria-label="Recordings list"
         >
           <div className="mx-auto max-w-6xl">
-            <nav aria-label="Breadcrumb" className={revealDelay(0)}>
-              <Link
-                href={backToHomeHref}
-                className="label-text text-[11px] tracking-[0.2em] text-sand/60 transition-colors hover:text-sand"
-              >
-                ← Lula Lake Sound
-              </Link>
-            </nav>
             <p
               className={cn(
-                revealDelay(1),
-                "label-text mt-8 text-[11px] tracking-[0.2em] text-sand/50",
-              )}
-            >
-              Listen
-            </p>
-            <h1
-              id="recordings-title"
-              className={cn(
-                revealDelay(2),
-                "headline-primary mt-4 text-balance leading-[1.05] text-warm-white",
-              )}
-              style={{ fontSize: "clamp(2rem, 4.5vw, 4rem)" }}
-            >
-              Selected Recordings
-            </h1>
-            <p
-              className={cn(
-                revealDelay(3),
-                "editorial-lede mt-6 max-w-2xl text-ivory/70",
+                revealDelay(0),
+                "editorial-lede max-w-2xl text-ivory/70",
               )}
             >
               A curated selection of projects tracked, mixed, or mastered at
@@ -684,7 +667,7 @@ export function RecordingsClient({
             {recordings.length === 0 ? (
               <div
                 className={cn(
-                  revealDelay(4),
+                  revealDelay(1),
                   "mt-16 border border-dashed border-sand/15 px-8 py-20 text-center",
                 )}
               >
@@ -698,7 +681,7 @@ export function RecordingsClient({
                 </p>
               </div>
             ) : (
-              <div className={cn(revealDelay(4), "mt-14")}>
+              <div className={cn(revealDelay(1), "mt-14")}>
                 {/* Column headers — desktop only */}
                 <div
                   aria-hidden
@@ -742,7 +725,7 @@ export function RecordingsClient({
 
             <div
               className={cn(
-                revealDelay(5),
+                revealDelay(2),
                 "mt-20 border-t border-sand/10 pt-16 flex flex-col gap-8 md:flex-row md:items-center md:justify-between",
               )}
             >

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -649,6 +649,7 @@ export function RecordingsClient({
           meta="Tracked · Mixed · Mastered"
           backHref={backToHomeHref}
           titleId="recordings-title"
+          titleSize="standard"
         />
 
         <section

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -14,6 +14,7 @@ import { MAX_REVEAL_DELAY, revealDelay } from "@/lib/reveal-delay";
 import { cn } from "@/lib/utils";
 import {
   type MarketingFeatureFlags,
+  isGalleryPageEnabled,
   isHomepagePricingSectionEnabled,
 } from "@/lib/site-settings";
 
@@ -551,6 +552,7 @@ export function RecordingsClient({
   const showPricing = isHomepagePricingSectionEnabled(marketing);
   const showAbout = marketing.aboutPage === true;
   const showRecordings = marketing.recordingsPage === true;
+  const showGallery = isGalleryPageEnabled(marketing);
 
   const { scrollY, containerRef } = useScrollAndReveal();
   const [active, setActive] = useState<ActiveTrackState | null>(null);
@@ -635,6 +637,7 @@ export function RecordingsClient({
         showAbout={showAbout}
         aboutHref={aboutHref}
         showRecordings={showRecordings}
+        showGallery={showGallery}
         homeSectionBase={homeSectionBase}
         recordingsHref={recordingsNavHref}
       />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -87,6 +87,15 @@ export function Header({
         ]
       : []),
     { kind: "hash", id: "the-space", label: "The Studio" },
+    {
+      kind: "route",
+      key: "gallery",
+      // `homeSectionBase` is `"/preview"` when the header is mounted under
+      // owner preview, otherwise `"/"`. Mirror that for the Gallery route.
+      href:
+        homeSectionBase === "/preview" ? "/preview/gallery" : "/gallery",
+      label: "Gallery",
+    },
     { kind: "hash", id: "equipment-specs", label: "Gear" },
     ...(showRecordings
       ? [

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -39,6 +39,11 @@ interface HeaderProps {
    * `"/recordings"`.
    */
   readonly recordingsHref?: string;
+  /**
+   * Shows the "Gallery" route link when the CMS gallery page flag is on.
+   * Defaults to `false` (hidden while marketing flags are loading).
+   */
+  readonly showGallery?: boolean;
 }
 
 /**
@@ -57,6 +62,7 @@ export function Header({
   showRecordings = false,
   homeSectionBase = "/",
   recordingsHref = "/recordings",
+  showGallery = false,
 }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -87,15 +93,17 @@ export function Header({
         ]
       : []),
     { kind: "hash", id: "the-space", label: "The Studio" },
-    {
-      kind: "route",
-      key: "gallery",
-      // `homeSectionBase` is `"/preview"` when the header is mounted under
-      // owner preview, otherwise `"/"`. Mirror that for the Gallery route.
-      href:
-        homeSectionBase === "/preview" ? "/preview/gallery" : "/gallery",
-      label: "Gallery",
-    },
+    ...(showGallery
+      ? [
+          {
+            kind: "route" as const,
+            key: "gallery",
+            href:
+              homeSectionBase === "/preview" ? "/preview/gallery" : "/gallery",
+            label: "Gallery",
+          },
+        ]
+      : []),
     { kind: "hash", id: "equipment-specs", label: "Gear" },
     ...(showRecordings
       ? [

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -18,6 +18,7 @@ import {
   type MarketingFeatureFlags,
   type PricingFlags,
   isHomepagePricingSectionEnabled,
+  isGalleryPageEnabled,
   previewHasActivePricingPackages,
 } from "@/lib/site-settings";
 
@@ -84,6 +85,7 @@ export function HomepageShell({
   const showAbout = marketing != null && marketing.aboutPage === true;
   const showRecordings =
     marketing != null && marketing.recordingsPage === true;
+  const showGallery = marketing != null && isGalleryPageEnabled(marketing);
 
   return (
     <div
@@ -97,6 +99,7 @@ export function HomepageShell({
         showAbout={showAbout}
         aboutHref={aboutHref}
         showRecordings={showRecordings}
+        showGallery={showGallery}
         homeSectionBase={homeSectionBase}
         recordingsHref={recordingsNavHref}
       />

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { revealDelay } from "@/lib/reveal-delay";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared editorial banner used at the top of every inner marketing page
+ * (About, Recordings, Gallery, …).
+ *
+ * Style direction (client direction, 2026-04-27):
+ *  - Flat washed-black ground, no hero imagery.
+ *  - Small uppercase eyebrow at top.
+ *  - Massive Acumin Wide Semibold title, left-aligned, balanced wrap.
+ *  - Bottom rule (short divider) + uppercase meta line.
+ *  - Optional breadcrumb back link above the eyebrow.
+ *  - Optional aside slot (e.g. gallery filter pills) anchored to the
+ *    bottom-right next to the meta line on desktop.
+ *
+ * The component is intentionally flat — no background image, no overlay —
+ * so it reads like a printed cover page rather than a marketing hero.
+ */
+
+interface PageHeaderProps {
+  /** Small eyebrow line, e.g. "About the studio". Rendered uppercase. */
+  readonly eyebrow: string;
+  /** Display title, e.g. "Lula Lake Sound". Wraps freely. */
+  readonly title: string;
+  /**
+   * Bottom-rule meta line, e.g. "Lookout Mountain, TN — Est. 2019". Rendered
+   * uppercase. Omit to skip the divider row.
+   */
+  readonly meta?: string;
+  /** Optional breadcrumb-style back link href. */
+  readonly backHref?: string;
+  /** Label for the back link. Defaults to "← Lula Lake Sound". */
+  readonly backLabel?: string;
+  /**
+   * Optional aside content rendered next to the meta line on desktop and
+   * stacked above it on mobile. Used by the gallery to host its filter
+   * pills.
+   */
+  readonly aside?: ReactNode;
+  /** Stable id used by `aria-labelledby` on the surrounding section. */
+  readonly titleId?: string;
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  meta,
+  backHref,
+  backLabel = "← Lula Lake Sound",
+  aside,
+  titleId = "page-header-title",
+}: PageHeaderProps) {
+  return (
+    <section
+      className="relative overflow-hidden bg-washed-black px-6 pb-16 pt-32 md:px-16 md:pb-24 md:pt-44"
+      aria-labelledby={titleId}
+    >
+      <div className="relative mx-auto w-full max-w-7xl">
+        {backHref ? (
+          <nav aria-label="Breadcrumb" className={revealDelay(0)}>
+            <Link
+              href={backHref}
+              className="label-text text-[11px] tracking-[0.2em] text-sand/60 transition-colors hover:text-sand"
+            >
+              {backLabel}
+            </Link>
+          </nav>
+        ) : null}
+        <p
+          className={cn(
+            revealDelay(1),
+            "label-text text-[11px] tracking-[0.3em] text-sand/55",
+            backHref ? "mt-12 md:mt-16" : "",
+          )}
+        >
+          {eyebrow}
+        </p>
+        <h1
+          id={titleId}
+          className={cn(
+            revealDelay(2),
+            "headline-primary mt-8 text-balance leading-[0.95] text-warm-white md:mt-10",
+          )}
+          style={{ fontSize: "clamp(3rem, 11vw, 8.5rem)" }}
+        >
+          {title}
+        </h1>
+
+        {meta || aside ? (
+          <div
+            className={cn(
+              revealDelay(3),
+              "mt-12 flex flex-col gap-8 md:mt-16 md:flex-row md:items-end md:justify-between md:gap-12",
+            )}
+          >
+            {meta ? (
+              <div className="flex items-center gap-6">
+                <span
+                  aria-hidden
+                  className="block h-px w-16 bg-sand/35 md:w-24"
+                />
+                <p className="label-text text-[11px] tracking-[0.25em] text-sand/55">
+                  {meta}
+                </p>
+              </div>
+            ) : (
+              <span aria-hidden />
+            )}
+            {aside ? <div className="md:flex-shrink-0">{aside}</div> : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -45,7 +45,19 @@ interface PageHeaderProps {
   readonly aside?: ReactNode;
   /** Stable id used by `aria-labelledby` on the surrounding section. */
   readonly titleId?: string;
+  /**
+   * `hero` — large cover title (Gallery). `about` / `standard` — tuned for
+   * longer hero titles on inner marketing pages.
+   */
+  readonly titleSize?: "hero" | "about" | "standard";
 }
+
+const TITLE_FONT_SIZE: Record<NonNullable<PageHeaderProps["titleSize"]>, string> =
+  {
+    hero: "clamp(3rem, 11vw, 8.5rem)",
+    about: "clamp(2.5rem, 6vw, 5.5rem)",
+    standard: "clamp(2rem, 4.5vw, 4rem)",
+  };
 
 export function PageHeader({
   eyebrow,
@@ -55,6 +67,7 @@ export function PageHeader({
   backLabel = "← Lula Lake Sound",
   aside,
   titleId = "page-header-title",
+  titleSize = "hero",
 }: PageHeaderProps) {
   return (
     <section
@@ -87,7 +100,7 @@ export function PageHeader({
             revealDelay(2),
             "headline-primary mt-8 text-balance leading-[0.95] text-warm-white md:mt-10",
           )}
-          style={{ fontSize: "clamp(3rem, 11vw, 8.5rem)" }}
+          style={{ fontSize: TITLE_FONT_SIZE[titleSize] }}
         >
           {title}
         </h1>

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -16,6 +16,13 @@ export type GalleryPhoto = {
   contentType: string;
   sizeBytes: number;
   originalFileName: string | null;
+  /**
+   * INF-47 — controlled-vocabulary tags from `GALLERY_CATEGORY_SLUGS`
+   * (`rooms` / `gear` / `grounds`). Drives the public `/gallery` page
+   * filter pills. Empty when the photo is uncategorized; the homepage
+   * carousel ignores this field.
+   */
+  categories: readonly string[];
 };
 
 function galleryImageAlt(alt: string): string {

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -23,6 +23,9 @@ export type GalleryPhoto = {
    * carousel ignores this field.
    */
   categories: readonly string[];
+  /** Omitted in older payloads; treat as `true` when undefined. */
+  showInCarousel?: boolean;
+  showInGallery?: boolean;
 };
 
 function galleryImageAlt(alt: string): string {

--- a/src/lib/site-settings.test.ts
+++ b/src/lib/site-settings.test.ts
@@ -36,6 +36,7 @@ describe("isHomepagePricingSectionEnabled", () => {
       aboutPage: false,
       recordingsPage: false,
       pricingSection: false,
+      galleryPage: true,
     };
     expect(isHomepagePricingSectionEnabled(flags)).toBe(false);
   });
@@ -45,6 +46,7 @@ describe("isHomepagePricingSectionEnabled", () => {
       aboutPage: false,
       recordingsPage: false,
       pricingSection: true,
+      galleryPage: true,
     };
     expect(isHomepagePricingSectionEnabled(flags)).toBe(true);
   });

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -33,12 +33,25 @@ export type PricingFlags = {
   packages?: PricingPackage[];
 };
 
-/** Published marketing page/section visibility (Convex `marketingFeatureFlags` table). */
+/** Published marketing page/section visibility (Convex `cmsSections` rows). */
 export type MarketingFeatureFlags = {
   aboutPage: boolean;
   recordingsPage: boolean;
   pricingSection: boolean;
+  /** Public `/gallery` page + "Gallery" nav; distinct from per-photo `showInGallery`. */
+  galleryPage: boolean;
 };
+
+/**
+ * When `false`, `/gallery` 404s and the Gallery nav item is hidden.
+ * Missing `galleryPage` is treated as on (matches `DEFAULT_IS_ENABLED.photos`).
+ */
+export function isGalleryPageEnabled(
+  flags: MarketingFeatureFlags | null | undefined,
+): boolean {
+  if (flags == null) return false;
+  return flags.galleryPage !== false;
+}
 
 /**
  * Homepage pricing block + primary-nav "Pricing" link.

--- a/src/lib/use-marketing-feature-flags-admin.ts
+++ b/src/lib/use-marketing-feature-flags-admin.ts
@@ -13,11 +13,16 @@ const FLAGS_DEFAULT: MarketingFeatureFlags = {
   aboutPage: false,
   recordingsPage: false,
   pricingSection: true,
+  galleryPage: true,
 };
 
-type FlagKey = keyof MarketingFeatureFlags;
+/** Settings-UI marketing flags only (gallery page is edited in /admin/photos). */
+type MarketingFlagKey = "aboutPage" | "recordingsPage" | "pricingSection";
 
-const FLAG_TO_SECTION: Record<FlagKey, "about" | "recordings" | "pricing"> = {
+const FLAG_TO_SECTION: Record<
+  MarketingFlagKey,
+  "about" | "recordings" | "pricing"
+> = {
   aboutPage: "about",
   recordingsPage: "recordings",
   pricingSection: "pricing",
@@ -58,7 +63,7 @@ export function useMarketingFeatureFlagsAdmin(pauseWhen: boolean) {
   const saveEffect = useCallback(() => {
     if (source === undefined) return Effect.void;
     const base = data?.flags ?? FLAGS_DEFAULT;
-    const dirtyKeys: FlagKey[] = (
+    const dirtyKeys: MarketingFlagKey[] = (
       ["aboutPage", "recordingsPage", "pricingSection"] as const
     ).filter((k) => source[k] !== base[k]);
     if (dirtyKeys.length === 0) return Effect.void;
@@ -90,7 +95,7 @@ export function useMarketingFeatureFlagsAdmin(pauseWhen: boolean) {
   kickFFAutosaveRef.current = kickFFAutosave;
 
   const patchFlags = useCallback(
-    (partial: Partial<MarketingFeatureFlags>) => {
+    (partial: Partial<Pick<MarketingFeatureFlags, MarketingFlagKey>>) => {
       if (!source) return;
       setLocalDraft({ ...source, ...partial });
       kickFFAutosaveRef.current();


### PR DESCRIPTION
- Add public /gallery page with CMS-driven masonry layout and lightbox, plus /preview/gallery for draft preview.
- Extract shared PageHeader component used by About, Recordings, and Gallery for consistent page intros.
- Convex: add gallery photos schema, admin mutations, public query, and test coverage for gallery photo flows.
- Header and the-space: minor supporting tweaks for the new gallery nav entry.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public route and expands the gallery photo data model (categories + surface visibility flags), changing what content is exposed on the homepage carousel vs `/gallery` and how publishes/discards behave.
> 
> **Overview**
> Adds a new public **`/gallery` page** (plus owner-only ` /preview/gallery`) that renders published/draft gallery photos in a masonry grid with category filter pills and a lightbox, and gates the route/nav visibility behind a new `cmsSections.photos` **gallery-page enable flag**.
> 
> Extends the gallery photo model with **`categories`** (controlled slugs: `rooms|gear|grounds`) and per-photo **surface flags** (`showInCarousel`, `showInGallery`), wiring these through Convex admin mutations/validation, publish/discard flows (including promoting the gallery-page flag on publish), and new public queries that separately serve carousel vs gallery photos.
> 
> Refactors About/Recordings/Gallery intros to use a new shared `PageHeader`, updates the global `Header` to optionally show a Gallery link, and adjusts homepage/preview data fetching to use the new carousel-specific photo query. Includes targeted test updates for the new CMS defaults/flag logic and category normalization/comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035aa7fdccb8cca912e7ae74d2767c35c0d88e2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->