### PR TITLE
INF-92: CMS videos + publish alignment

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -57,6 +57,8 @@ import type * as seed from "../seed.js";
 import type * as sentryNodeReport from "../sentryNodeReport.js";
 import type * as settingsTree from "../settingsTree.js";
 import type * as siteSettingsPreviewDraft from "../siteSettingsPreviewDraft.js";
+import type * as videoUrls from "../videoUrls.js";
+import type * as videos from "../videos.js";
 
 import type {
   ApiFromModules,
@@ -114,6 +116,8 @@ declare const fullApi: ApiFromModules<{
   sentryNodeReport: typeof sentryNodeReport;
   settingsTree: typeof settingsTree;
   siteSettingsPreviewDraft: typeof siteSettingsPreviewDraft;
+  videoUrls: typeof videoUrls;
+  videos: typeof videos;
 }>;
 
 /**

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as admin_photos from "../admin/photos.js";
 import type * as admin_pricing from "../admin/pricing.js";
 import type * as admin_publish from "../admin/publish.js";
 import type * as admin_siteSettings from "../admin/siteSettings.js";
+import type * as admin_videos from "../admin/videos.js";
 import type * as amenitiesNearbyCms from "../amenitiesNearbyCms.js";
 import type * as amenitiesPreviewDraft from "../amenitiesPreviewDraft.js";
 import type * as amenitiesTree from "../amenitiesTree.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   "admin/pricing": typeof admin_pricing;
   "admin/publish": typeof admin_publish;
   "admin/siteSettings": typeof admin_siteSettings;
+  "admin/videos": typeof admin_videos;
   amenitiesNearbyCms: typeof amenitiesNearbyCms;
   amenitiesPreviewDraft: typeof amenitiesPreviewDraft;
   amenitiesTree: typeof amenitiesTree;

--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -15,6 +15,7 @@ import { requireCmsOwner } from "../lib/auth";
 import { cmsPublishValidationFailed } from "../errors";
 import { loadGalleryPhotos } from "../galleryPhotos";
 import { loadAudioTracks } from "../audioTracks";
+import { loadVideos } from "../videos";
 import { collectAboutTeamBlobIssues } from "../aboutTeamStorage";
 import {
   collectAllPublishIssues,
@@ -24,6 +25,10 @@ import {
 import { ensureSectionMetaRow } from "../cmsMeta";
 import { publishGalleryDraftCore, validateDraftForPublish } from "./photos";
 import { publishAudioDraftCore, validateDraftAudioForPublish } from "./audio";
+import {
+  publishVideosDraftCore,
+  validateDraftVideosForPublish,
+} from "./videos";
 
 export const publish = mutation({
   args: { section: cmsSectionValidator },
@@ -60,7 +65,13 @@ export const publishSite = mutation({
       .unique();
     const audioPending = audioMeta?.hasDraftChanges ?? false;
 
-    if (targets.length === 0 && !galleryPending && !audioPending) {
+    const videoMeta = await ctx.db
+      .query("videoMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+    const videosPending = videoMeta?.hasDraftChanges ?? false;
+
+    if (targets.length === 0 && !galleryPending && !audioPending && !videosPending) {
       return {
         ok: true as const,
         kind: "nothing_to_publish" as const,
@@ -100,6 +111,16 @@ export const publishSite = mutation({
         });
       }
     }
+    if (videosPending) {
+      const draftVideos = await loadVideos(ctx, "draft");
+      const videoIssues = await validateDraftVideosForPublish(ctx, draftVideos);
+      for (const issue of videoIssues) {
+        issues.push({
+          path: `videos.${issue.path}`,
+          message: issue.message,
+        });
+      }
+    }
     if (issues.length > 0) {
       cmsPublishValidationFailed(
         "site",
@@ -129,6 +150,10 @@ export const publishSite = mutation({
       ? await publishAudioDraftCore(ctx, { userId, updatedBy })
       : undefined;
 
+    const videosResult = videosPending
+      ? await publishVideosDraftCore(ctx, { userId, updatedBy })
+      : undefined;
+
     return {
       ok: true as const,
       kind: "published" as const,
@@ -136,6 +161,7 @@ export const publishSite = mutation({
       results,
       ...(galleryResult !== undefined ? { gallery: galleryResult } : {}),
       ...(audioResult !== undefined ? { audio: audioResult } : {}),
+      ...(videosResult !== undefined ? { videos: videosResult } : {}),
     };
   },
 });

--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -292,7 +292,7 @@ async function buildVideoInsertPatch(args: {
   };
 }
 
-async function validateDraftForPublish(
+export async function validateDraftVideosForPublish(
   ctx: MutationCtx,
   rows: VideoDoc[],
 ): Promise<VideoPublishIssue[]> {
@@ -301,7 +301,7 @@ async function validateDraftForPublish(
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
-    const base = `videos[${i}]`;
+    const base = `items[${i}]`;
 
     if (row.title.trim().length === 0) {
       issues.push({ path: `${base}.title`, message: "Title is required." });
@@ -672,7 +672,7 @@ export async function publishVideosDraftCore(
 }> {
   const { userId, updatedBy } = args;
   const draft = await loadVideos(ctx, "draft");
-  const issues = await validateDraftForPublish(ctx, draft);
+  const issues = await validateDraftVideosForPublish(ctx, draft);
   if (issues.length > 0) {
     cmsPublishValidationFailed("videos", "Publish validation failed.", issues);
   }

--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -1,0 +1,714 @@
+import { v } from "convex/values";
+import { mutation, query, type MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import {
+  ALLOWED_CMS_VIDEO_MIME_TYPES,
+  MAX_CMS_VIDEO_UPLOAD_BYTES,
+  MAX_CMS_VIDEOS,
+  ensureCmsVideoMeta,
+  getStorageMetadata,
+  loadCmsVideos,
+  materializeCmsVideos,
+  patchCmsVideoMetaAfterDraftChange,
+  replaceCmsVideosScope,
+  type CmsVideoDoc,
+} from "../cmsVideos";
+import { deleteStorageIfUnreferenced } from "../mediaStorage";
+import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
+import { requireCmsOwner } from "../lib/auth";
+import {
+  externalIdValidationMessage,
+  muxPlaybackUrlErrorMessage,
+  normalizeExternalIdForProvider,
+  parseHttpsThumbnailUrl,
+  parseMuxPlaybackUrl,
+  thumbnailUrlErrorMessage,
+} from "../videoUrls";
+import type { CmsVideoProvider } from "../videoUrls";
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_DESCRIPTION_LENGTH = 2000;
+
+const cmsVideoProviderArg = v.union(
+  v.literal("youtube"),
+  v.literal("vimeo"),
+  v.literal("mux"),
+  v.literal("upload"),
+);
+
+type VideoPublishIssue = { path: string; message: string };
+
+function generateVideoStableId(): string {
+  return `vid_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeTitle(raw: string): string {
+  const value = raw.trim();
+  if (value.length === 0) {
+    cmsValidationError("Title is required.", "title");
+  }
+  if (value.length > MAX_TITLE_LENGTH) {
+    cmsValidationError(
+      `Title must be at most ${MAX_TITLE_LENGTH} characters.`,
+      "title",
+    );
+  }
+  return value;
+}
+
+function normalizeDescription(raw?: string | null): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  if (value.length > MAX_DESCRIPTION_LENGTH) {
+    cmsValidationError(
+      `Description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`,
+      "description",
+    );
+  }
+  return value;
+}
+
+function normalizeOptionalThumbnailUrl(
+  raw?: string | null,
+): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  try {
+    return parseHttpsThumbnailUrl(value).url;
+  } catch (e) {
+    const code = e instanceof Error ? e.message : "INVALID";
+    if (code === "TOO_LONG") {
+      cmsValidationError("Thumbnail URL is too long.", "thumbnailUrl");
+    }
+    cmsValidationError(
+      thumbnailUrlErrorMessage("thumbnail URL"),
+      "thumbnailUrl",
+    );
+  }
+}
+
+function normalizeOptionalMuxPlayback(
+  raw?: string | null,
+): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return undefined;
+  }
+  try {
+    return parseMuxPlaybackUrl(value).url;
+  } catch {
+    cmsValidationError(
+      muxPlaybackUrlErrorMessage("Mux playback URL"),
+      "playbackUrl",
+    );
+  }
+}
+
+function normalizeDurationSec(raw?: number | null): number | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (!Number.isFinite(raw) || raw < 0 || raw > 24 * 3600) {
+    cmsValidationError(
+      "Duration must be between 0 and 24 hours (in seconds).",
+      "durationSec",
+    );
+  }
+  return Math.round(raw * 1000) / 1000;
+}
+
+function isAllowedVideoMime(
+  contentType: string,
+): contentType is (typeof ALLOWED_CMS_VIDEO_MIME_TYPES)[number] {
+  return (ALLOWED_CMS_VIDEO_MIME_TYPES as readonly string[]).includes(
+    contentType,
+  );
+}
+
+async function validateVideoUploadStorage(
+  ctx: MutationCtx,
+  storageId: Id<"_storage">,
+): Promise<void> {
+  const storage = await getStorageMetadata(ctx, storageId);
+  if (!storage) {
+    cmsValidationError(
+      "Uploaded file was not found in storage.",
+      "videoStorageId",
+    );
+  }
+  if (!storage.contentType || !isAllowedVideoMime(storage.contentType)) {
+    cmsValidationError(
+      "Only MP4, WebM, or QuickTime video uploads are allowed.",
+      "videoStorageId",
+    );
+  }
+  if (storage.size > MAX_CMS_VIDEO_UPLOAD_BYTES) {
+    cmsValidationError(
+      `Video uploads must be ${Math.floor(MAX_CMS_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB or smaller.`,
+      "videoStorageId",
+    );
+  }
+}
+
+async function getDraftVideoByStableId(
+  ctx: MutationCtx,
+  stableId: string,
+): Promise<CmsVideoDoc | null> {
+  return await ctx.db
+    .query("cmsVideos")
+    .withIndex("by_scope_and_stableId", (q) =>
+      q.eq("scope", "draft").eq("stableId", stableId),
+    )
+    .unique();
+}
+
+function resolveEmbedFields(args: {
+  provider: CmsVideoProvider;
+  externalId?: string | null;
+  playbackUrl?: string | null;
+}): { externalId?: string; playbackUrl?: string } {
+  const { provider } = args;
+  if (provider === "upload") {
+    return {};
+  }
+  if (provider === "mux") {
+    const extRaw = args.externalId?.trim() ?? "";
+    if (extRaw.length === 0) {
+      cmsValidationError(
+        "Mux playback id or URL is required.",
+        "externalId",
+      );
+    }
+    let externalId: string;
+    try {
+      externalId = normalizeExternalIdForProvider("mux", extRaw);
+    } catch (e) {
+      const code = e instanceof Error ? e.message : "INVALID_MUX_URL";
+      cmsValidationError(
+        externalIdValidationMessage("mux", code),
+        "externalId",
+      );
+    }
+    const playback = normalizeOptionalMuxPlayback(args.playbackUrl);
+    return {
+      externalId,
+      ...(playback !== undefined ? { playbackUrl: playback } : {}),
+    };
+  }
+
+  const extRaw = args.externalId?.trim() ?? "";
+  if (extRaw.length === 0) {
+    cmsValidationError(
+      "Video id or watch URL is required for this provider.",
+      "externalId",
+    );
+  }
+  try {
+    const externalId = normalizeExternalIdForProvider(provider, extRaw);
+    return { externalId };
+  } catch (e) {
+    const code = e instanceof Error ? e.message : "INVALID";
+    cmsValidationError(
+      externalIdValidationMessage(provider, code),
+      "externalId",
+    );
+  }
+}
+
+async function buildVideoInsertPatch(args: {
+  provider: CmsVideoProvider;
+  title: string;
+  description?: string;
+  sortOrder: number;
+  externalId?: string | null;
+  playbackUrl?: string | null;
+  videoStorageId?: Id<"_storage"> | null;
+  thumbnailStorageId?: Id<"_storage"> | null;
+  thumbnailUrl?: string | null;
+  durationSec?: number | null;
+}): Promise<Omit<CmsVideoDoc, "_id" | "_creationTime">> {
+  const title = normalizeTitle(args.title);
+  const description = normalizeDescription(args.description);
+  const thumbUrl = normalizeOptionalThumbnailUrl(args.thumbnailUrl);
+  const durationSec = normalizeDurationSec(args.durationSec);
+
+  const base = {
+    scope: "draft" as const,
+    title,
+    ...(description !== undefined ? { description } : {}),
+    sortOrder: args.sortOrder,
+    ...(thumbUrl !== undefined ? { thumbnailUrl: thumbUrl } : {}),
+    ...(args.thumbnailStorageId !== undefined &&
+    args.thumbnailStorageId !== null
+      ? { thumbnailStorageId: args.thumbnailStorageId }
+      : {}),
+    ...(durationSec !== undefined ? { durationSec } : {}),
+  };
+
+  if (args.provider === "upload") {
+    if (!args.videoStorageId) {
+      cmsValidationError(
+        "A video file upload is required when provider is upload.",
+        "videoStorageId",
+      );
+    }
+    return {
+      ...base,
+      stableId: generateVideoStableId(),
+      provider: "upload",
+      videoStorageId: args.videoStorageId,
+    };
+  }
+
+  const resolved = resolveEmbedFields({
+    provider: args.provider,
+    externalId: args.externalId,
+    playbackUrl: args.playbackUrl,
+  });
+
+  return {
+    ...base,
+    stableId: generateVideoStableId(),
+    provider: args.provider,
+    ...(resolved.externalId !== undefined
+      ? { externalId: resolved.externalId }
+      : {}),
+    ...(resolved.playbackUrl !== undefined
+      ? { playbackUrl: resolved.playbackUrl }
+      : {}),
+  };
+}
+
+async function validateDraftForPublish(
+  ctx: MutationCtx,
+  rows: CmsVideoDoc[],
+): Promise<VideoPublishIssue[]> {
+  const issues: VideoPublishIssue[] = [];
+  const stableIds = new Set<string>();
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const base = `videos[${i}]`;
+
+    if (row.title.trim().length === 0) {
+      issues.push({ path: `${base}.title`, message: "Title is required." });
+    }
+    if (stableIds.has(row.stableId)) {
+      issues.push({
+        path: `${base}.stableId`,
+        message: `Duplicate stableId: ${row.stableId}`,
+      });
+    } else {
+      stableIds.add(row.stableId);
+    }
+
+    if (row.provider === "upload") {
+      if (!row.videoStorageId) {
+        issues.push({
+          path: `${base}.videoStorageId`,
+          message: "Uploaded video file is missing.",
+        });
+      } else {
+        const storage = await getStorageMetadata(ctx, row.videoStorageId);
+        if (!storage) {
+          issues.push({
+            path: `${base}.videoStorageId`,
+            message: "Referenced video storage blob is missing.",
+          });
+        } else if (!storage.contentType || !isAllowedVideoMime(storage.contentType)) {
+          issues.push({
+            path: `${base}.videoStorageId`,
+            message: "Video blob must be MP4, WebM, or QuickTime.",
+          });
+        } else if (storage.size > MAX_CMS_VIDEO_UPLOAD_BYTES) {
+          issues.push({
+            path: `${base}.videoStorageId`,
+            message: `Video exceeds ${Math.floor(MAX_CMS_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB.`,
+          });
+        }
+      }
+    } else if (row.provider === "mux") {
+      if (!row.externalId || row.externalId.trim().length === 0) {
+        issues.push({
+          path: `${base}.externalId`,
+          message: "Mux playback id is required.",
+        });
+      }
+      if (row.playbackUrl !== undefined && row.playbackUrl.trim().length > 0) {
+        try {
+          parseMuxPlaybackUrl(row.playbackUrl);
+        } catch {
+          issues.push({
+            path: `${base}.playbackUrl`,
+            message: muxPlaybackUrlErrorMessage("Mux playback URL"),
+          });
+        }
+      }
+    } else {
+      if (!row.externalId || row.externalId.trim().length === 0) {
+        issues.push({
+          path: `${base}.externalId`,
+          message: "Video id or URL is required.",
+        });
+      }
+    }
+
+    if (row.thumbnailUrl !== undefined && row.thumbnailUrl.trim().length > 0) {
+      try {
+        parseHttpsThumbnailUrl(row.thumbnailUrl);
+      } catch {
+        issues.push({
+          path: `${base}.thumbnailUrl`,
+          message: thumbnailUrlErrorMessage("thumbnail URL"),
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+async function resequenceDraftVideos(ctx: MutationCtx): Promise<void> {
+  const draft = await loadCmsVideos(ctx, "draft");
+  draft.sort((a, b) => a.sortOrder - b.sortOrder);
+  for (let i = 0; i < draft.length; i++) {
+    const row = draft[i];
+    if (row.sortOrder !== i) {
+      await ctx.db.patch(row._id, { sortOrder: i });
+    }
+  }
+}
+
+export const listDraftVideos = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    const rows = await loadCmsVideos(ctx, "draft");
+    const meta = await ctx.db
+      .query("cmsVideoMeta")
+      .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+      .unique();
+    const videos = await materializeCmsVideos(ctx, rows);
+    return {
+      videos,
+      meta: meta
+        ? {
+            hasDraftChanges: meta.hasDraftChanges,
+            publishedAt: meta.publishedAt,
+            publishedBy: meta.publishedBy,
+            updatedAt: meta.updatedAt,
+          }
+        : null,
+      maxVideos: MAX_CMS_VIDEOS,
+    };
+  },
+});
+
+export const createDraftVideo = mutation({
+  args: {
+    provider: cmsVideoProviderArg,
+    title: v.string(),
+    description: v.optional(v.string()),
+    externalId: v.optional(v.string()),
+    playbackUrl: v.optional(v.string()),
+    videoStorageId: v.optional(v.id("_storage")),
+    thumbnailStorageId: v.optional(v.id("_storage")),
+    thumbnailUrl: v.optional(v.string()),
+    durationSec: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureCmsVideoMeta(ctx);
+
+    const draft = await loadCmsVideos(ctx, "draft");
+    if (draft.length >= MAX_CMS_VIDEOS) {
+      cmsValidationError(
+        `Video list supports up to ${MAX_CMS_VIDEOS} items.`,
+        "provider",
+      );
+    }
+
+    const sortOrder = draft.length;
+
+    if (args.provider === "upload") {
+      if (!args.videoStorageId) {
+        cmsValidationError(
+          "videoStorageId is required for upload provider.",
+          "videoStorageId",
+        );
+      }
+      await validateVideoUploadStorage(ctx, args.videoStorageId);
+    } else if (args.videoStorageId !== undefined) {
+      cmsValidationError(
+        "videoStorageId is only valid when provider is upload.",
+        "videoStorageId",
+      );
+    }
+
+    const patch = await buildVideoInsertPatch({
+      provider: args.provider,
+      title: args.title,
+      description: args.description,
+      sortOrder,
+      externalId: args.externalId,
+      playbackUrl: args.playbackUrl,
+      videoStorageId: args.videoStorageId,
+      thumbnailStorageId: args.thumbnailStorageId,
+      thumbnailUrl: args.thumbnailUrl,
+      durationSec: args.durationSec,
+    });
+
+    await ctx.db.insert("cmsVideos", patch);
+    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, stableId: patch.stableId };
+  },
+});
+
+export const updateDraftVideo = mutation({
+  args: {
+    stableId: v.string(),
+    title: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
+    externalId: v.optional(v.string()),
+    playbackUrl: v.optional(v.union(v.string(), v.null())),
+    videoStorageId: v.optional(v.id("_storage")),
+    thumbnailStorageId: v.optional(v.union(v.id("_storage"), v.null())),
+    thumbnailUrl: v.optional(v.union(v.string(), v.null())),
+    durationSec: v.optional(v.union(v.number(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftVideoByStableId(ctx, args.stableId);
+    if (!row) {
+      cmsNotFound("cmsVideo", args.stableId);
+    }
+
+    const patch: Partial<CmsVideoDoc> = {};
+
+    if (args.title !== undefined) {
+      patch.title = normalizeTitle(args.title);
+    }
+    if (args.description !== undefined) {
+      if (args.description === null) {
+        patch.description = undefined;
+      } else {
+        const d = normalizeDescription(args.description);
+        if (d === undefined) {
+          patch.description = undefined;
+        } else {
+          patch.description = d;
+        }
+      }
+    }
+    if (args.durationSec !== undefined) {
+      if (args.durationSec === null) {
+        patch.durationSec = undefined;
+      } else {
+        patch.durationSec = normalizeDurationSec(args.durationSec);
+      }
+    }
+
+    if (args.thumbnailUrl !== undefined) {
+      if (args.thumbnailUrl === null) {
+        patch.thumbnailUrl = undefined;
+      } else {
+        const u = normalizeOptionalThumbnailUrl(args.thumbnailUrl);
+        if (u === undefined) {
+          patch.thumbnailUrl = undefined;
+        } else {
+          patch.thumbnailUrl = u;
+        }
+      }
+    }
+
+    if (args.thumbnailStorageId !== undefined) {
+      if (args.thumbnailStorageId === null) {
+        const prev = row.thumbnailStorageId;
+        patch.thumbnailStorageId = undefined;
+        if (prev) {
+          await deleteStorageIfUnreferenced(ctx, prev);
+        }
+      } else {
+        patch.thumbnailStorageId = args.thumbnailStorageId;
+      }
+    }
+
+    if (row.provider === "upload") {
+      if (args.videoStorageId !== undefined) {
+        await validateVideoUploadStorage(ctx, args.videoStorageId);
+        const prev = row.videoStorageId;
+        patch.videoStorageId = args.videoStorageId;
+        if (prev && prev !== args.videoStorageId) {
+          await deleteStorageIfUnreferenced(ctx, prev);
+        }
+      }
+    }
+
+    if (row.provider !== "upload") {
+      const nextExternal =
+        args.externalId !== undefined ? args.externalId : row.externalId;
+      const nextPlayback =
+        args.playbackUrl !== undefined
+          ? args.playbackUrl
+          : row.playbackUrl;
+
+      if (
+        args.externalId !== undefined ||
+        args.playbackUrl !== undefined
+      ) {
+        const resolved = resolveEmbedFields({
+          provider: row.provider,
+          externalId: nextExternal ?? "",
+          playbackUrl: nextPlayback ?? null,
+        });
+        patch.externalId = resolved.externalId as string;
+        if (resolved.playbackUrl !== undefined) {
+          patch.playbackUrl = resolved.playbackUrl;
+        } else if (
+          row.provider === "mux" &&
+          args.playbackUrl !== undefined &&
+          args.playbackUrl === null
+        ) {
+          patch.playbackUrl = undefined;
+        }
+      }
+    }
+
+    await ctx.db.patch(row._id, patch);
+    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export const removeDraftVideo = mutation({
+  args: { stableId: v.string() },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const row = await getDraftVideoByStableId(ctx, args.stableId);
+    if (!row) {
+      return { ok: true as const, removed: false };
+    }
+
+    await ctx.db.delete(row._id);
+    if (row.videoStorageId) {
+      await deleteStorageIfUnreferenced(ctx, row.videoStorageId);
+    }
+    if (row.thumbnailStorageId) {
+      await deleteStorageIfUnreferenced(ctx, row.thumbnailStorageId);
+    }
+    await resequenceDraftVideos(ctx);
+    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const, removed: true };
+  },
+});
+
+export const reorderDraftVideos = mutation({
+  args: { orderedStableIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    const draft = await loadCmsVideos(ctx, "draft");
+    if (args.orderedStableIds.length !== draft.length) {
+      cmsValidationError(
+        "Reorder payload must include every draft video exactly once.",
+        "orderedStableIds",
+      );
+    }
+    const idSet = new Set(draft.map((r) => r.stableId));
+    for (const id of args.orderedStableIds) {
+      if (!idSet.has(id)) {
+        cmsValidationError(
+          "Reorder payload must include every draft video exactly once.",
+          "orderedStableIds",
+        );
+      }
+    }
+    for (let i = 0; i < args.orderedStableIds.length; i++) {
+      const stableId = args.orderedStableIds[i];
+      const row = draft.find((r) => r.stableId === stableId);
+      if (!row) {
+        cmsNotFound("cmsVideo", stableId);
+      }
+      if (row.sortOrder !== i) {
+        await ctx.db.patch(row._id, { sortOrder: i });
+      }
+    }
+    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    return { ok: true as const };
+  },
+});
+
+export async function publishCmsVideosDraftCore(
+  ctx: MutationCtx,
+  args: { userId: string; updatedBy: string },
+): Promise<{
+  ok: true;
+  kind: "published";
+  publishedAt: number;
+  publishedBy: string;
+}> {
+  const { userId, updatedBy } = args;
+  const draft = await loadCmsVideos(ctx, "draft");
+  const issues = await validateDraftForPublish(ctx, draft);
+  if (issues.length > 0) {
+    cmsPublishValidationFailed("videos", "Publish validation failed.", issues);
+  }
+
+  await replaceCmsVideosScope(ctx, "draft", "published");
+
+  const now = Date.now();
+  const { id: metaId } = await ensureCmsVideoMeta(ctx);
+  await ctx.db.patch(metaId, {
+    hasDraftChanges: false,
+    publishedAt: now,
+    publishedBy: userId,
+    updatedAt: now,
+    updatedBy,
+  });
+
+  return {
+    ok: true as const,
+    kind: "published" as const,
+    publishedAt: now,
+    publishedBy: userId,
+  };
+}
+
+export const publishVideos = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { userId, updatedBy } = await requireCmsOwner(ctx);
+    return await publishCmsVideosDraftCore(ctx, { userId, updatedBy });
+  },
+});
+
+export const discardDraftVideos = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const { updatedBy } = await requireCmsOwner(ctx);
+    await ensureCmsVideoMeta(ctx);
+    await replaceCmsVideosScope(ctx, "published", "draft");
+
+    const now = Date.now();
+    const { id: metaId } = await ensureCmsVideoMeta(ctx);
+    await ctx.db.patch(metaId, {
+      hasDraftChanges: false,
+      updatedAt: now,
+      updatedBy,
+    });
+
+    return { ok: true as const, discarded: true };
+  },
+});

--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -536,11 +536,7 @@ export const updateDraftVideo = mutation({
 
     if (args.thumbnailStorageId !== undefined) {
       if (args.thumbnailStorageId === null) {
-        const prev = row.thumbnailStorageId;
         patch.thumbnailStorageId = undefined;
-        if (prev) {
-          await deleteStorageIfUnreferenced(ctx, prev);
-        }
       } else {
         patch.thumbnailStorageId = args.thumbnailStorageId;
       }
@@ -549,11 +545,7 @@ export const updateDraftVideo = mutation({
     if (row.provider === "upload") {
       if (args.videoStorageId !== undefined) {
         await validateVideoUploadStorage(ctx, args.videoStorageId);
-        const prev = row.videoStorageId;
         patch.videoStorageId = args.videoStorageId;
-        if (prev && prev !== args.videoStorageId) {
-          await deleteStorageIfUnreferenced(ctx, prev);
-        }
       }
     }
 
@@ -588,6 +580,21 @@ export const updateDraftVideo = mutation({
     }
 
     await ctx.db.patch(row._id, patch);
+
+    if (args.thumbnailStorageId !== undefined && args.thumbnailStorageId === null) {
+      const prev = row.thumbnailStorageId;
+      if (prev) {
+        await deleteStorageIfUnreferenced(ctx, prev);
+      }
+    }
+
+    if (row.provider === "upload" && args.videoStorageId !== undefined) {
+      const prev = row.videoStorageId;
+      if (prev && prev !== args.videoStorageId) {
+        await deleteStorageIfUnreferenced(ctx, prev);
+      }
+    }
+
     await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const };
   },
@@ -626,14 +633,18 @@ export const reorderDraftVideos = mutation({
         "orderedStableIds",
       );
     }
-    const idSet = new Set(draft.map((r) => r.stableId));
-    for (const id of args.orderedStableIds) {
-      if (!idSet.has(id)) {
-        cmsValidationError(
-          "Reorder payload must include every draft video exactly once.",
-          "orderedStableIds",
-        );
-      }
+
+    const draftIds = new Set(draft.map((r) => r.stableId));
+    const orderedIds = new Set(args.orderedStableIds);
+    if (
+      orderedIds.size !== args.orderedStableIds.length ||
+      draftIds.size !== orderedIds.size ||
+      args.orderedStableIds.some((stableId) => !draftIds.has(stableId))
+    ) {
+      cmsValidationError(
+        "Reorder payload must include every draft video exactly once.",
+        "orderedStableIds",
+      );
     }
     for (let i = 0; i < args.orderedStableIds.length; i++) {
       const stableId = args.orderedStableIds[i];

--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -2,17 +2,17 @@ import { v } from "convex/values";
 import { mutation, query, type MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import {
-  ALLOWED_CMS_VIDEO_MIME_TYPES,
-  MAX_CMS_VIDEO_UPLOAD_BYTES,
-  MAX_CMS_VIDEOS,
-  ensureCmsVideoMeta,
+  ALLOWED_VIDEO_MIME_TYPES,
+  MAX_VIDEO_UPLOAD_BYTES,
+  MAX_VIDEOS,
+  ensureVideoMeta,
   getStorageMetadata,
-  loadCmsVideos,
-  materializeCmsVideos,
-  patchCmsVideoMetaAfterDraftChange,
-  replaceCmsVideosScope,
-  type CmsVideoDoc,
-} from "../cmsVideos";
+  loadVideos,
+  materializeVideos,
+  patchVideoMetaAfterDraftChange,
+  replaceVideosScope,
+  type VideoDoc,
+} from "../videos";
 import { deleteStorageIfUnreferenced } from "../mediaStorage";
 import { cmsNotFound, cmsPublishValidationFailed, cmsValidationError } from "../errors";
 import { requireCmsOwner } from "../lib/auth";
@@ -24,12 +24,12 @@ import {
   parseMuxPlaybackUrl,
   thumbnailUrlErrorMessage,
 } from "../videoUrls";
-import type { CmsVideoProvider } from "../videoUrls";
+import type { VideoProvider } from "../videoUrls";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
 
-const cmsVideoProviderArg = v.union(
+const videoProviderArg = v.union(
   v.literal("youtube"),
   v.literal("vimeo"),
   v.literal("mux"),
@@ -132,8 +132,8 @@ function normalizeDurationSec(raw?: number | null): number | undefined {
 
 function isAllowedVideoMime(
   contentType: string,
-): contentType is (typeof ALLOWED_CMS_VIDEO_MIME_TYPES)[number] {
-  return (ALLOWED_CMS_VIDEO_MIME_TYPES as readonly string[]).includes(
+): contentType is (typeof ALLOWED_VIDEO_MIME_TYPES)[number] {
+  return (ALLOWED_VIDEO_MIME_TYPES as readonly string[]).includes(
     contentType,
   );
 }
@@ -155,9 +155,9 @@ async function validateVideoUploadStorage(
       "videoStorageId",
     );
   }
-  if (storage.size > MAX_CMS_VIDEO_UPLOAD_BYTES) {
+  if (storage.size > MAX_VIDEO_UPLOAD_BYTES) {
     cmsValidationError(
-      `Video uploads must be ${Math.floor(MAX_CMS_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB or smaller.`,
+      `Video uploads must be ${Math.floor(MAX_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB or smaller.`,
       "videoStorageId",
     );
   }
@@ -166,9 +166,9 @@ async function validateVideoUploadStorage(
 async function getDraftVideoByStableId(
   ctx: MutationCtx,
   stableId: string,
-): Promise<CmsVideoDoc | null> {
+): Promise<VideoDoc | null> {
   return await ctx.db
-    .query("cmsVideos")
+    .query("videos")
     .withIndex("by_scope_and_stableId", (q) =>
       q.eq("scope", "draft").eq("stableId", stableId),
     )
@@ -176,7 +176,7 @@ async function getDraftVideoByStableId(
 }
 
 function resolveEmbedFields(args: {
-  provider: CmsVideoProvider;
+  provider: VideoProvider;
   externalId?: string | null;
   playbackUrl?: string | null;
 }): { externalId?: string; playbackUrl?: string } {
@@ -229,7 +229,7 @@ function resolveEmbedFields(args: {
 }
 
 async function buildVideoInsertPatch(args: {
-  provider: CmsVideoProvider;
+  provider: VideoProvider;
   title: string;
   description?: string;
   sortOrder: number;
@@ -239,7 +239,7 @@ async function buildVideoInsertPatch(args: {
   thumbnailStorageId?: Id<"_storage"> | null;
   thumbnailUrl?: string | null;
   durationSec?: number | null;
-}): Promise<Omit<CmsVideoDoc, "_id" | "_creationTime">> {
+}): Promise<Omit<VideoDoc, "_id" | "_creationTime">> {
   const title = normalizeTitle(args.title);
   const description = normalizeDescription(args.description);
   const thumbUrl = normalizeOptionalThumbnailUrl(args.thumbnailUrl);
@@ -294,7 +294,7 @@ async function buildVideoInsertPatch(args: {
 
 async function validateDraftForPublish(
   ctx: MutationCtx,
-  rows: CmsVideoDoc[],
+  rows: VideoDoc[],
 ): Promise<VideoPublishIssue[]> {
   const issues: VideoPublishIssue[] = [];
   const stableIds = new Set<string>();
@@ -333,10 +333,10 @@ async function validateDraftForPublish(
             path: `${base}.videoStorageId`,
             message: "Video blob must be MP4, WebM, or QuickTime.",
           });
-        } else if (storage.size > MAX_CMS_VIDEO_UPLOAD_BYTES) {
+        } else if (storage.size > MAX_VIDEO_UPLOAD_BYTES) {
           issues.push({
             path: `${base}.videoStorageId`,
-            message: `Video exceeds ${Math.floor(MAX_CMS_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB.`,
+            message: `Video exceeds ${Math.floor(MAX_VIDEO_UPLOAD_BYTES / (1024 * 1024))}MB.`,
           });
         }
       }
@@ -382,7 +382,7 @@ async function validateDraftForPublish(
 }
 
 async function resequenceDraftVideos(ctx: MutationCtx): Promise<void> {
-  const draft = await loadCmsVideos(ctx, "draft");
+  const draft = await loadVideos(ctx, "draft");
   draft.sort((a, b) => a.sortOrder - b.sortOrder);
   for (let i = 0; i < draft.length; i++) {
     const row = draft[i];
@@ -396,12 +396,12 @@ export const listDraftVideos = query({
   args: {},
   handler: async (ctx) => {
     await requireCmsOwner(ctx);
-    const rows = await loadCmsVideos(ctx, "draft");
+    const rows = await loadVideos(ctx, "draft");
     const meta = await ctx.db
-      .query("cmsVideoMeta")
+      .query("videoMeta")
       .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
       .unique();
-    const videos = await materializeCmsVideos(ctx, rows);
+    const videos = await materializeVideos(ctx, rows);
     return {
       videos,
       meta: meta
@@ -412,14 +412,14 @@ export const listDraftVideos = query({
             updatedAt: meta.updatedAt,
           }
         : null,
-      maxVideos: MAX_CMS_VIDEOS,
+      maxVideos: MAX_VIDEOS,
     };
   },
 });
 
 export const createDraftVideo = mutation({
   args: {
-    provider: cmsVideoProviderArg,
+    provider: videoProviderArg,
     title: v.string(),
     description: v.optional(v.string()),
     externalId: v.optional(v.string()),
@@ -431,12 +431,12 @@ export const createDraftVideo = mutation({
   },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
-    await ensureCmsVideoMeta(ctx);
+    await ensureVideoMeta(ctx);
 
-    const draft = await loadCmsVideos(ctx, "draft");
-    if (draft.length >= MAX_CMS_VIDEOS) {
+    const draft = await loadVideos(ctx, "draft");
+    if (draft.length >= MAX_VIDEOS) {
       cmsValidationError(
-        `Video list supports up to ${MAX_CMS_VIDEOS} items.`,
+        `Video list supports up to ${MAX_VIDEOS} items.`,
         "provider",
       );
     }
@@ -471,8 +471,8 @@ export const createDraftVideo = mutation({
       durationSec: args.durationSec,
     });
 
-    await ctx.db.insert("cmsVideos", patch);
-    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    await ctx.db.insert("videos", patch);
+    await patchVideoMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const, stableId: patch.stableId };
   },
 });
@@ -493,10 +493,10 @@ export const updateDraftVideo = mutation({
     const { updatedBy } = await requireCmsOwner(ctx);
     const row = await getDraftVideoByStableId(ctx, args.stableId);
     if (!row) {
-      cmsNotFound("cmsVideo", args.stableId);
+      cmsNotFound("video", args.stableId);
     }
 
-    const patch: Partial<CmsVideoDoc> = {};
+    const patch: Partial<VideoDoc> = {};
 
     if (args.title !== undefined) {
       patch.title = normalizeTitle(args.title);
@@ -595,7 +595,7 @@ export const updateDraftVideo = mutation({
       }
     }
 
-    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    await patchVideoMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const };
   },
 });
@@ -617,7 +617,7 @@ export const removeDraftVideo = mutation({
       await deleteStorageIfUnreferenced(ctx, row.thumbnailStorageId);
     }
     await resequenceDraftVideos(ctx);
-    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    await patchVideoMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const, removed: true };
   },
 });
@@ -626,7 +626,7 @@ export const reorderDraftVideos = mutation({
   args: { orderedStableIds: v.array(v.string()) },
   handler: async (ctx, args) => {
     const { updatedBy } = await requireCmsOwner(ctx);
-    const draft = await loadCmsVideos(ctx, "draft");
+    const draft = await loadVideos(ctx, "draft");
     if (args.orderedStableIds.length !== draft.length) {
       cmsValidationError(
         "Reorder payload must include every draft video exactly once.",
@@ -650,18 +650,18 @@ export const reorderDraftVideos = mutation({
       const stableId = args.orderedStableIds[i];
       const row = draft.find((r) => r.stableId === stableId);
       if (!row) {
-        cmsNotFound("cmsVideo", stableId);
+        cmsNotFound("video", stableId);
       }
       if (row.sortOrder !== i) {
         await ctx.db.patch(row._id, { sortOrder: i });
       }
     }
-    await patchCmsVideoMetaAfterDraftChange(ctx, updatedBy);
+    await patchVideoMetaAfterDraftChange(ctx, updatedBy);
     return { ok: true as const };
   },
 });
 
-export async function publishCmsVideosDraftCore(
+export async function publishVideosDraftCore(
   ctx: MutationCtx,
   args: { userId: string; updatedBy: string },
 ): Promise<{
@@ -671,16 +671,16 @@ export async function publishCmsVideosDraftCore(
   publishedBy: string;
 }> {
   const { userId, updatedBy } = args;
-  const draft = await loadCmsVideos(ctx, "draft");
+  const draft = await loadVideos(ctx, "draft");
   const issues = await validateDraftForPublish(ctx, draft);
   if (issues.length > 0) {
     cmsPublishValidationFailed("videos", "Publish validation failed.", issues);
   }
 
-  await replaceCmsVideosScope(ctx, "draft", "published");
+  await replaceVideosScope(ctx, "draft", "published");
 
   const now = Date.now();
-  const { id: metaId } = await ensureCmsVideoMeta(ctx);
+  const { id: metaId } = await ensureVideoMeta(ctx);
   await ctx.db.patch(metaId, {
     hasDraftChanges: false,
     publishedAt: now,
@@ -701,7 +701,7 @@ export const publishVideos = mutation({
   args: {},
   handler: async (ctx) => {
     const { userId, updatedBy } = await requireCmsOwner(ctx);
-    return await publishCmsVideosDraftCore(ctx, { userId, updatedBy });
+    return await publishVideosDraftCore(ctx, { userId, updatedBy });
   },
 });
 
@@ -709,11 +709,11 @@ export const discardDraftVideos = mutation({
   args: {},
   handler: async (ctx) => {
     const { updatedBy } = await requireCmsOwner(ctx);
-    await ensureCmsVideoMeta(ctx);
-    await replaceCmsVideosScope(ctx, "published", "draft");
+    await ensureVideoMeta(ctx);
+    await replaceVideosScope(ctx, "published", "draft");
 
     const now = Date.now();
-    const { id: metaId } = await ensureCmsVideoMeta(ctx);
+    const { id: metaId } = await ensureVideoMeta(ctx);
     await ctx.db.patch(metaId, {
       hasDraftChanges: false,
       updatedAt: now,

--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -581,9 +581,9 @@ export const updateDraftVideo = mutation({
 
     await ctx.db.patch(row._id, patch);
 
-    if (args.thumbnailStorageId !== undefined && args.thumbnailStorageId === null) {
+    if (args.thumbnailStorageId !== undefined) {
       const prev = row.thumbnailStorageId;
-      if (prev) {
+      if (prev && prev !== args.thumbnailStorageId) {
         await deleteStorageIfUnreferenced(ctx, prev);
       }
     }

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -276,6 +276,9 @@ export const listPendingDrafts = query({
       | "photos"
     > = [];
     for (const row of cmsRows) {
+      // Legacy deployments may still have a `cmsSections` row for photos; the
+      // active photo draft state lives in `galleryPhotoMeta`.
+      if (row.section === "photos") continue;
       if (row.hasDraftChanges) sections.push(row.section);
     }
     if (gearMeta?.hasDraftChanges) sections.push("gear");

--- a/convex/cmsPublishHelpers.test.ts
+++ b/convex/cmsPublishHelpers.test.ts
@@ -38,6 +38,17 @@ describe("rowsWithPublishableDraft", () => {
     expect(rowsWithPublishableDraft([])).toEqual([]);
   });
 
+  test("ignores legacy photos rows handled by galleryPhotoMeta", () => {
+    const rows = [
+      row({ section: "photos", hasDraftChanges: true }),
+      row({ section: "about", hasDraftChanges: true }),
+    ];
+
+    expect(rowsWithPublishableDraft(rows).map((r) => r.section)).toEqual([
+      "about",
+    ]);
+  });
+
   test("does not mutate the input", () => {
     const rows = [
       row({ section: "about", hasDraftChanges: true }),

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -540,8 +540,17 @@ export const publishSettingsSectionCore = publishSectionCore;
  */
 export function rowsWithPublishableDraft(
   rows: Doc<"cmsSections">[],
-): Doc<"cmsSections">[] {
-  return rows.filter((row) => row.hasDraftChanges === true);
+): Array<Doc<"cmsSections"> & { section: CmsSection }> {
+  return rows.filter(
+    (row): row is Doc<"cmsSections"> & { section: CmsSection } =>
+      row.hasDraftChanges === true && isPublishableCmsSection(row.section),
+  );
+}
+
+function isPublishableCmsSection(
+  section: Doc<"cmsSections">["section"],
+): section is CmsSection {
+  return section !== "photos";
 }
 
 /**
@@ -551,7 +560,7 @@ export function rowsWithPublishableDraft(
  */
 export async function collectAllPublishIssues(
   ctx: QueryCtx | MutationCtx,
-  targets: Doc<"cmsSections">[],
+  targets: Array<Doc<"cmsSections"> & { section: CmsSection }>,
 ): Promise<PublishIssue[]> {
   const issues: PublishIssue[] = [];
   for (const row of targets) {

--- a/convex/cmsVideos.ts
+++ b/convex/cmsVideos.ts
@@ -1,0 +1,220 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import {
+  deleteStorageIfUnreferenced,
+  getStorageMetadata,
+} from "./mediaStorage";
+
+const CMS_VIDEOS_QUERY_LIMIT = 64;
+
+export const MAX_CMS_VIDEOS = 24;
+
+/** Convex file upload — raw video only; no transcoding (INF-92). */
+export const ALLOWED_CMS_VIDEO_MIME_TYPES = [
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+] as const;
+
+export const MAX_CMS_VIDEO_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+export type CmsVideoScope = Doc<"cmsVideos">["scope"];
+export type CmsVideoDoc = Doc<"cmsVideos">;
+export type CmsVideoMetaDoc = Doc<"cmsVideoMeta">;
+
+function comparableVideo(row: CmsVideoDoc) {
+  return {
+    stableId: row.stableId,
+    title: row.title,
+    description: row.description ?? null,
+    sortOrder: row.sortOrder,
+    provider: row.provider,
+    externalId: row.externalId ?? null,
+    playbackUrl: row.playbackUrl ?? null,
+    videoStorageId: row.videoStorageId ?? null,
+    thumbnailStorageId: row.thumbnailStorageId ?? null,
+    thumbnailUrl: row.thumbnailUrl ?? null,
+    durationSec: row.durationSec ?? null,
+  };
+}
+
+export function cmsVideoDraftMatchesPublished(
+  draft: CmsVideoDoc[],
+  published: CmsVideoDoc[],
+): boolean {
+  if (draft.length !== published.length) {
+    return false;
+  }
+  for (let i = 0; i < draft.length; i++) {
+    if (
+      JSON.stringify(comparableVideo(draft[i])) !==
+      JSON.stringify(comparableVideo(published[i]))
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function loadCmsVideos(
+  ctx: QueryCtx | MutationCtx,
+  scope: CmsVideoScope,
+): Promise<CmsVideoDoc[]> {
+  return await ctx.db
+    .query("cmsVideos")
+    .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
+    .take(CMS_VIDEOS_QUERY_LIMIT);
+}
+
+export async function ensureCmsVideoMeta(
+  ctx: MutationCtx,
+): Promise<{ id: Id<"cmsVideoMeta">; row: CmsVideoMetaDoc }> {
+  const existing = await ctx.db
+    .query("cmsVideoMeta")
+    .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+    .unique();
+
+  if (existing) {
+    return { id: existing._id, row: existing };
+  }
+
+  const now = Date.now();
+  const id = await ctx.db.insert("cmsVideoMeta", {
+    singletonKey: "default",
+    hasDraftChanges: false,
+    publishedAt: null,
+    updatedAt: now,
+  });
+  const row = await ctx.db.get(id);
+  if (!row) {
+    throw new Error("Failed to create cmsVideoMeta row.");
+  }
+  return { id, row };
+}
+
+export async function replaceCmsVideosScope(
+  ctx: MutationCtx,
+  fromScope: CmsVideoScope,
+  toScope: CmsVideoScope,
+): Promise<void> {
+  const [source, target] = await Promise.all([
+    loadCmsVideos(ctx, fromScope),
+    loadCmsVideos(ctx, toScope),
+  ]);
+
+  const sourceStorageIds = new Set<Id<"_storage">>();
+  for (const row of source) {
+    if (row.videoStorageId) {
+      sourceStorageIds.add(row.videoStorageId);
+    }
+    if (row.thumbnailStorageId) {
+      sourceStorageIds.add(row.thumbnailStorageId);
+    }
+  }
+
+  const targetOnlyStorageIds: Id<"_storage">[] = [];
+  for (const row of target) {
+    if (row.videoStorageId && !sourceStorageIds.has(row.videoStorageId)) {
+      targetOnlyStorageIds.push(row.videoStorageId);
+    }
+    if (row.thumbnailStorageId && !sourceStorageIds.has(row.thumbnailStorageId)) {
+      targetOnlyStorageIds.push(row.thumbnailStorageId);
+    }
+  }
+  const uniqueOrphans = Array.from(new Set(targetOnlyStorageIds));
+
+  for (const row of target) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const row of source) {
+    await ctx.db.insert("cmsVideos", {
+      scope: toScope,
+      stableId: row.stableId,
+      title: row.title,
+      ...(row.description !== undefined ? { description: row.description } : {}),
+      sortOrder: row.sortOrder,
+      provider: row.provider,
+      ...(row.externalId !== undefined ? { externalId: row.externalId } : {}),
+      ...(row.playbackUrl !== undefined ? { playbackUrl: row.playbackUrl } : {}),
+      ...(row.videoStorageId !== undefined
+        ? { videoStorageId: row.videoStorageId }
+        : {}),
+      ...(row.thumbnailStorageId !== undefined
+        ? { thumbnailStorageId: row.thumbnailStorageId }
+        : {}),
+      ...(row.thumbnailUrl !== undefined ? { thumbnailUrl: row.thumbnailUrl } : {}),
+      ...(row.durationSec !== undefined ? { durationSec: row.durationSec } : {}),
+    });
+  }
+
+  for (const storageId of uniqueOrphans) {
+    await deleteStorageIfUnreferenced(ctx, storageId);
+  }
+}
+
+export async function patchCmsVideoMetaAfterDraftChange(
+  ctx: MutationCtx,
+  updatedBy: string,
+): Promise<void> {
+  const [draft, published, meta] = await Promise.all([
+    loadCmsVideos(ctx, "draft"),
+    loadCmsVideos(ctx, "published"),
+    ensureCmsVideoMeta(ctx),
+  ]);
+
+  await ctx.db.patch(meta.id, {
+    hasDraftChanges: !cmsVideoDraftMatchesPublished(draft, published),
+    updatedAt: Date.now(),
+    updatedBy,
+  });
+}
+
+export type MaterializedCmsVideo = {
+  stableId: string;
+  title: string;
+  description: string | null;
+  sortOrder: number;
+  provider: CmsVideoDoc["provider"];
+  externalId: string | null;
+  playbackUrl: string | null;
+  videoStorageId: Id<"_storage"> | null;
+  videoUrl: string | null;
+  thumbnailStorageId: Id<"_storage"> | null;
+  thumbnailUrl: string | null;
+  resolvedThumbnailUrl: string | null;
+  durationSec: number | null;
+};
+
+export async function materializeCmsVideos(
+  ctx: QueryCtx | MutationCtx,
+  rows: CmsVideoDoc[],
+): Promise<MaterializedCmsVideo[]> {
+  return await Promise.all(
+    rows.map(async (row) => {
+      const videoUrl = row.videoStorageId
+        ? await ctx.storage.getUrl(row.videoStorageId)
+        : null;
+      const thumbFromStorage = row.thumbnailStorageId
+        ? await ctx.storage.getUrl(row.thumbnailStorageId)
+        : null;
+      return {
+        stableId: row.stableId,
+        title: row.title,
+        description: row.description ?? null,
+        sortOrder: row.sortOrder,
+        provider: row.provider,
+        externalId: row.externalId ?? null,
+        playbackUrl: row.playbackUrl ?? null,
+        videoStorageId: row.videoStorageId ?? null,
+        videoUrl,
+        thumbnailStorageId: row.thumbnailStorageId ?? null,
+        thumbnailUrl: row.thumbnailUrl ?? null,
+        resolvedThumbnailUrl: thumbFromStorage ?? row.thumbnailUrl ?? null,
+        durationSec: row.durationSec ?? null,
+      };
+    }),
+  );
+}
+
+export { getStorageMetadata };

--- a/convex/mediaStorage.ts
+++ b/convex/mediaStorage.ts
@@ -40,11 +40,11 @@ export async function deleteStorageIfUnreferenced(
       )
       .take(1),
     ctx.db
-      .query("cmsVideos")
+      .query("videos")
       .withIndex("by_videoStorageId", (q) => q.eq("videoStorageId", storageId))
       .take(1),
     ctx.db
-      .query("cmsVideos")
+      .query("videos")
       .withIndex("by_thumbnailStorageId", (q) =>
         q.eq("thumbnailStorageId", storageId),
       )

--- a/convex/mediaStorage.ts
+++ b/convex/mediaStorage.ts
@@ -23,7 +23,8 @@ export async function deleteStorageIfUnreferenced(
   ctx: MutationCtx,
   storageId: Id<"_storage">,
 ): Promise<boolean> {
-  const [galleryRefs, audioRefs, audioArtRefs] = await Promise.all([
+  const [galleryRefs, audioRefs, audioArtRefs, videoRefs, videoThumbRefs] =
+    await Promise.all([
     ctx.db
       .query("galleryPhotos")
       .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
@@ -38,11 +39,23 @@ export async function deleteStorageIfUnreferenced(
         q.eq("albumThumbnailStorageId", storageId),
       )
       .take(1),
+    ctx.db
+      .query("cmsVideos")
+      .withIndex("by_videoStorageId", (q) => q.eq("videoStorageId", storageId))
+      .take(1),
+    ctx.db
+      .query("cmsVideos")
+      .withIndex("by_thumbnailStorageId", (q) =>
+        q.eq("thumbnailStorageId", storageId),
+      )
+      .take(1),
   ]);
   if (
     galleryRefs.length > 0 ||
     audioRefs.length > 0 ||
-    audioArtRefs.length > 0
+    audioArtRefs.length > 0 ||
+    videoRefs.length > 0 ||
+    videoThumbRefs.length > 0
   ) {
     return false;
   }

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -9,6 +9,7 @@ import { loadGearDocs, mapSortedGearTree } from "./gearTree";
 import type { Doc } from "./_generated/dataModel";
 import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
 import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
+import { loadCmsVideos, materializeCmsVideos } from "./cmsVideos";
 import { getSectionMetaRow, publishedIsEnabled } from "./cmsMeta";
 import {
   fallbackAmenitiesSnapshotFromTree,
@@ -114,6 +115,19 @@ export const getPublishedAudioTracks = query({
     const rows = await loadAudioTracks(ctx, "published");
     const tracks = await materializeAudioTracks(ctx, rows);
     return tracks.filter((t) => t.url !== null);
+  },
+});
+
+/**
+ * Published CMS videos (INF-92). Anonymous; `scope === "published"` only.
+ * Embed URLs are **not** stored — clients build YouTube/Vimeo/Mux iframes from
+ * `provider` + `externalId`; uploads expose `videoUrl` from storage.
+ */
+export const getPublishedCmsVideos = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await loadCmsVideos(ctx, "published");
+    return await materializeCmsVideos(ctx, rows);
   },
 });
 

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -9,7 +9,7 @@ import { loadGearDocs, mapSortedGearTree } from "./gearTree";
 import type { Doc } from "./_generated/dataModel";
 import { loadGalleryPhotos, materializeGalleryPhotos } from "./galleryPhotos";
 import { loadAudioTracks, materializeAudioTracks } from "./audioTracks";
-import { loadCmsVideos, materializeCmsVideos } from "./cmsVideos";
+import { loadVideos, materializeVideos } from "./videos";
 import { getSectionMetaRow, publishedIsEnabled } from "./cmsMeta";
 import {
   fallbackAmenitiesSnapshotFromTree,
@@ -123,11 +123,11 @@ export const getPublishedAudioTracks = query({
  * Embed URLs are **not** stored — clients build YouTube/Vimeo/Mux iframes from
  * `provider` + `externalId`; uploads expose `videoUrl` from storage.
  */
-export const getPublishedCmsVideos = query({
+export const getPublishedVideos = query({
   args: {},
   handler: async (ctx) => {
-    const rows = await loadCmsVideos(ctx, "published");
-    return await materializeCmsVideos(ctx, rows);
+    const rows = await loadVideos(ctx, "published");
+    return await materializeVideos(ctx, rows);
   },
 });
 

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -319,6 +319,40 @@ export const amenitiesNearbyItemRowValidator = {
 export const gearScopeValidator = cmsScopeValidator;
 
 /**
+ * CMS video embed/upload providers (INF-92). Only these values may drive embed UI;
+ * arbitrary iframe URLs are rejected — see `videoUrls.ts` and `docs/cms-videos.md`.
+ */
+export const cmsVideoProviderValidator = v.union(
+  v.literal("youtube"),
+  v.literal("vimeo"),
+  v.literal("mux"),
+  v.literal("upload"),
+);
+
+/**
+ * One row per studio video in draft or published scope (same pattern as `galleryPhotos`).
+ */
+export const cmsVideoRowValidator = {
+  scope: cmsScopeValidator,
+  stableId: v.string(),
+  title: v.string(),
+  description: v.optional(v.string()),
+  sortOrder: v.number(),
+  provider: cmsVideoProviderValidator,
+  /** Provider-native id when applicable (e.g. YouTube video id, Vimeo numeric id). */
+  externalId: v.optional(v.string()),
+  /**
+   * HTTPS playback URL when stored explicitly (e.g. Mux `.m3u8`); upload rows may omit and use `videoStorageId` only.
+   */
+  playbackUrl: v.optional(v.string()),
+  /** Uploaded video blob (`provider === "upload"`). */
+  videoStorageId: v.optional(v.id("_storage")),
+  thumbnailStorageId: v.optional(v.id("_storage")),
+  thumbnailUrl: v.optional(v.string()),
+  durationSec: v.optional(v.number()),
+} as const;
+
+/**
  * Item specs: markdown string or structured key/value pairs.
  */
 export const gearSpecsValidator = v.union(

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -322,7 +322,7 @@ export const gearScopeValidator = cmsScopeValidator;
  * CMS video embed/upload providers (INF-92). Only these values may drive embed UI;
  * arbitrary iframe URLs are rejected — see `videoUrls.ts` and `docs/cms-videos.md`.
  */
-export const cmsVideoProviderValidator = v.union(
+export const videoProviderValidator = v.union(
   v.literal("youtube"),
   v.literal("vimeo"),
   v.literal("mux"),
@@ -332,13 +332,13 @@ export const cmsVideoProviderValidator = v.union(
 /**
  * One row per studio video in draft or published scope (same pattern as `galleryPhotos`).
  */
-export const cmsVideoRowValidator = {
+export const videoRowValidator = {
   scope: cmsScopeValidator,
   stableId: v.string(),
   title: v.string(),
   description: v.optional(v.string()),
   sortOrder: v.number(),
-  provider: cmsVideoProviderValidator,
+  provider: videoProviderValidator,
   /** Provider-native id when applicable (e.g. YouTube video id, Vimeo numeric id). */
   externalId: v.optional(v.string()),
   /**

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -201,9 +201,10 @@ export const cmsSnapshotValidator = v.union(
 );
 
 /**
- * The set of sections tracked in `cmsSections`. `recordings` was added when
- * flags moved off the `marketingFeatureFlags` singleton and onto `cmsSections`
- * rows; its visibility is flag-only while audio content is stored separately.
+ * The set of active sections tracked in `cmsSections`. `recordings` was added
+ * when flags moved off the `marketingFeatureFlags` singleton and onto
+ * `cmsSections` rows; its visibility is flag-only while audio content is stored
+ * separately.
  */
 export const cmsSectionValidator = v.union(
   v.literal("settings"),
@@ -212,6 +213,19 @@ export const cmsSectionValidator = v.union(
   v.literal("recordings"),
   v.literal("faq"),
   v.literal("amenitiesNearby"),
+);
+
+/**
+ * Table-level validator for `cmsSections.section`.
+ *
+ * Some deployments have a stale `"photos"` row from before gallery publishing
+ * moved fully to `galleryPhotoMeta`. Keep the row schema tolerant so Convex can
+ * validate existing data, but keep public/admin function args on
+ * `cmsSectionValidator` so new CMS section mutations cannot target it.
+ */
+export const cmsSectionRowValidator = v.union(
+  cmsSectionValidator,
+  v.literal("photos"),
 );
 
 /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,6 +7,7 @@ import {
   amenitiesNearbyCopyRowValidator,
   amenitiesNearbyItemRowValidator,
   cmsSectionValidator,
+  cmsVideoRowValidator,
   faqCategoryRowValidator,
   faqQuestionRowValidator,
   gearScopeValidator,
@@ -208,4 +209,25 @@ export default defineSchema({
     .index("by_storageId", ["storageId"])
     .index("by_albumThumbnailStorageId", ["albumThumbnailStorageId"])
     .index("by_scope_and_createdAt", ["scope", "createdAt"]),
+
+  /**
+   * CMS videos (INF-92): draft/publish bookkeeping — mirrors `galleryPhotoMeta`.
+   */
+  cmsVideoMeta: defineTable({
+    singletonKey: v.literal("default"),
+    hasDraftChanges: v.boolean(),
+    publishedAt: v.union(v.number(), v.null()),
+    publishedBy: v.optional(v.string()),
+    updatedAt: v.number(),
+    updatedBy: v.optional(v.string()),
+  }).index("by_singleton", ["singletonKey"]),
+
+  /**
+   * CMS videos (INF-92): scoped rows — mirrors `galleryPhotos` / `audioTracks`.
+   */
+  cmsVideos: defineTable(cmsVideoRowValidator)
+    .index("by_scope_and_sort", ["scope", "sortOrder"])
+    .index("by_scope_and_stableId", ["scope", "stableId"])
+    .index("by_videoStorageId", ["videoStorageId"])
+    .index("by_thumbnailStorageId", ["thumbnailStorageId"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,7 +6,7 @@ import {
   aboutTeamMemberRowValidator,
   amenitiesNearbyCopyRowValidator,
   amenitiesNearbyItemRowValidator,
-  cmsSectionValidator,
+  cmsSectionRowValidator,
   videoRowValidator,
   faqCategoryRowValidator,
   faqQuestionRowValidator,
@@ -44,7 +44,7 @@ export default defineSchema({
   }),
 
   cmsSections: defineTable({
-    section: cmsSectionValidator,
+    section: cmsSectionRowValidator,
     /** Published visibility. Controls route/section visibility on the public site. */
     isEnabled: v.optional(v.boolean()),
     /** Draft override for `isEnabled`; cleared on publish / discard. */

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,7 +7,7 @@ import {
   amenitiesNearbyCopyRowValidator,
   amenitiesNearbyItemRowValidator,
   cmsSectionValidator,
-  cmsVideoRowValidator,
+  videoRowValidator,
   faqCategoryRowValidator,
   faqQuestionRowValidator,
   gearScopeValidator,
@@ -211,9 +211,9 @@ export default defineSchema({
     .index("by_scope_and_createdAt", ["scope", "createdAt"]),
 
   /**
-   * CMS videos (INF-92): draft/publish bookkeeping — mirrors `galleryPhotoMeta`.
+   * Video portfolio (INF-92): draft/publish bookkeeping — mirrors `galleryPhotoMeta`.
    */
-  cmsVideoMeta: defineTable({
+  videoMeta: defineTable({
     singletonKey: v.literal("default"),
     hasDraftChanges: v.boolean(),
     publishedAt: v.union(v.number(), v.null()),
@@ -223,9 +223,9 @@ export default defineSchema({
   }).index("by_singleton", ["singletonKey"]),
 
   /**
-   * CMS videos (INF-92): scoped rows — mirrors `galleryPhotos` / `audioTracks`.
+   * Video portfolio (INF-92): scoped rows — mirrors `galleryPhotos` / `audioTracks`.
    */
-  cmsVideos: defineTable(cmsVideoRowValidator)
+  videos: defineTable(videoRowValidator)
     .index("by_scope_and_sort", ["scope", "sortOrder"])
     .index("by_scope_and_stableId", ["scope", "stableId"])
     .index("by_videoStorageId", ["videoStorageId"])

--- a/convex/videoUrls.test.ts
+++ b/convex/videoUrls.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeExternalIdForProvider,
+  parseHttpsThumbnailUrl,
+} from "./videoUrls";
+
+describe("normalizeExternalIdForProvider", () => {
+  test("youtube: accepts bare id", () => {
+    expect(normalizeExternalIdForProvider("youtube", "dQw4w9WgXcQ")).toBe(
+      "dQw4w9WgXcQ",
+    );
+  });
+
+  test("youtube: parses watch URL", () => {
+    expect(
+      normalizeExternalIdForProvider(
+        "youtube",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ),
+    ).toBe("dQw4w9WgXcQ");
+  });
+
+  test("youtube: rejects invalid host", () => {
+    expect(() =>
+      normalizeExternalIdForProvider(
+        "youtube",
+        "https://evil.com/embed/dQw4w9WgXcQ",
+      ),
+    ).toThrow();
+  });
+
+  test("vimeo: parses numeric id from URL path", () => {
+    expect(
+      normalizeExternalIdForProvider("vimeo", "https://vimeo.com/123456789"),
+    ).toBe("123456789");
+  });
+
+  test("mux: accepts playback id string", () => {
+    expect(normalizeExternalIdForProvider("mux", "abc123xyz")).toBe(
+      "abc123xyz",
+    );
+  });
+});
+
+describe("parseHttpsThumbnailUrl", () => {
+  test("allows YouTube CDN", () => {
+    expect(
+      parseHttpsThumbnailUrl(
+        "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+      ).hostname,
+    ).toBe("i.ytimg.com");
+  });
+
+  test("rejects arbitrary host", () => {
+    expect(() =>
+      parseHttpsThumbnailUrl("https://evil.com/thumb.jpg"),
+    ).toThrow();
+  });
+});

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -26,7 +26,6 @@ const ALLOWED_THUMB_HOST_SUFFIXES = [
 const MUX_PLAYBACK_HOST_SUFFIXES = [
   "mux.com",
   "muxcdn.com",
-  "fastly.mux.com",
 ] as const;
 
 function normalizeHostname(raw: string): string | null {

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -1,0 +1,302 @@
+import type { Doc } from "./_generated/dataModel";
+
+export type CmsVideoProvider = Doc<"cmsVideos">["provider"];
+
+const MAX_URL_LENGTH = 2048;
+
+/** Hostnames allowed for user-supplied HTTPS URLs (thumbnail, Mux playback). */
+const ALLOWED_THUMB_HOST_SUFFIXES = [
+  "i.ytimg.com",
+  "img.youtube.com",
+  "i9.ytimg.com",
+  "yt3.ggpht.com",
+  "vumbnail.com",
+  "vumbnail.net",
+  "i.vimeocdn.com",
+  "images.unsplash.com",
+  "fastly.picsum.photos",
+  "picsum.photos",
+  "image.mux.com",
+  "stream.mux.com",
+  "cdn.mux.com",
+  "assets.mux.com",
+  "image-us-east-1.mux.com",
+] as const;
+
+const MUX_PLAYBACK_HOST_SUFFIXES = [
+  "mux.com",
+  "muxcdn.com",
+  "fastly.mux.com",
+] as const;
+
+function normalizeHostname(raw: string): string | null {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== "https:") {
+      return null;
+    }
+    return u.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function hostnameMatchesSuffix(hostname: string, suffix: string): boolean {
+  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+}
+
+function isAllowedThumbnailHost(hostname: string): boolean {
+  for (const suffix of ALLOWED_THUMB_HOST_SUFFIXES) {
+    if (hostnameMatchesSuffix(hostname, suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAllowedMuxPlaybackHost(hostname: string): boolean {
+  for (const suffix of MUX_PLAYBACK_HOST_SUFFIXES) {
+    if (hostnameMatchesSuffix(hostname, suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Validates an HTTPS URL for optional thumbnail / poster images.
+ * Rejects arbitrary hosts so embed security stays tied to known CDNs.
+ */
+export function parseHttpsThumbnailUrl(raw: string): {
+  url: string;
+  hostname: string;
+} {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new Error("EMPTY");
+  }
+  if (trimmed.length > MAX_URL_LENGTH) {
+    throw new Error("TOO_LONG");
+  }
+  const hostname = normalizeHostname(trimmed);
+  if (!hostname) {
+    throw new Error("INVALID");
+  }
+  if (!isAllowedThumbnailHost(hostname)) {
+    throw new Error("HOST_NOT_ALLOWED");
+  }
+  return { url: trimmed, hostname };
+}
+
+export function thumbnailUrlErrorMessage(fieldLabel: string): string {
+  return `Invalid ${fieldLabel}: use an HTTPS URL from an allowed image host (YouTube/Vimeo CDNs, Mux image CDN, or common image hosts).`;
+}
+
+/**
+ * Mux stream / asset playback URLs (HLS or image) — hostname allowlist.
+ */
+export function parseMuxPlaybackUrl(raw: string): {
+  url: string;
+  hostname: string;
+} {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new Error("EMPTY");
+  }
+  if (trimmed.length > MAX_URL_LENGTH) {
+    throw new Error("TOO_LONG");
+  }
+  const hostname = normalizeHostname(trimmed);
+  if (!hostname) {
+    throw new Error("INVALID");
+  }
+  if (!isAllowedMuxPlaybackHost(hostname)) {
+    throw new Error("HOST_NOT_ALLOWED");
+  }
+  return { url: trimmed, hostname };
+}
+
+export function muxPlaybackUrlErrorMessage(fieldLabel: string): string {
+  return `Invalid ${fieldLabel}: use an HTTPS URL on an allowed Mux host (e.g. stream.mux.com, image.mux.com, *.mux.com).`;
+}
+
+const YOUTUBE_ID_RE = /^[\w-]{11}$/;
+/** Vimeo numeric id or legacy hash-style id (short hex). */
+const VIMEO_ID_RE = /^\d{6,12}$/;
+const VIMEO_HASH_RE = /^[a-f0-9]{8,12}$/i;
+
+function stripOuterQuotes(raw: string): string {
+  const t = raw.trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+function urlWithHttpsFallback(raw: string): string {
+  const t = raw.trim();
+  if (/^https?:\/\//i.test(t)) {
+    return t;
+  }
+  if (t.startsWith("//")) {
+    return `https:${t}`;
+  }
+  return `https://${t}`;
+}
+
+/**
+ * Normalizes YouTube/Vimeo/Mux **externalId** from a pasted URL or bare id.
+ * Returns canonical external id for storage, or throws with a code for messaging.
+ */
+export function normalizeExternalIdForProvider(
+  provider: Exclude<CmsVideoProvider, "upload">,
+  raw: string,
+): string {
+  const input = stripOuterQuotes(raw).trim();
+  if (input.length === 0) {
+    throw new Error("EMPTY");
+  }
+  if (input.length > 512) {
+    throw new Error("TOO_LONG");
+  }
+
+  if (provider === "youtube") {
+    if (YOUTUBE_ID_RE.test(input)) {
+      return input;
+    }
+    try {
+      const u = new URL(urlWithHttpsFallback(input));
+      const host = u.hostname.toLowerCase();
+      if (
+        !hostnameMatchesSuffix(host, "youtube.com") &&
+        !hostnameMatchesSuffix(host, "youtube-nocookie.com") &&
+        host !== "youtu.be"
+      ) {
+        throw new Error("INVALID_YOUTUBE_HOST");
+      }
+      if (host === "youtu.be") {
+        const id = u.pathname.replace(/^\//, "").split("/")[0] ?? "";
+        if (!YOUTUBE_ID_RE.test(id)) {
+          throw new Error("INVALID_YOUTUBE_ID");
+        }
+        return id;
+      }
+      const pathParts = u.pathname.split("/").filter(Boolean);
+      if (pathParts[0] === "shorts" && pathParts[1]) {
+        const id = pathParts[1];
+        if (!YOUTUBE_ID_RE.test(id)) {
+          throw new Error("INVALID_YOUTUBE_ID");
+        }
+        return id;
+      }
+      const v = u.searchParams.get("v");
+      if (v && YOUTUBE_ID_RE.test(v)) {
+        return v;
+      }
+      if (pathParts[0] === "embed" && pathParts[1]) {
+        const id = pathParts[1];
+        if (!YOUTUBE_ID_RE.test(id)) {
+          throw new Error("INVALID_YOUTUBE_ID");
+        }
+        return id;
+      }
+      throw new Error("INVALID_YOUTUBE_ID");
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("INVALID")) {
+        throw e;
+      }
+      throw new Error("INVALID_YOUTUBE_URL");
+    }
+  }
+
+  if (provider === "vimeo") {
+    if (VIMEO_ID_RE.test(input) || VIMEO_HASH_RE.test(input)) {
+      return input;
+    }
+    try {
+      const u = new URL(urlWithHttpsFallback(input));
+      const host = u.hostname.toLowerCase();
+      if (!hostnameMatchesSuffix(host, "vimeo.com")) {
+        throw new Error("INVALID_VIMEO_HOST");
+      }
+      const parts = u.pathname.split("/").filter(Boolean);
+      const videoIdx = parts.indexOf("video");
+      const idCandidate =
+        videoIdx >= 0 && parts[videoIdx + 1]
+          ? parts[videoIdx + 1]
+          : parts[0];
+      if (
+        !idCandidate ||
+        (!VIMEO_ID_RE.test(idCandidate) && !VIMEO_HASH_RE.test(idCandidate))
+      ) {
+        throw new Error("INVALID_VIMEO_ID");
+      }
+      return idCandidate;
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("INVALID")) {
+        throw e;
+      }
+      throw new Error("INVALID_VIMEO_URL");
+    }
+  }
+
+  // mux — store playback id or asset id string (admin UI builds iframe/player URL client-side)
+  if (provider === "mux") {
+    if (/^[a-zA-Z0-9_-]+$/.test(input) && input.length >= 4 && input.length <= 128) {
+      return input;
+    }
+    try {
+      const u = new URL(urlWithHttpsFallback(input));
+      const host = u.hostname.toLowerCase();
+      if (!isAllowedMuxPlaybackHost(host)) {
+        throw new Error("INVALID_MUX_HOST");
+      }
+      const path = u.pathname;
+      const match = path.match(/\/(?:videos|manifest)\/([a-zA-Z0-9_-]+)/);
+      if (match?.[1]) {
+        return match[1];
+      }
+      const last = path.split("/").filter(Boolean).pop();
+      if (last && /^[a-zA-Z0-9_-]+$/.test(last)) {
+        return last;
+      }
+      throw new Error("INVALID_MUX_ID");
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("INVALID")) {
+        throw e;
+      }
+      throw new Error("INVALID_MUX_URL");
+    }
+  }
+
+  throw new Error("UNSUPPORTED_PROVIDER");
+}
+
+export function externalIdValidationMessage(
+  provider: Exclude<CmsVideoProvider, "upload">,
+  code: string,
+): string {
+  switch (code) {
+    case "EMPTY":
+      return "Video id or URL is required for this provider.";
+    case "TOO_LONG":
+      return "Video id or URL is too long.";
+    case "INVALID_YOUTUBE_HOST":
+    case "INVALID_YOUTUBE_URL":
+    case "INVALID_YOUTUBE_ID":
+      return "Invalid YouTube URL or video id. Paste a watch URL, youtu.be link, or the 11-character video id.";
+    case "INVALID_VIMEO_HOST":
+    case "INVALID_VIMEO_URL":
+    case "INVALID_VIMEO_ID":
+      return "Invalid Vimeo URL or video id. Paste a vimeo.com/video/… link or the numeric video id.";
+    case "INVALID_MUX_HOST":
+    case "INVALID_MUX_URL":
+    case "INVALID_MUX_ID":
+      return "Invalid Mux URL or playback id. Use a stream URL on mux.com or paste the playback/asset id.";
+    default:
+      return `Invalid ${provider} reference.`;
+  }
+}

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -1,6 +1,6 @@
 import type { Doc } from "./_generated/dataModel";
 
-export type CmsVideoProvider = Doc<"cmsVideos">["provider"];
+export type VideoProvider = Doc<"videos">["provider"];
 
 const MAX_URL_LENGTH = 2048;
 
@@ -152,7 +152,7 @@ function urlWithHttpsFallback(raw: string): string {
  * Returns canonical external id for storage, or throws with a code for messaging.
  */
 export function normalizeExternalIdForProvider(
-  provider: Exclude<CmsVideoProvider, "upload">,
+  provider: Exclude<VideoProvider, "upload">,
   raw: string,
 ): string {
   const input = stripOuterQuotes(raw).trim();
@@ -284,7 +284,7 @@ export function normalizeExternalIdForProvider(
 }
 
 export function externalIdValidationMessage(
-  provider: Exclude<CmsVideoProvider, "upload">,
+  provider: Exclude<VideoProvider, "upload">,
   code: string,
 ): string {
   switch (code) {

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -223,7 +223,10 @@ export function normalizeExternalIdForProvider(
         throw new Error("INVALID_VIMEO_HOST");
       }
       const parts = u.pathname.split("/").filter(Boolean);
-      const videoIdx = parts.indexOf("video");
+      let videoIdx = parts.indexOf("video");
+      if (videoIdx < 0) {
+        videoIdx = parts.indexOf("videos");
+      }
       const idCandidate =
         videoIdx >= 0 && parts[videoIdx + 1]
           ? parts[videoIdx + 1]

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -260,8 +260,16 @@ export function normalizeExternalIdForProvider(
         return match[1];
       }
       const last = path.split("/").filter(Boolean).pop();
-      if (last && /^[a-zA-Z0-9_-]+$/.test(last)) {
-        return last;
+      let segment = last ?? "";
+      const dot = segment.lastIndexOf(".");
+      if (dot > 0) {
+        const ext = segment.slice(dot + 1).toLowerCase();
+        if (ext === "m3u8" || ext === "mp4") {
+          segment = segment.slice(0, dot);
+        }
+      }
+      if (segment && /^[a-zA-Z0-9_-]+$/.test(segment)) {
+        return segment;
       }
       throw new Error("INVALID_MUX_ID");
     } catch (e) {

--- a/convex/videoUrls.ts
+++ b/convex/videoUrls.ts
@@ -122,7 +122,7 @@ export function muxPlaybackUrlErrorMessage(fieldLabel: string): string {
 
 const YOUTUBE_ID_RE = /^[\w-]{11}$/;
 /** Vimeo numeric id or legacy hash-style id (short hex). */
-const VIMEO_ID_RE = /^\d{6,12}$/;
+const VIMEO_ID_RE = /^\d{1,12}$/;
 const VIMEO_HASH_RE = /^[a-f0-9]{8,12}$/i;
 
 function stripOuterQuotes(raw: string): string {

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -38,7 +38,7 @@ function comparableVideo(row: VideoDoc) {
   };
 }
 
-export function videoDraftMatchesPublished(
+function videoDraftMatchesPublished(
   draft: VideoDoc[],
   published: VideoDoc[],
 ): boolean {

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -5,24 +5,24 @@ import {
   getStorageMetadata,
 } from "./mediaStorage";
 
-const CMS_VIDEOS_QUERY_LIMIT = 64;
+const VIDEO_QUERY_LIMIT = 64;
 
-export const MAX_CMS_VIDEOS = 24;
+export const MAX_VIDEOS = 24;
 
 /** Convex file upload — raw video only; no transcoding (INF-92). */
-export const ALLOWED_CMS_VIDEO_MIME_TYPES = [
+export const ALLOWED_VIDEO_MIME_TYPES = [
   "video/mp4",
   "video/webm",
   "video/quicktime",
 ] as const;
 
-export const MAX_CMS_VIDEO_UPLOAD_BYTES = 100 * 1024 * 1024;
+export const MAX_VIDEO_UPLOAD_BYTES = 100 * 1024 * 1024;
 
-export type CmsVideoScope = Doc<"cmsVideos">["scope"];
-export type CmsVideoDoc = Doc<"cmsVideos">;
-export type CmsVideoMetaDoc = Doc<"cmsVideoMeta">;
+export type VideoScope = Doc<"videos">["scope"];
+export type VideoDoc = Doc<"videos">;
+export type VideoMetaDoc = Doc<"videoMeta">;
 
-function comparableVideo(row: CmsVideoDoc) {
+function comparableVideo(row: VideoDoc) {
   return {
     stableId: row.stableId,
     title: row.title,
@@ -38,9 +38,9 @@ function comparableVideo(row: CmsVideoDoc) {
   };
 }
 
-export function cmsVideoDraftMatchesPublished(
-  draft: CmsVideoDoc[],
-  published: CmsVideoDoc[],
+export function videoDraftMatchesPublished(
+  draft: VideoDoc[],
+  published: VideoDoc[],
 ): boolean {
   if (draft.length !== published.length) {
     return false;
@@ -56,21 +56,21 @@ export function cmsVideoDraftMatchesPublished(
   return true;
 }
 
-export async function loadCmsVideos(
+export async function loadVideos(
   ctx: QueryCtx | MutationCtx,
-  scope: CmsVideoScope,
-): Promise<CmsVideoDoc[]> {
+  scope: VideoScope,
+): Promise<VideoDoc[]> {
   return await ctx.db
-    .query("cmsVideos")
+    .query("videos")
     .withIndex("by_scope_and_sort", (q) => q.eq("scope", scope))
-    .take(CMS_VIDEOS_QUERY_LIMIT);
+    .take(VIDEO_QUERY_LIMIT);
 }
 
-export async function ensureCmsVideoMeta(
+export async function ensureVideoMeta(
   ctx: MutationCtx,
-): Promise<{ id: Id<"cmsVideoMeta">; row: CmsVideoMetaDoc }> {
+): Promise<{ id: Id<"videoMeta">; row: VideoMetaDoc }> {
   const existing = await ctx.db
-    .query("cmsVideoMeta")
+    .query("videoMeta")
     .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
     .unique();
 
@@ -79,7 +79,7 @@ export async function ensureCmsVideoMeta(
   }
 
   const now = Date.now();
-  const id = await ctx.db.insert("cmsVideoMeta", {
+  const id = await ctx.db.insert("videoMeta", {
     singletonKey: "default",
     hasDraftChanges: false,
     publishedAt: null,
@@ -87,19 +87,19 @@ export async function ensureCmsVideoMeta(
   });
   const row = await ctx.db.get(id);
   if (!row) {
-    throw new Error("Failed to create cmsVideoMeta row.");
+    throw new Error("Failed to create videoMeta row.");
   }
   return { id, row };
 }
 
-export async function replaceCmsVideosScope(
+export async function replaceVideosScope(
   ctx: MutationCtx,
-  fromScope: CmsVideoScope,
-  toScope: CmsVideoScope,
+  fromScope: VideoScope,
+  toScope: VideoScope,
 ): Promise<void> {
   const [source, target] = await Promise.all([
-    loadCmsVideos(ctx, fromScope),
-    loadCmsVideos(ctx, toScope),
+    loadVideos(ctx, fromScope),
+    loadVideos(ctx, toScope),
   ]);
 
   const sourceStorageIds = new Set<Id<"_storage">>();
@@ -128,7 +128,7 @@ export async function replaceCmsVideosScope(
   }
 
   for (const row of source) {
-    await ctx.db.insert("cmsVideos", {
+    await ctx.db.insert("videos", {
       scope: toScope,
       stableId: row.stableId,
       title: row.title,
@@ -153,29 +153,29 @@ export async function replaceCmsVideosScope(
   }
 }
 
-export async function patchCmsVideoMetaAfterDraftChange(
+export async function patchVideoMetaAfterDraftChange(
   ctx: MutationCtx,
   updatedBy: string,
 ): Promise<void> {
   const [draft, published, meta] = await Promise.all([
-    loadCmsVideos(ctx, "draft"),
-    loadCmsVideos(ctx, "published"),
-    ensureCmsVideoMeta(ctx),
+    loadVideos(ctx, "draft"),
+    loadVideos(ctx, "published"),
+    ensureVideoMeta(ctx),
   ]);
 
   await ctx.db.patch(meta.id, {
-    hasDraftChanges: !cmsVideoDraftMatchesPublished(draft, published),
+    hasDraftChanges: !videoDraftMatchesPublished(draft, published),
     updatedAt: Date.now(),
     updatedBy,
   });
 }
 
-export type MaterializedCmsVideo = {
+export type MaterializedVideo = {
   stableId: string;
   title: string;
   description: string | null;
   sortOrder: number;
-  provider: CmsVideoDoc["provider"];
+  provider: VideoDoc["provider"];
   externalId: string | null;
   playbackUrl: string | null;
   videoStorageId: Id<"_storage"> | null;
@@ -186,10 +186,10 @@ export type MaterializedCmsVideo = {
   durationSec: number | null;
 };
 
-export async function materializeCmsVideos(
+export async function materializeVideos(
   ctx: QueryCtx | MutationCtx,
-  rows: CmsVideoDoc[],
-): Promise<MaterializedCmsVideo[]> {
+  rows: VideoDoc[],
+): Promise<MaterializedVideo[]> {
   return await Promise.all(
     rows.map(async (row) => {
       const videoUrl = row.videoStorageId

--- a/docs/cms-videos.md
+++ b/docs/cms-videos.md
@@ -9,7 +9,7 @@
 
 This is **one** mental model: each row is either an embed reference + metadata or an uploaded blob + metadata. There is no parallel “paste any iframe HTML” flow.
 
-## Schema (`cmsVideos`)
+## Schema (`videos` + `videoMeta`)
 
 | Field | Purpose |
 | ----- | ------- |
@@ -25,12 +25,12 @@ This is **one** mental model: each row is either an embed reference + metadata o
 | `thumbnailUrl` | Optional HTTPS poster URL (hostname allowlist — CDNs only, not arbitrary domains). |
 | `durationSec` | Optional length in seconds. |
 
-Bookkeeping: **`cmsVideoMeta`** mirrors **`galleryPhotoMeta`** (`hasDraftChanges`, `publishedAt`, etc.).
+Bookkeeping: **`videoMeta`** mirrors **`galleryPhotoMeta`** (`hasDraftChanges`, `publishedAt`, etc.). Rows live in the **`videos`** table.
 
 ## Constraints (upload)
 
 - **Max videos:** 24 rows (draft list cap).
-- **Max upload size:** 100MB (`MAX_CMS_VIDEO_UPLOAD_BYTES`).
+- **Max upload size:** 100MB (`MAX_VIDEO_UPLOAD_BYTES` in `convex/videos.ts`).
 - **Allowed MIME types:** `video/mp4`, `video/webm`, `video/quicktime`.
 - **Transcoding:** out of scope — owners should upload browser-playable files or use YouTube/Vimeo/Mux embeds.
 
@@ -44,11 +44,11 @@ Bookkeeping: **`cmsVideoMeta`** mirrors **`galleryPhotoMeta`** (`hasDraftChanges
 | Surface | Functions |
 | ------- | --------- |
 | **Admin** | `admin/videos`: `listDraftVideos`, `createDraftVideo`, `updateDraftVideo`, `removeDraftVideo`, `reorderDraftVideos`, `publishVideos`, `discardDraftVideos` |
-| **Public** | `public.getPublishedCmsVideos` — published scope only, materialized URLs for storage-backed assets |
+| **Public** | `public.getPublishedVideos` — published scope only, materialized URLs for storage-backed assets |
 
 Invalid URLs and ids fail with **`ConvexError`** payload `code: "VALIDATION_ERROR"` and a **clear message** (e.g. invalid YouTube URL, thumbnail host not allowed).
 
 ## Follow-ups
 
 - Wire the Next.js admin UI to these mutations.
-- Optional: add `cmsVideos` to `publishSite` if site-wide publish should include videos in one action.
+- Optional: add `videos` to `publishSite` if site-wide publish should include videos in one action.

--- a/docs/cms-videos.md
+++ b/docs/cms-videos.md
@@ -1,0 +1,54 @@
+# CMS videos (INF-92)
+
+## Decision (v1)
+
+**Primary strategy: structured embeds + optional Convex upload.**
+
+- **Default path:** store **`provider`** (`youtube` | `vimeo` | `mux`) and a canonical **`externalId`** (or parsed from a pasted watch URL). The **public site never assigns arbitrary iframe `src` strings** — it builds player/embed URLs from allowlisted provider patterns (same idea as validating on save).
+- **Secondary path:** **`provider: upload`** — raw video file in **Convex file storage** (`videoStorageId`). Used when an embed is not acceptable or for short clips. **No transcoding** in v1; clients play the file URL directly (MP4/WebM) where supported.
+
+This is **one** mental model: each row is either an embed reference + metadata or an uploaded blob + metadata. There is no parallel “paste any iframe HTML” flow.
+
+## Schema (`cmsVideos`)
+
+| Field | Purpose |
+| ----- | ------- |
+| `scope` | `draft` \| `published` (same as gallery photos / audio). |
+| `stableId` | Client-stable id for edits. |
+| `title`, `description` | Display copy. |
+| `sortOrder` | Manual ordering. |
+| `provider` | `youtube` \| `vimeo` \| `mux` \| `upload`. |
+| `externalId` | Provider-native id (YouTube 11-char id, Vimeo id, Mux playback id), **after** URL normalization. |
+| `playbackUrl` | Optional **Mux** HTTPS playback URL (hostname allowlist); can accompany `externalId`. |
+| `videoStorageId` | Convex `_storage` id when `provider === "upload"`. |
+| `thumbnailStorageId` | Optional poster image in Convex storage. |
+| `thumbnailUrl` | Optional HTTPS poster URL (hostname allowlist — CDNs only, not arbitrary domains). |
+| `durationSec` | Optional length in seconds. |
+
+Bookkeeping: **`cmsVideoMeta`** mirrors **`galleryPhotoMeta`** (`hasDraftChanges`, `publishedAt`, etc.).
+
+## Constraints (upload)
+
+- **Max videos:** 24 rows (draft list cap).
+- **Max upload size:** 100MB (`MAX_CMS_VIDEO_UPLOAD_BYTES`).
+- **Allowed MIME types:** `video/mp4`, `video/webm`, `video/quicktime`.
+- **Transcoding:** out of scope — owners should upload browser-playable files or use YouTube/Vimeo/Mux embeds.
+
+## Security
+
+- **Embeds:** only **`provider`** values in the enum are valid; **`externalId`** is validated per provider (YouTube/Vimeo URL parsing, Mux id/URL extraction). No user-supplied iframe URL for YouTube/Vimeo.
+- **HTTPS URLs** (thumbnails, optional Mux playback): validated with **hostname allowlists** in `convex/videoUrls.ts` so arbitrary attacker-controlled origins cannot be stored.
+
+## Convex API
+
+| Surface | Functions |
+| ------- | --------- |
+| **Admin** | `admin/videos`: `listDraftVideos`, `createDraftVideo`, `updateDraftVideo`, `removeDraftVideo`, `reorderDraftVideos`, `publishVideos`, `discardDraftVideos` |
+| **Public** | `public.getPublishedCmsVideos` — published scope only, materialized URLs for storage-backed assets |
+
+Invalid URLs and ids fail with **`ConvexError`** payload `code: "VALIDATION_ERROR"` and a **clear message** (e.g. invalid YouTube URL, thumbnail host not allowed).
+
+## Follow-ups
+
+- Wire the Next.js admin UI to these mutations.
+- Optional: add `cmsVideos` to `publishSite` if site-wide publish should include videos in one action.

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -2,56 +2,80 @@ import Image from "next/image";
 
 /**
  * Minimal editorial footer for the marketing site. Sits below the contact
- * section as a quiet sign-off — thin sand rule, a small logo, and a
- * carefully-set address.
+ * section as a quiet sign-off — a primary row of identity + contact,
+ * followed by a hairline sand rule and a quiet credits line.
  */
 export function SiteFooter() {
   const year = new Date().getFullYear();
 
   return (
     <footer className="relative bg-washed-black border-t border-sand/10">
-      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-12 px-6 py-20 md:grid-cols-[auto_1fr_auto] md:items-end md:gap-16 md:px-12">
-        <div className="flex items-center">
-          <Image
-            src="/Logos/Wordmark/LLS_Logo_Text_Sand.png"
-            alt="Lula Lake Sound"
-            width={1024}
-            height={135}
-            className="h-10 w-auto max-w-[min(100%,320px)] object-contain object-left opacity-90"
-          />
+      <div className="mx-auto max-w-6xl px-6 py-20 md:px-12">
+        {/* Primary row: wordmark / tagline / contact — vertically centered
+         * so the three blocks read at a single editorial baseline regardless
+         * of the wordmark's larger optical weight. */}
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-[auto_1fr_auto] md:items-center md:gap-16">
+          <div className="flex items-center">
+            <Image
+              src="/Logos/Wordmark/LLS_Logo_Text_Sand.png"
+              alt="Lula Lake Sound"
+              width={1024}
+              height={135}
+              className="h-10 w-auto max-w-[min(100%,320px)] object-contain object-left opacity-90"
+            />
+          </div>
+
+          <div className="md:px-10 md:text-center">
+            <p className="body-text-small text-ivory/55">
+              A natural creative refuge on Lookout Mountain.
+            </p>
+            <p className="body-text-small mt-2 text-ivory/40">
+              Chattanooga, Tennessee
+            </p>
+          </div>
+
+          {/* Email paired with the Sage graphic mark — the pairing gives the
+           * right column the same visual weight as the wordmark on the left,
+           * so the row balances symmetrically around the centered tagline. */}
+          <div className="flex items-center gap-5">
+            <a
+              href="mailto:info@lulalakesound.com"
+              className="body-text-small text-sand transition-colors duration-500 hover:text-warm-white"
+            >
+              info@lulalakesound.com
+            </a>
+            {/* Graphic LLS mark in Sage — quiet secondary identity per the
+             * brand guide's §2.2 guidance for repeated brand moments. Sage
+             * holds its form on the Washed Black footer ground where Pond
+             * disappears. */}
+            <Image
+              src="/Logos/Graphic/LLS_Logo_Graphic_Sage.png"
+              alt=""
+              width={200}
+              height={200}
+              aria-hidden
+              className="h-8 w-auto opacity-75"
+            />
+          </div>
         </div>
 
-        <div className="md:px-10 md:text-center">
-          <p className="body-text-small text-ivory/55">
-            A natural creative refuge on Lookout Mountain.
-          </p>
-          <p className="body-text-small mt-2 text-ivory/40">
-            Chattanooga, Tennessee
-          </p>
-        </div>
-
-        <div className="flex flex-col items-start gap-3 md:items-end">
-          <a
-            href="mailto:info@lulalakesound.com"
-            className="body-text-small text-sand transition-colors duration-500 hover:text-warm-white"
-          >
-            info@lulalakesound.com
-          </a>
+        {/* Credits sub-row — copyright on the left, partner credit on the
+         * right, divided from the primary row by a hairline sand rule. */}
+        <div className="mt-14 flex flex-col items-start gap-2 border-t border-sand/10 pt-6 md:mt-16 md:flex-row md:items-center md:justify-between md:pt-6">
           <p className="label-text text-[10px] text-ivory/30">
             &copy; {year} Lula Lake Sound
           </p>
-          {/* Graphic LLS mark in Sage — quiet secondary identity per the
-           * brand guide's §2.2 guidance for repeated brand moments. Sage
-           * holds its form on the Washed Black footer ground where Pond
-           * disappears. */}
-          <Image
-            src="/Logos/Graphic/LLS_Logo_Graphic_Sage.png"
-            alt=""
-            width={200}
-            height={200}
-            aria-hidden
-            className="mt-3 h-8 w-auto opacity-75"
-          />
+          <p className="label-text text-[10px] text-ivory/30">
+            Powered by{" "}
+            <a
+              href="https://www.inferencepartners.ai/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-ivory/50 transition-colors duration-500 hover:text-sand"
+            >
+              Inference Partners
+            </a>
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Exported video draft publish validation as `validateDraftVideosForPublish` (avoids name clash with `validateDraftForPublish` in `photos.ts`).
- Integrated videos into `publishSite`: reads `videoMeta.hasDraftChanges`, runs the same validation as `publishVideosDraftCore`, calls `publishVideosDraftCore` when pending, and includes `videos` in the mutation return when published.
- Aligned validation issue paths with audio (`items[i]` under `videos.*`) so site-wide paths read `videos.items[0].title` instead of `videos.videos[0].title`.

## Testing

- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-92](https://linear.app/only-football-fans/issue/INF-92/lls-video-metadata-model-hosting-strategy)

<div><a href="https://cursor.com/agents/bc-66c24a53-7f90-4ab6-ac02-37f2853d082b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66c24a53-7f90-4ab6-ac02-37f2853d082b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

