### PR TITLE
feat(inf-93): admin videos editor with embed preview + draft/publish

### DIFF
--- a/convex/admin/videos.ts
+++ b/convex/admin/videos.ts
@@ -412,8 +412,27 @@ export const listDraftVideos = query({
             updatedAt: meta.updatedAt,
           }
         : null,
+      limits: {
+        maxVideos: MAX_VIDEOS,
+        maxUploadBytes: MAX_VIDEO_UPLOAD_BYTES,
+        acceptedMimeTypes: [...ALLOWED_VIDEO_MIME_TYPES],
+      },
+      /** @deprecated — read `limits.maxVideos` instead. */
       maxVideos: MAX_VIDEOS,
     };
+  },
+});
+
+/**
+ * Owner-only short-lived upload URL for the `provider: "upload"` flow.
+ * The admin client `POST`s the raw video blob here, then calls
+ * `createDraftVideo` / `updateDraftVideo` with the returned `storageId`.
+ */
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+    return { uploadUrl: await ctx.storage.generateUploadUrl() };
   },
 });
 

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -256,13 +256,14 @@ export const listPendingDrafts = query({
           | "amenitiesNearby"
           | "gear"
           | "photos"
+          | "videos"
         >,
       };
     }
 
     await requireCmsOwner(ctx);
 
-    const [cmsRows, gearMeta, galleryMeta] = await Promise.all([
+    const [cmsRows, gearMeta, galleryMeta, videoMeta] = await Promise.all([
       ctx.db.query("cmsSections").collect(),
       ctx.db
         .query("gearMeta")
@@ -270,6 +271,10 @@ export const listPendingDrafts = query({
         .unique(),
       ctx.db
         .query("galleryPhotoMeta")
+        .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
+        .unique(),
+      ctx.db
+        .query("videoMeta")
         .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))
         .unique(),
     ]);
@@ -283,6 +288,7 @@ export const listPendingDrafts = query({
       | "amenitiesNearby"
       | "gear"
       | "photos"
+      | "videos"
     > = [];
     for (const row of cmsRows) {
       // Legacy deployments may still have a `cmsSections` row for photos; the
@@ -292,6 +298,7 @@ export const listPendingDrafts = query({
     }
     if (gearMeta?.hasDraftChanges) sections.push("gear");
     if (galleryMeta?.hasDraftChanges) sections.push("photos");
+    if (videoMeta?.hasDraftChanges) sections.push("videos");
 
     return { sections: [...new Set(sections)] };
   },

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -19,7 +19,7 @@ import {
   type ChangeEvent,
   type DragEvent as ReactDragEvent,
 } from "react";
-import { Effect, pipe } from "effect";
+import { Effect } from "effect";
 import { toast } from "sonner";
 import {
   ArrowDown,
@@ -47,7 +47,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
-import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import {
+  convexMutationEffect,
+  sequentialEffects,
+  type CmsAppError,
+} from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import {
   mergeAutosaveStatus,
@@ -288,19 +292,6 @@ function httpsImagePreviewUrl(raw: string): string | null {
 
 function isAcceptedAlbumArtFile(file: File): boolean {
   return ["image/jpeg", "image/png", "image/webp"].includes(file.type);
-}
-
-function sequentialEffects(
-  effects: Array<Effect.Effect<unknown, CmsAppError>>,
-): Effect.Effect<void, CmsAppError> {
-  return effects.reduce(
-    (acc, effect) =>
-      pipe(
-        acc,
-        Effect.flatMap(() => effect),
-      ),
-    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
-  );
 }
 
 async function readAudioDurationSec(file: File): Promise<number | null> {

--- a/src/app/admin/gear/gear-editor.tsx
+++ b/src/app/admin/gear/gear-editor.tsx
@@ -16,7 +16,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { Effect, pipe } from "effect";
+import { Effect } from "effect";
 import { toast } from "sonner";
 import {
   ArrowDown,
@@ -48,7 +48,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
-import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import {
+  convexMutationEffect,
+  sequentialEffects,
+  type CmsAppError,
+} from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 
@@ -174,15 +178,6 @@ export function sortItems(items: GearItemPayload[]): GearItemPayload[] {
 export function nextAppendSort(sorts: readonly number[]): number {
   if (sorts.length === 0) return 0;
   return Math.max(...sorts) + 1;
-}
-
-function sequentialEffects(
-  effects: Array<Effect.Effect<unknown, CmsAppError>>,
-): Effect.Effect<void, CmsAppError> {
-  return effects.reduce(
-    (acc, e) => pipe(acc, Effect.flatMap(() => e)),
-    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
-  );
 }
 
 export function GearEditor() {

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -23,7 +23,7 @@ import {
   type ChangeEvent,
   type DragEvent as ReactDragEvent,
 } from "react";
-import { Effect, pipe } from "effect";
+import { Effect } from "effect";
 import { toast } from "sonner";
 import {
   ArrowDown,
@@ -50,7 +50,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
-import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import {
+  convexMutationEffect,
+  sequentialEffects,
+  type CmsAppError,
+} from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { cn } from "@/lib/utils";
 
@@ -165,15 +169,6 @@ function canonicaliseCategories(
 ): GalleryCategorySlug[] {
   return GALLERY_CATEGORY_OPTIONS.filter((option) => selected.has(option.slug)).map(
     (option) => option.slug,
-  );
-}
-
-function sequentialEffects(
-  effects: Array<Effect.Effect<unknown, CmsAppError>>,
-): Effect.Effect<void, CmsAppError> {
-  return effects.reduce(
-    (acc, effect) => pipe(acc, Effect.flatMap(() => effect)),
-    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
   );
 }
 

--- a/src/app/admin/videos/page.tsx
+++ b/src/app/admin/videos/page.tsx
@@ -1,5 +1,16 @@
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+
+const VideosEditor = dynamic(
+  () =>
+    import("./videos-editor").then((m) => ({ default: m.VideosEditor })),
+  {
+    loading: () => (
+      <p className="body-text text-muted-foreground">Loading videos…</p>
+    ),
+  },
+);
 
 export const metadata: Metadata = {
   title: "Videos",
@@ -9,13 +20,9 @@ export default function VideosPage() {
   return (
     <>
       <AdminHeader title="Videos" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-4xl">
-          <div className="rounded-lg border border-border bg-muted/50 p-8 text-center">
-            <p className="body-text text-muted-foreground">
-              Video portfolio management coming soon.
-            </p>
-          </div>
+      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
+        <div className="mx-auto max-w-5xl">
+          <VideosEditor />
         </div>
       </div>
     </>

--- a/src/app/admin/videos/videos-editor.test.ts
+++ b/src/app/admin/videos/videos-editor.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { validateVideoFields } from "./videos-editor";
+
+describe("validateVideoFields", () => {
+  test("empty title is rejected", () => {
+    expect(validateVideoFields("", "")).toContain("Title");
+    expect(validateVideoFields("   ", "")).toContain("Title");
+  });
+
+  test("title over 200 characters is rejected", () => {
+    expect(validateVideoFields("a".repeat(201), "")).toContain("200");
+  });
+
+  test("description over 2000 characters is rejected", () => {
+    expect(validateVideoFields("Title", "x".repeat(2001))).toContain("2000");
+  });
+
+  test("valid title returns null", () => {
+    expect(validateVideoFields("Live session", "")).toBeNull();
+    expect(validateVideoFields("Live session", "Optional notes.")).toBeNull();
+  });
+});

--- a/src/app/admin/videos/videos-editor.tsx
+++ b/src/app/admin/videos/videos-editor.tsx
@@ -1,0 +1,1713 @@
+"use client";
+
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useMutation,
+  useQuery,
+} from "convex/react";
+import { useUser } from "@clerk/nextjs";
+import { Effect, pipe } from "effect";
+import { toast } from "sonner";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  Eye,
+  EyeOff,
+  Film,
+  ImagePlus,
+  Loader2,
+  Plus,
+  Save,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
+import { runAdminEffect } from "@/lib/admin-run-effect";
+import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import { cn } from "@/lib/utils";
+import {
+  defaultTitleFromFileName,
+  formatDuration,
+  getProviderLabel,
+  isPlayableForPublish,
+  resolveVideoPreview,
+  type VideoProvider,
+} from "@/lib/video-embed";
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_DESCRIPTION_LENGTH = 2000;
+
+const PROVIDER_OPTIONS: ReadonlyArray<{
+  readonly id: VideoProvider;
+  readonly label: string;
+  readonly hint: string;
+}> = [
+  {
+    id: "youtube",
+    label: "YouTube",
+    hint: "Paste a watch URL or 11-character video id.",
+  },
+  {
+    id: "vimeo",
+    label: "Vimeo",
+    hint: "Paste a vimeo.com/video/… link or numeric id.",
+  },
+  {
+    id: "mux",
+    label: "Mux",
+    hint: "Paste a Mux playback id or stream URL.",
+  },
+  {
+    id: "upload",
+    label: "Upload",
+    hint: "Upload an MP4, WebM, or QuickTime file (≤100MB).",
+  },
+];
+
+type VideoItem = {
+  readonly stableId: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly sortOrder: number;
+  readonly provider: VideoProvider;
+  readonly externalId: string | null;
+  readonly playbackUrl: string | null;
+  readonly videoStorageId: Id<"_storage"> | null;
+  readonly videoUrl: string | null;
+  readonly thumbnailStorageId: Id<"_storage"> | null;
+  readonly thumbnailUrl: string | null;
+  readonly resolvedThumbnailUrl: string | null;
+  readonly durationSec: number | null;
+};
+
+type VideoEdits = Record<
+  string,
+  {
+    readonly title: string;
+    readonly description: string;
+    readonly externalId: string;
+    readonly playbackUrl: string;
+    readonly thumbnailUrl: string;
+  }
+>;
+
+type RowAction = "saving" | "deleting";
+type RowBusy = Record<string, RowAction | undefined>;
+
+interface UploadProgressEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly progress: number;
+  readonly status: "uploading" | "saving" | "done" | "error";
+  readonly error?: string;
+}
+
+interface NewVideoDraft {
+  readonly provider: VideoProvider;
+  readonly title: string;
+  readonly description: string;
+  readonly externalId: string;
+  readonly playbackUrl: string;
+  readonly thumbnailUrl: string;
+}
+
+const EMPTY_NEW_VIDEO: NewVideoDraft = {
+  provider: "youtube",
+  title: "",
+  description: "",
+  externalId: "",
+  playbackUrl: "",
+  thumbnailUrl: "",
+};
+
+export function validateVideoFields(
+  title: string,
+  description: string,
+): string | null {
+  const t = title.trim();
+  if (t.length === 0) return "Title is required.";
+  if (t.length > MAX_TITLE_LENGTH) {
+    return `Title must be at most ${MAX_TITLE_LENGTH} characters.`;
+  }
+  if (description.trim().length > MAX_DESCRIPTION_LENGTH) {
+    return `Description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`;
+  }
+  return null;
+}
+
+function sequentialEffects(
+  effects: Array<Effect.Effect<unknown, CmsAppError>>,
+): Effect.Effect<void, CmsAppError> {
+  return effects.reduce(
+    (acc, effect) => pipe(acc, Effect.flatMap(() => effect)),
+    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
+  );
+}
+
+async function uploadFileWithProgress(
+  uploadUrl: string,
+  file: File,
+  onProgress: (fraction: number) => void,
+): Promise<Id<"_storage">> {
+  return await new Promise<Id<"_storage">>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", uploadUrl);
+    xhr.setRequestHeader("Content-Type", file.type);
+    xhr.upload.addEventListener("progress", (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress(Math.min(1, event.loaded / event.total));
+      }
+    });
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const parsed = JSON.parse(xhr.responseText) as {
+            storageId: Id<"_storage">;
+          };
+          onProgress(1);
+          resolve(parsed.storageId);
+        } catch {
+          reject(new Error("Upload succeeded but response was malformed."));
+        }
+      } else {
+        reject(
+          new Error(
+            `Upload failed (${xhr.status} ${xhr.statusText || "unknown"}).`,
+          ),
+        );
+      }
+    });
+    xhr.addEventListener("error", () =>
+      reject(new Error("Network error during upload.")),
+    );
+    xhr.addEventListener("abort", () =>
+      reject(new Error("Upload was aborted.")),
+    );
+    xhr.send(file);
+  });
+}
+
+export function VideosEditor() {
+  return (
+    <>
+      <AuthLoading>
+        <VideosEditorSkeleton />
+      </AuthLoading>
+
+      <Unauthenticated>
+        <p className="body-text text-foreground/80">
+          Sign in to manage the video portfolio.
+        </p>
+      </Unauthenticated>
+
+      <Authenticated>
+        <VideosEditorForm />
+      </Authenticated>
+    </>
+  );
+}
+
+function VideosEditorSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <div className="grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-72 w-full" />
+        <Skeleton className="h-72 w-full" />
+      </div>
+    </div>
+  );
+}
+
+function VideosEditorForm() {
+  const { user } = useUser();
+  const data = useQuery(api.admin.videos.listDraftVideos);
+
+  const generateUploadUrl = useMutation(api.admin.videos.generateUploadUrl);
+  const createDraftVideo = useMutation(api.admin.videos.createDraftVideo);
+  const updateDraftVideo = useMutation(api.admin.videos.updateDraftVideo);
+  const removeDraftVideo = useMutation(api.admin.videos.removeDraftVideo);
+  const reorderDraftVideos = useMutation(api.admin.videos.reorderDraftVideos);
+  const publishVideos = useMutation(api.admin.videos.publishVideos);
+  const discardDraftVideos = useMutation(
+    api.admin.videos.discardDraftVideos,
+  );
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [busy, setBusy] = useState<string | null>(null);
+  const [rowBusy, setRowBusy] = useState<RowBusy>({});
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [edits, setEdits] = useState<VideoEdits>({});
+  const [deleteStableId, setDeleteStableId] = useState<string | null>(null);
+  const [showAddPanel, setShowAddPanel] = useState(false);
+  const [newVideo, setNewVideo] = useState<NewVideoDraft>(EMPTY_NEW_VIDEO);
+  const [previewOpen, setPreviewOpen] = useState<Record<string, boolean>>({});
+  const [uploadQueue, setUploadQueue] = useState<UploadProgressEntry[]>([]);
+
+  const videos = useMemo(
+    () => (data?.videos ?? []) as VideoItem[],
+    [data?.videos],
+  );
+
+  const limits = data?.limits ?? null;
+  const legacyMaxVideos = data?.maxVideos;
+  const maxVideos = limits?.maxVideos ?? legacyMaxVideos ?? 24;
+  const acceptedMimeTypes = useMemo(
+    () => limits?.acceptedMimeTypes ?? [],
+    [limits?.acceptedMimeTypes],
+  );
+  const maxUploadBytes = limits?.maxUploadBytes ?? 100 * 1024 * 1024;
+
+  const setRowAction = useCallback(
+    (stableId: string, action: RowAction | undefined) => {
+      setRowBusy((prev) => {
+        const next = { ...prev };
+        if (action === undefined) {
+          delete next[stableId];
+        } else {
+          next[stableId] = action;
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const runAction = useCallback(
+    async <A,>(label: string, program: Effect.Effect<A, CmsAppError>) => {
+      setInlineError(null);
+      setBusy(label);
+      const outcome = await runAdminEffect(program, {
+        onErrorMessage: setInlineError,
+      });
+      setBusy(null);
+      return outcome;
+    },
+    [],
+  );
+
+  const getEditableFields = useCallback(
+    (video: VideoItem) => ({
+      title: edits[video.stableId]?.title ?? video.title,
+      description: edits[video.stableId]?.description ?? video.description ?? "",
+      externalId: edits[video.stableId]?.externalId ?? video.externalId ?? "",
+      playbackUrl: edits[video.stableId]?.playbackUrl ?? video.playbackUrl ?? "",
+      thumbnailUrl:
+        edits[video.stableId]?.thumbnailUrl ?? video.thumbnailUrl ?? "",
+    }),
+    [edits],
+  );
+
+  const updateVideoEdit = useCallback(
+    (
+      video: VideoItem,
+      patch: Partial<{
+        title: string;
+        description: string;
+        externalId: string;
+        playbackUrl: string;
+        thumbnailUrl: string;
+      }>,
+    ) => {
+      setEdits((current) => {
+        const base = {
+          title: current[video.stableId]?.title ?? video.title,
+          description:
+            current[video.stableId]?.description ?? video.description ?? "",
+          externalId:
+            current[video.stableId]?.externalId ?? video.externalId ?? "",
+          playbackUrl:
+            current[video.stableId]?.playbackUrl ?? video.playbackUrl ?? "",
+          thumbnailUrl:
+            current[video.stableId]?.thumbnailUrl ?? video.thumbnailUrl ?? "",
+        };
+        const next = {
+          title: patch.title ?? base.title,
+          description: patch.description ?? base.description,
+          externalId: patch.externalId ?? base.externalId,
+          playbackUrl: patch.playbackUrl ?? base.playbackUrl,
+          thumbnailUrl: patch.thumbnailUrl ?? base.thumbnailUrl,
+        };
+        const matchesSaved =
+          next.title === video.title &&
+          next.description === (video.description ?? "") &&
+          next.externalId === (video.externalId ?? "") &&
+          next.playbackUrl === (video.playbackUrl ?? "") &&
+          next.thumbnailUrl === (video.thumbnailUrl ?? "");
+        if (matchesSaved) {
+          const rest = { ...current };
+          delete rest[video.stableId];
+          return rest;
+        }
+        return { ...current, [video.stableId]: next };
+      });
+    },
+    [],
+  );
+
+  const clearVideoEdit = useCallback((stableId: string) => {
+    setEdits((current) => {
+      const rest = { ...current };
+      delete rest[stableId];
+      return rest;
+    });
+  }, []);
+
+  const togglePreview = useCallback((stableId: string) => {
+    setPreviewOpen((prev) => ({ ...prev, [stableId]: !prev[stableId] }));
+  }, []);
+
+  const saveVideoDetails = useCallback(
+    async (video: VideoItem): Promise<boolean> => {
+      const fields = getEditableFields(video);
+      const validationError = validateVideoFields(fields.title, fields.description);
+      if (validationError) {
+        setInlineError(validationError);
+        toast.error(validationError);
+        return false;
+      }
+
+      setInlineError(null);
+      setRowAction(video.stableId, "saving");
+      const trimmedExternal = fields.externalId.trim();
+      const trimmedPlayback = fields.playbackUrl.trim();
+      const trimmedThumb = fields.thumbnailUrl.trim();
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() =>
+          updateDraftVideo({
+            stableId: video.stableId,
+            title: fields.title.trim(),
+            description:
+              fields.description.trim().length > 0
+                ? fields.description.trim()
+                : null,
+            ...(video.provider !== "upload" && trimmedExternal.length > 0
+              ? { externalId: trimmedExternal }
+              : {}),
+            ...(video.provider === "mux"
+              ? {
+                  playbackUrl:
+                    trimmedPlayback.length > 0 ? trimmedPlayback : null,
+                }
+              : {}),
+            thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
+          }),
+        ),
+        { onErrorMessage: setInlineError },
+      );
+      setRowAction(video.stableId, undefined);
+
+      if (outcome === undefined) {
+        return false;
+      }
+      clearVideoEdit(video.stableId);
+      toast.success("Video saved.");
+      return true;
+    },
+    [clearVideoEdit, getEditableFields, setRowAction, updateDraftVideo],
+  );
+
+  const savePendingEdits = useCallback(async (): Promise<boolean> => {
+    const dirty = videos.filter((v) => edits[v.stableId] !== undefined);
+    if (dirty.length === 0) return true;
+
+    for (const video of dirty) {
+      const fields = getEditableFields(video);
+      const validationError = validateVideoFields(
+        fields.title,
+        fields.description,
+      );
+      if (validationError) {
+        setInlineError(validationError);
+        toast.error(`${video.title || "Video"}: ${validationError}`);
+        return false;
+      }
+    }
+
+    const effects = dirty.map((video) => {
+      const fields = getEditableFields(video);
+      const trimmedExternal = fields.externalId.trim();
+      const trimmedPlayback = fields.playbackUrl.trim();
+      const trimmedThumb = fields.thumbnailUrl.trim();
+      return convexMutationEffect(() =>
+        updateDraftVideo({
+          stableId: video.stableId,
+          title: fields.title.trim(),
+          description:
+            fields.description.trim().length > 0
+              ? fields.description.trim()
+              : null,
+          ...(video.provider !== "upload" && trimmedExternal.length > 0
+            ? { externalId: trimmedExternal }
+            : {}),
+          ...(video.provider === "mux"
+            ? {
+                playbackUrl:
+                  trimmedPlayback.length > 0 ? trimmedPlayback : null,
+              }
+            : {}),
+          thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
+        }),
+      );
+    });
+
+    const outcome = await runAction("Saving…", sequentialEffects(effects));
+    if (outcome === undefined) return false;
+    setEdits({});
+    return true;
+  }, [edits, getEditableFields, runAction, updateDraftVideo, videos]);
+
+  const persistOrder = useCallback(
+    async (orderedStableIds: string[]): Promise<boolean> => {
+      const outcome = await runAction(
+        "Reordering…",
+        convexMutationEffect(() =>
+          reorderDraftVideos({ orderedStableIds }),
+        ),
+      );
+      return outcome !== undefined;
+    },
+    [reorderDraftVideos, runAction],
+  );
+
+  const moveVideo = useCallback(
+    async (stableId: string, direction: -1 | 1) => {
+      const index = videos.findIndex((v) => v.stableId === stableId);
+      if (index === -1) return;
+      const target = index + direction;
+      if (target < 0 || target >= videos.length) return;
+      const reordered = [...videos];
+      const [moved] = reordered.splice(index, 1);
+      reordered.splice(target, 0, moved);
+      const ok = await persistOrder(reordered.map((v) => v.stableId));
+      if (ok) {
+        toast.success("Video order updated.");
+      }
+    },
+    [persistOrder, videos],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteStableId) return;
+    setInlineError(null);
+    setRowAction(deleteStableId, "deleting");
+    const outcome = await runAdminEffect(
+      convexMutationEffect(() =>
+        removeDraftVideo({ stableId: deleteStableId }),
+      ),
+      { onErrorMessage: setInlineError },
+    );
+    setRowAction(deleteStableId, undefined);
+    setDeleteStableId(null);
+    if (outcome !== undefined) {
+      clearVideoEdit(deleteStableId);
+      toast.success("Video removed.");
+    }
+  }, [clearVideoEdit, deleteStableId, removeDraftVideo, setRowAction]);
+
+  const handleDiscardConfirm = useCallback(async (): Promise<boolean> => {
+    setInlineError(null);
+    if (data?.meta?.hasDraftChanges) {
+      const outcome = await runAdminEffect(
+        convexMutationEffect(() => discardDraftVideos({})),
+        { onErrorMessage: setInlineError },
+      );
+      if (outcome === undefined) return false;
+    }
+    setEdits({});
+    toast.success(
+      data?.meta?.hasDraftChanges
+        ? "Draft discarded. The editor matches the published list."
+        : "Unsaved changes discarded.",
+    );
+    return true;
+  }, [data?.meta?.hasDraftChanges, discardDraftVideos]);
+
+  const handlePublish = useCallback(async () => {
+    const saved = await savePendingEdits();
+    if (!saved) return;
+
+    const outcome = await runAction(
+      "Publishing…",
+      convexMutationEffect(() => publishVideos({})),
+    );
+    if (outcome !== undefined) {
+      toast.success("Videos published.");
+    }
+  }, [publishVideos, runAction, savePendingEdits]);
+
+  const handleToolbarPublish = useCallback(() => {
+    void handlePublish();
+  }, [handlePublish]);
+
+  // -------------------- Add new video flow --------------------
+
+  const resetAddPanel = useCallback(() => {
+    setNewVideo(EMPTY_NEW_VIDEO);
+    setShowAddPanel(false);
+  }, []);
+
+  const submitNewEmbed = useCallback(async () => {
+    const titleError = validateVideoFields(newVideo.title, newVideo.description);
+    if (titleError) {
+      toast.error(titleError);
+      return;
+    }
+    if (newVideo.provider !== "upload" && newVideo.externalId.trim().length === 0) {
+      toast.error("Video URL or id is required.");
+      return;
+    }
+
+    const trimmedExternal = newVideo.externalId.trim();
+    const trimmedPlayback = newVideo.playbackUrl.trim();
+    const trimmedThumb = newVideo.thumbnailUrl.trim();
+
+    const outcome = await runAction(
+      "Adding…",
+      convexMutationEffect(() =>
+        createDraftVideo({
+          provider: newVideo.provider,
+          title: newVideo.title.trim(),
+          ...(newVideo.description.trim().length > 0
+            ? { description: newVideo.description.trim() }
+            : {}),
+          ...(newVideo.provider !== "upload"
+            ? { externalId: trimmedExternal }
+            : {}),
+          ...(newVideo.provider === "mux" && trimmedPlayback.length > 0
+            ? { playbackUrl: trimmedPlayback }
+            : {}),
+          ...(trimmedThumb.length > 0 ? { thumbnailUrl: trimmedThumb } : {}),
+        }),
+      ),
+    );
+
+    if (outcome) {
+      toast.success(`${getProviderLabel(newVideo.provider)} video added.`);
+      resetAddPanel();
+    }
+  }, [createDraftVideo, newVideo, resetAddPanel, runAction]);
+
+  // -------------------- Upload flow --------------------
+
+  const updateUploadEntry = useCallback(
+    (id: string, patch: Partial<UploadProgressEntry>) => {
+      setUploadQueue((prev) =>
+        prev.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)),
+      );
+    },
+    [],
+  );
+
+  const processUploadFiles = useCallback(
+    async (incoming: File[]) => {
+      if (incoming.length === 0 || !data) return;
+      setInlineError(null);
+
+      const remainingSlots = Math.max(0, maxVideos - videos.length);
+      if (remainingSlots === 0) {
+        toast.error(
+          `Video list is full (${maxVideos}). Remove a video first.`,
+        );
+        return;
+      }
+      const filesToUpload =
+        incoming.length > remainingSlots
+          ? (toast.error(
+              `Only ${remainingSlots} slot${
+                remainingSlots === 1 ? "" : "s"
+              } left; skipping the rest.`,
+            ),
+            incoming.slice(0, remainingSlots))
+          : incoming;
+
+      setBusy("Uploading…");
+      let successCount = 0;
+      const acceptedSet = new Set<string>(acceptedMimeTypes);
+
+      for (const file of filesToUpload) {
+        const entryId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        setUploadQueue((prev) => [
+          ...prev,
+          {
+            id: entryId,
+            name: file.name,
+            progress: 0,
+            status: "uploading",
+          },
+        ]);
+
+        if (!acceptedSet.has(file.type)) {
+          const msg = `${file.name}: only MP4, WebM, or QuickTime files are allowed.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+        if (file.size > maxUploadBytes) {
+          const msg = `${file.name}: file must be ${Math.floor(
+            maxUploadBytes / (1024 * 1024),
+          )}MB or smaller.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+
+        const upload = await runAdminEffect(
+          convexMutationEffect(() => generateUploadUrl({})),
+          { onErrorMessage: setInlineError },
+        );
+        if (!upload) {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: "Could not get upload URL.",
+          });
+          break;
+        }
+
+        let storageId: Id<"_storage"> | undefined;
+        try {
+          storageId = await uploadFileWithProgress(
+            upload.uploadUrl,
+            file,
+            (fraction) => updateUploadEntry(entryId, { progress: fraction }),
+          );
+        } catch (error) {
+          const msg =
+            error instanceof Error
+              ? `${file.name}: ${error.message}`
+              : `${file.name}: upload failed.`;
+          toast.error(msg);
+          updateUploadEntry(entryId, { status: "error", error: msg });
+          continue;
+        }
+
+        updateUploadEntry(entryId, { status: "saving", progress: 1 });
+        const saved = await runAdminEffect(
+          convexMutationEffect(() =>
+            createDraftVideo({
+              provider: "upload",
+              title: defaultTitleFromFileName(file.name),
+              videoStorageId: storageId,
+            }),
+          ),
+          { onErrorMessage: setInlineError },
+        );
+
+        if (saved !== undefined) {
+          successCount += 1;
+          updateUploadEntry(entryId, { status: "done" });
+        } else {
+          updateUploadEntry(entryId, {
+            status: "error",
+            error: `${file.name}: could not save video.`,
+          });
+        }
+      }
+
+      setBusy(null);
+      if (successCount > 0) {
+        toast.success(
+          successCount === 1
+            ? "Video uploaded."
+            : `${successCount} videos uploaded.`,
+        );
+      }
+
+      window.setTimeout(() => {
+        setUploadQueue((prev) =>
+          prev.filter((entry) => entry.status === "error"),
+        );
+      }, 2500);
+    },
+    [
+      acceptedMimeTypes,
+      createDraftVideo,
+      data,
+      generateUploadUrl,
+      maxUploadBytes,
+      maxVideos,
+      updateUploadEntry,
+      videos.length,
+    ],
+  );
+
+  const handleFileSelection = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+      event.target.value = "";
+      await processUploadFiles(files);
+    },
+    [processUploadFiles],
+  );
+
+  // -------------------- Toolbar registration --------------------
+
+  const hasDraftOnServer = data?.meta?.hasDraftChanges ?? false;
+  const hasLocalEdits = Object.keys(edits).length > 0;
+  const publishedAt = data?.meta?.publishedAt ?? null;
+  const publishedByLabel =
+    data?.meta?.publishedBy && user?.id === data.meta.publishedBy
+      ? "You"
+      : undefined;
+
+  const { toolbarPortal, editorRef } = useRegisterCmsEditor({
+    section: "videos",
+    sectionLabel: "Video portfolio",
+    hasDraftOnServer,
+    hasLocalEdits,
+    publishedAt,
+    publishedByLabel,
+    busy,
+    autosaveStatus: "idle",
+    inlineError,
+    previewHref: "/preview",
+    onPublish: handleToolbarPublish,
+    onDiscardConfirm: handleDiscardConfirm,
+  });
+
+  if (data === undefined) {
+    return <VideosEditorSkeleton />;
+  }
+
+  const slotsRemaining = Math.max(0, maxVideos - videos.length);
+  const allowAdd = slotsRemaining > 0 && busy === null;
+  const anyUploading = uploadQueue.some(
+    (entry) => entry.status === "uploading" || entry.status === "saving",
+  );
+
+  return (
+    <div ref={editorRef} className="space-y-8 pb-24">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={acceptedMimeTypes.join(",")}
+        multiple
+        className="hidden"
+        onChange={(event) => void handleFileSelection(event)}
+      />
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            Video portfolio
+          </h2>
+          <p className="body-text-small max-w-2xl text-foreground/85">
+            Embed videos from YouTube, Vimeo, or Mux, or upload short clips
+            directly to Convex storage. Order, edits, and additions live on
+            the draft until you publish — preview each panel inline before
+            it goes live.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={!allowAdd}
+          >
+            {anyUploading ? (
+              <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+            ) : (
+              <Upload className="mr-1 size-4" aria-hidden />
+            )}
+            Upload file
+          </Button>
+          <Button
+            type="button"
+            variant="default"
+            onClick={() => setShowAddPanel((v) => !v)}
+            disabled={!allowAdd}
+          >
+            <Plus className="mr-1 size-4" aria-hidden />
+            Add embed
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {slotsRemaining === 0
+          ? `Video list is full (${maxVideos}/${maxVideos}). Remove a video to add another.`
+          : `${videos.length}/${maxVideos} videos in the draft list.`}
+      </p>
+
+      {showAddPanel ? (
+        <AddVideoPanel
+          value={newVideo}
+          onChange={setNewVideo}
+          onCancel={resetAddPanel}
+          onSubmit={() => void submitNewEmbed()}
+          busy={busy === "Adding…"}
+          disabled={!allowAdd}
+        />
+      ) : null}
+
+      {uploadQueue.length > 0 ? (
+        <UploadTray queue={uploadQueue} anyUploading={anyUploading} />
+      ) : null}
+
+      {videos.length === 0 ? (
+        <EmptyState
+          onAdd={() => setShowAddPanel(true)}
+          onUpload={() => fileInputRef.current?.click()}
+          disabled={busy !== null}
+        />
+      ) : (
+        <ul className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {videos.map((video, index) => {
+            const fields = getEditableFields(video);
+            const isDirty = edits[video.stableId] !== undefined;
+            const rowAction = rowBusy[video.stableId];
+            const isRowBusy = rowAction !== undefined;
+            const titleInvalid = fields.title.trim().length === 0;
+            const willPublish = isPlayableForPublish({
+              title: fields.title,
+              provider: video.provider,
+              externalId: fields.externalId,
+              videoStorageId: video.videoStorageId,
+              videoUrl: video.videoUrl,
+            });
+            const previewIsOpen = previewOpen[video.stableId] ?? true;
+
+            return (
+              <li key={video.stableId}>
+                <VideoCard
+                  video={video}
+                  index={index}
+                  totalCount={videos.length}
+                  fields={fields}
+                  isDirty={isDirty}
+                  isRowBusy={isRowBusy}
+                  rowAction={rowAction}
+                  titleInvalid={titleInvalid}
+                  willPublish={willPublish}
+                  previewIsOpen={previewIsOpen}
+                  busy={busy}
+                  onUpdate={(patch) => updateVideoEdit(video, patch)}
+                  onSave={() => void saveVideoDetails(video)}
+                  onDiscardEdit={() => clearVideoEdit(video.stableId)}
+                  onTogglePreview={() => togglePreview(video.stableId)}
+                  onMoveUp={() => void moveVideo(video.stableId, -1)}
+                  onMoveDown={() => void moveVideo(video.stableId, 1)}
+                  onDelete={() => setDeleteStableId(video.stableId)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {toolbarPortal}
+
+      <AlertDialog
+        open={deleteStableId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteStableId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove video?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The draft row is deleted immediately. Uploaded video and
+              thumbnail blobs are removed from storage when nothing else
+              references them. Publish to apply on the public site.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
+            >
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                deleteStableId
+                  ? rowBusy[deleteStableId] === "deleting"
+                  : busy !== null
+              }
+              onClick={() => void handleDeleteConfirm()}
+            >
+              {deleteStableId && rowBusy[deleteStableId] === "deleting" ? (
+                <>
+                  <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+                  Removing…
+                </>
+              ) : (
+                "Remove video"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Add panel
+// -------------------------------------------------------------------------
+
+interface AddVideoPanelProps {
+  readonly value: NewVideoDraft;
+  readonly onChange: (value: NewVideoDraft) => void;
+  readonly onCancel: () => void;
+  readonly onSubmit: () => void;
+  readonly busy: boolean;
+  readonly disabled: boolean;
+}
+
+function AddVideoPanel({
+  value,
+  onChange,
+  onCancel,
+  onSubmit,
+  busy,
+  disabled,
+}: AddVideoPanelProps) {
+  const formId = useId();
+
+  const setProvider = useCallback(
+    (next: VideoProvider) => {
+      if (next === "upload") {
+        // Upload uses the dedicated drag-drop path, not this form.
+        return;
+      }
+      onChange({ ...value, provider: next });
+    },
+    [onChange, value],
+  );
+
+  const providerHint =
+    PROVIDER_OPTIONS.find((opt) => opt.id === value.provider)?.hint ?? "";
+
+  return (
+    <Card className="space-y-5 border-primary/30 bg-card/95 p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold tracking-tight text-foreground">
+            Add embedded video
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Pick a provider, paste the URL or id, and the public site will
+            render a privacy-enhanced player after publish.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close add panel"
+          onClick={onCancel}
+          disabled={busy}
+        >
+          <X className="size-4" aria-hidden />
+        </Button>
+      </div>
+
+      <div role="radiogroup" aria-label="Provider" className="flex flex-wrap gap-2">
+        {PROVIDER_OPTIONS.filter((opt) => opt.id !== "upload").map((opt) => {
+          const active = value.provider === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => setProvider(opt.id)}
+              disabled={disabled || busy}
+              className={cn(
+                "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                active
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground",
+                "disabled:cursor-not-allowed disabled:opacity-60",
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      <p className="-mt-2 text-xs text-muted-foreground">{providerHint}</p>
+
+      <div className="grid gap-3">
+        <label className="space-y-1" htmlFor={`${formId}-title`}>
+          <span className="text-sm font-medium text-foreground/90">
+            Title <span className="text-destructive">*</span>
+          </span>
+          <Input
+            id={`${formId}-title`}
+            value={value.title}
+            maxLength={MAX_TITLE_LENGTH}
+            placeholder="e.g. Live session at the lake house"
+            disabled={busy}
+            onChange={(event) =>
+              onChange({ ...value, title: event.target.value })
+            }
+          />
+        </label>
+
+        <label className="space-y-1" htmlFor={`${formId}-external`}>
+          <span className="text-sm font-medium text-foreground/90">
+            {value.provider === "mux"
+              ? "Mux playback id or URL"
+              : `${getProviderLabel(value.provider)} URL or id`}{" "}
+            <span className="text-destructive">*</span>
+          </span>
+          <Input
+            id={`${formId}-external`}
+            value={value.externalId}
+            placeholder={
+              value.provider === "youtube"
+                ? "https://www.youtube.com/watch?v=…"
+                : value.provider === "vimeo"
+                  ? "https://vimeo.com/123456789"
+                  : "abc123XYZ (playback id)"
+            }
+            disabled={busy}
+            onChange={(event) =>
+              onChange({ ...value, externalId: event.target.value })
+            }
+          />
+        </label>
+
+        {value.provider === "mux" ? (
+          <label className="space-y-1" htmlFor={`${formId}-playback`}>
+            <span className="text-sm font-medium text-foreground/90">
+              Mux HLS playback URL (optional)
+            </span>
+            <Input
+              id={`${formId}-playback`}
+              value={value.playbackUrl}
+              placeholder="https://stream.mux.com/…m3u8"
+              disabled={busy}
+              onChange={(event) =>
+                onChange({ ...value, playbackUrl: event.target.value })
+              }
+            />
+          </label>
+        ) : null}
+
+        <label className="space-y-1" htmlFor={`${formId}-thumb`}>
+          <span className="text-sm font-medium text-foreground/90">
+            Thumbnail URL (optional)
+          </span>
+          <Input
+            id={`${formId}-thumb`}
+            value={value.thumbnailUrl}
+            placeholder="https://i.ytimg.com/… or https://i.vimeocdn.com/…"
+            disabled={busy}
+            onChange={(event) =>
+              onChange({ ...value, thumbnailUrl: event.target.value })
+            }
+          />
+          <span className="text-xs text-muted-foreground">
+            Provider thumbnails on YouTube, Vimeo, Mux, or Unsplash CDN are
+            accepted. Other hosts will be rejected on save.
+          </span>
+        </label>
+
+        <label className="space-y-1" htmlFor={`${formId}-description`}>
+          <span className="text-sm font-medium text-foreground/90">
+            Description (optional)
+          </span>
+          <Textarea
+            id={`${formId}-description`}
+            value={value.description}
+            maxLength={MAX_DESCRIPTION_LENGTH}
+            rows={3}
+            placeholder="Short context shown alongside the embed."
+            disabled={busy}
+            onChange={(event) =>
+              onChange({ ...value, description: event.target.value })
+            }
+          />
+        </label>
+      </div>
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="default"
+          onClick={onSubmit}
+          disabled={busy || disabled}
+        >
+          {busy ? (
+            <Loader2 className="mr-1 size-4 animate-spin" aria-hidden />
+          ) : (
+            <Plus className="mr-1 size-4" aria-hidden />
+          )}
+          Add to draft
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Empty state
+// -------------------------------------------------------------------------
+
+function EmptyState({
+  onAdd,
+  onUpload,
+  disabled,
+}: {
+  readonly onAdd: () => void;
+  readonly onUpload: () => void;
+  readonly disabled: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-muted/20 px-6 py-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Film className="size-6" aria-hidden />
+      </div>
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-foreground">
+          No videos in the draft yet
+        </p>
+        <p className="body-text-small max-w-md text-foreground/80">
+          Embed videos from YouTube, Vimeo, or Mux for marketing pages, or
+          upload a short MP4 / WebM directly. Owners can preview each one
+          before publish.
+        </p>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+        <Button type="button" variant="outline" onClick={onUpload} disabled={disabled}>
+          <Upload className="mr-1 size-4" aria-hidden />
+          Upload file
+        </Button>
+        <Button type="button" onClick={onAdd} disabled={disabled}>
+          <Plus className="mr-1 size-4" aria-hidden />
+          Add embed
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Upload tray
+// -------------------------------------------------------------------------
+
+function UploadTray({
+  queue,
+  anyUploading,
+}: {
+  readonly queue: ReadonlyArray<UploadProgressEntry>;
+  readonly anyUploading: boolean;
+}) {
+  return (
+    <div
+      className="space-y-2 rounded-xl border border-border bg-muted/30 p-4"
+      aria-live="polite"
+      aria-busy={anyUploading}
+    >
+      <p className="body-text-small font-medium text-foreground/85">
+        {anyUploading ? "Uploading videos…" : "Upload results"}
+      </p>
+      <ul className="space-y-2">
+        {queue.map((entry) => (
+          <li key={entry.id} className="space-y-1">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span
+                className="truncate text-foreground/85"
+                title={entry.name}
+              >
+                {entry.name}
+              </span>
+              <span
+                className={cn(
+                  "shrink-0 text-xs",
+                  entry.status === "error"
+                    ? "text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                {entry.status === "uploading" &&
+                  `${Math.round(entry.progress * 100)}%`}
+                {entry.status === "saving" && "Saving…"}
+                {entry.status === "done" && "Done"}
+                {entry.status === "error" && "Failed"}
+              </span>
+            </div>
+            <div
+              className={cn(
+                "h-1.5 overflow-hidden rounded-full bg-border/70",
+                entry.status === "error" && "bg-destructive/20",
+              )}
+            >
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all",
+                  entry.status === "error"
+                    ? "bg-destructive"
+                    : entry.status === "done"
+                      ? "bg-emerald-500"
+                      : "bg-primary",
+                )}
+                style={{
+                  width:
+                    entry.status === "error"
+                      ? "100%"
+                      : `${Math.round(entry.progress * 100)}%`,
+                }}
+              />
+            </div>
+            {entry.error ? (
+              <p className="text-xs text-destructive">{entry.error}</p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Video card
+// -------------------------------------------------------------------------
+
+interface VideoCardProps {
+  readonly video: VideoItem;
+  readonly index: number;
+  readonly totalCount: number;
+  readonly fields: {
+    readonly title: string;
+    readonly description: string;
+    readonly externalId: string;
+    readonly playbackUrl: string;
+    readonly thumbnailUrl: string;
+  };
+  readonly isDirty: boolean;
+  readonly isRowBusy: boolean;
+  readonly rowAction: RowAction | undefined;
+  readonly titleInvalid: boolean;
+  readonly willPublish: boolean;
+  readonly previewIsOpen: boolean;
+  readonly busy: string | null;
+  readonly onUpdate: (
+    patch: Partial<{
+      title: string;
+      description: string;
+      externalId: string;
+      playbackUrl: string;
+      thumbnailUrl: string;
+    }>,
+  ) => void;
+  readonly onSave: () => void;
+  readonly onDiscardEdit: () => void;
+  readonly onTogglePreview: () => void;
+  readonly onMoveUp: () => void;
+  readonly onMoveDown: () => void;
+  readonly onDelete: () => void;
+}
+
+function VideoCard({
+  video,
+  index,
+  totalCount,
+  fields,
+  isDirty,
+  isRowBusy,
+  rowAction,
+  titleInvalid,
+  willPublish,
+  previewIsOpen,
+  busy,
+  onUpdate,
+  onSave,
+  onDiscardEdit,
+  onTogglePreview,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: VideoCardProps) {
+  const headingId = useId();
+  const titleFieldId = useId();
+  const descFieldId = useId();
+  const externalFieldId = useId();
+  const playbackFieldId = useId();
+  const thumbFieldId = useId();
+  const headingTitle =
+    fields.title.trim().length > 0 ? fields.title : "Untitled video";
+  const providerLabel = getProviderLabel(video.provider);
+  const duration = formatDuration(video.durationSec);
+
+  const preview = useMemo(
+    () =>
+      resolveVideoPreview(
+        {
+          provider: video.provider,
+          externalId: fields.externalId.trim(),
+          videoUrl: video.videoUrl,
+          playbackUrl: fields.playbackUrl.trim(),
+          thumbnailUrl: fields.thumbnailUrl.trim() || video.resolvedThumbnailUrl,
+        },
+        { title: headingTitle },
+      ),
+    [
+      fields.externalId,
+      fields.playbackUrl,
+      fields.thumbnailUrl,
+      headingTitle,
+      video.provider,
+      video.resolvedThumbnailUrl,
+      video.videoUrl,
+    ],
+  );
+
+  return (
+    <Card
+      aria-labelledby={headingId}
+      className={cn(
+        "flex h-full flex-col gap-4 p-4 transition",
+        isRowBusy && "pointer-events-none opacity-90",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground/55">
+            Video #{index + 1} · {providerLabel}
+            {duration ? ` · ${duration}` : ""}
+          </p>
+          <h3
+            id={headingId}
+            className="truncate text-base font-semibold leading-tight text-foreground"
+          >
+            {headingTitle}
+          </h3>
+          {video.provider === "upload" && video.videoUrl ? (
+            <p className="truncate text-[11px] text-muted-foreground">
+              Convex storage · {video.videoStorageId}
+            </p>
+          ) : video.externalId ? (
+            <p className="truncate text-[11px] text-muted-foreground">
+              {providerLabel} id · {video.externalId}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/60 bg-muted/30 p-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Move video up"
+            disabled={index === 0 || busy !== null || isRowBusy}
+            onClick={onMoveUp}
+          >
+            <ArrowUp className="size-4 stroke-[2.25]" aria-hidden />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Move video down"
+            disabled={index === totalCount - 1 || busy !== null || isRowBusy}
+            onClick={onMoveDown}
+          >
+            <ArrowDown className="size-4 stroke-[2.25]" aria-hidden />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Remove video"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            disabled={busy !== null || isRowBusy}
+            onClick={onDelete}
+          >
+            {rowAction === "deleting" ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <Trash2 className="size-4 stroke-[2.25]" aria-hidden />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <PreviewPanel
+        preview={preview}
+        title={headingTitle}
+        previewIsOpen={previewIsOpen}
+        onTogglePreview={onTogglePreview}
+      />
+
+      <div className="grid gap-2.5">
+        <label className="space-y-1" htmlFor={titleFieldId}>
+          <span className="text-[11px] font-medium text-foreground/90">
+            Title <span className="text-destructive">*</span>
+          </span>
+          <Input
+            id={titleFieldId}
+            value={fields.title}
+            maxLength={MAX_TITLE_LENGTH}
+            aria-invalid={titleInvalid || undefined}
+            aria-describedby={titleInvalid ? `${titleFieldId}-hint` : undefined}
+            onChange={(event) => onUpdate({ title: event.target.value })}
+            className="h-8 py-1 text-sm"
+          />
+          {titleInvalid ? (
+            <span
+              id={`${titleFieldId}-hint`}
+              className="block text-xs text-amber-600 dark:text-amber-400"
+            >
+              Title is required before publish.
+            </span>
+          ) : null}
+        </label>
+
+        {video.provider !== "upload" ? (
+          <label className="space-y-1" htmlFor={externalFieldId}>
+            <span className="text-[11px] font-medium text-foreground/90">
+              {video.provider === "mux"
+                ? "Mux playback id"
+                : `${providerLabel} URL or id`}{" "}
+              <span className="text-destructive">*</span>
+            </span>
+            <Input
+              id={externalFieldId}
+              value={fields.externalId}
+              onChange={(event) =>
+                onUpdate({ externalId: event.target.value })
+              }
+              className="h-8 py-1 text-sm font-mono"
+            />
+          </label>
+        ) : null}
+
+        {video.provider === "mux" ? (
+          <label className="space-y-1" htmlFor={playbackFieldId}>
+            <span className="text-[11px] font-medium text-foreground/90">
+              Mux HLS URL (optional)
+            </span>
+            <Input
+              id={playbackFieldId}
+              value={fields.playbackUrl}
+              onChange={(event) =>
+                onUpdate({ playbackUrl: event.target.value })
+              }
+              className="h-8 py-1 text-sm font-mono"
+            />
+          </label>
+        ) : null}
+
+        <label className="space-y-1" htmlFor={thumbFieldId}>
+          <span className="text-[11px] font-medium text-foreground/90">
+            Thumbnail URL (optional)
+          </span>
+          <Input
+            id={thumbFieldId}
+            value={fields.thumbnailUrl}
+            placeholder="https://i.ytimg.com/…"
+            onChange={(event) =>
+              onUpdate({ thumbnailUrl: event.target.value })
+            }
+            className="h-8 py-1 text-sm font-mono"
+          />
+        </label>
+
+        <label className="space-y-1" htmlFor={descFieldId}>
+          <span className="text-[11px] font-medium text-foreground/90">
+            Description
+          </span>
+          <Textarea
+            id={descFieldId}
+            value={fields.description}
+            maxLength={MAX_DESCRIPTION_LENGTH}
+            rows={2}
+            onChange={(event) =>
+              onUpdate({ description: event.target.value })
+            }
+            className="min-h-[2.5rem] max-h-32 resize-y py-1.5 text-sm [field-sizing:fixed]"
+          />
+        </label>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 text-[11px] font-medium",
+            willPublish
+              ? "text-emerald-700 dark:text-emerald-300"
+              : "text-amber-700 dark:text-amber-300",
+          )}
+        >
+          {willPublish ? (
+            <Check className="size-3.5" aria-hidden />
+          ) : (
+            <Film className="size-3.5" aria-hidden />
+          )}
+          {willPublish
+            ? "Ready to publish"
+            : "Needs title + playable reference"}
+        </span>
+        <div className="flex items-center gap-2">
+          {isDirty ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onDiscardEdit}
+              disabled={busy !== null || isRowBusy}
+            >
+              Reset
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!isDirty || busy !== null || isRowBusy}
+            onClick={onSave}
+          >
+            {rowAction === "saving" ? (
+              <Loader2 className="mr-1 size-3.5 animate-spin" aria-hidden />
+            ) : (
+              <Save className="mr-1 size-3.5" aria-hidden />
+            )}
+            Save
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Preview panel
+// -------------------------------------------------------------------------
+
+interface PreviewPanelProps {
+  readonly preview: ReturnType<typeof resolveVideoPreview>;
+  readonly title: string;
+  readonly previewIsOpen: boolean;
+  readonly onTogglePreview: () => void;
+}
+
+function PreviewPanel({
+  preview,
+  title,
+  previewIsOpen,
+  onTogglePreview,
+}: PreviewPanelProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-foreground/65">
+          Preview · {preview.providerLabel}
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-pressed={previewIsOpen}
+          onClick={onTogglePreview}
+          className="h-7 gap-1 px-2 text-[11px]"
+        >
+          {previewIsOpen ? (
+            <EyeOff className="size-3.5" aria-hidden />
+          ) : (
+            <Eye className="size-3.5" aria-hidden />
+          )}
+          {previewIsOpen ? "Hide" : "Show"}
+        </Button>
+      </div>
+
+      {previewIsOpen ? (
+        <div
+          className={cn(
+            "relative w-full overflow-hidden rounded-lg border border-border bg-black",
+            // Aspect-ratio wrapper — survives narrow mobile widths and keeps
+            // YouTube/Vimeo iframes legible without media queries.
+            "aspect-video",
+          )}
+        >
+          {preview.kind === "iframe" ? (
+            <iframe
+              src={preview.src}
+              title={`Preview: ${title}`}
+              loading="lazy"
+              allow={preview.allow}
+              allowFullScreen={preview.allowFullScreen}
+              referrerPolicy="strict-origin-when-cross-origin"
+              className="absolute inset-0 size-full"
+            />
+          ) : preview.kind === "video" ? (
+            <video
+              key={preview.src}
+              controls
+              preload="metadata"
+              {...(preview.poster ? { poster: preview.poster } : {})}
+              className="absolute inset-0 size-full bg-black object-contain"
+              aria-label={`Preview: ${title}`}
+            >
+              <source src={preview.src} />
+              Your browser does not support embedded video.
+            </video>
+          ) : (
+            <PreviewFallback reason={preview.reason} />
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PreviewFallback({ reason }: { readonly reason: string }) {
+  return (
+    <div className="flex size-full flex-col items-center justify-center gap-2 px-4 text-center">
+      <div className="flex size-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+        <ImagePlus className="size-5" aria-hidden />
+      </div>
+      <p className="text-sm font-medium text-white">No preview yet</p>
+      <p className="max-w-xs text-xs text-white/70">{reason}</p>
+    </div>
+  );
+}

--- a/src/app/admin/videos/videos-editor.tsx
+++ b/src/app/admin/videos/videos-editor.tsx
@@ -164,6 +164,33 @@ export function validateVideoFields(
   return null;
 }
 
+function buildUpdateDraftVideoArgs(
+  video: Pick<VideoItem, "stableId" | "provider">,
+  fields: VideoEdits[string],
+) {
+  const trimmedExternal = fields.externalId.trim();
+  const trimmedPlayback = fields.playbackUrl.trim();
+  const trimmedThumb = fields.thumbnailUrl.trim();
+  return {
+    stableId: video.stableId,
+    title: fields.title.trim(),
+    description:
+      fields.description.trim().length > 0
+        ? fields.description.trim()
+        : null,
+    ...(video.provider !== "upload" && trimmedExternal.length > 0
+      ? { externalId: trimmedExternal }
+      : {}),
+    ...(video.provider === "mux"
+      ? {
+          playbackUrl:
+            trimmedPlayback.length > 0 ? trimmedPlayback : null,
+        }
+      : {}),
+    thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
+  };
+}
+
 function sequentialEffects(
   effects: Array<Effect.Effect<unknown, CmsAppError>>,
 ): Effect.Effect<void, CmsAppError> {
@@ -400,29 +427,9 @@ function VideosEditorForm() {
 
       setInlineError(null);
       setRowAction(video.stableId, "saving");
-      const trimmedExternal = fields.externalId.trim();
-      const trimmedPlayback = fields.playbackUrl.trim();
-      const trimmedThumb = fields.thumbnailUrl.trim();
       const outcome = await runAdminEffect(
         convexMutationEffect(() =>
-          updateDraftVideo({
-            stableId: video.stableId,
-            title: fields.title.trim(),
-            description:
-              fields.description.trim().length > 0
-                ? fields.description.trim()
-                : null,
-            ...(video.provider !== "upload" && trimmedExternal.length > 0
-              ? { externalId: trimmedExternal }
-              : {}),
-            ...(video.provider === "mux"
-              ? {
-                  playbackUrl:
-                    trimmedPlayback.length > 0 ? trimmedPlayback : null,
-                }
-              : {}),
-            thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
-          }),
+          updateDraftVideo(buildUpdateDraftVideoArgs(video, fields)),
         ),
         { onErrorMessage: setInlineError },
       );
@@ -457,28 +464,8 @@ function VideosEditorForm() {
 
     const effects = dirty.map((video) => {
       const fields = getEditableFields(video);
-      const trimmedExternal = fields.externalId.trim();
-      const trimmedPlayback = fields.playbackUrl.trim();
-      const trimmedThumb = fields.thumbnailUrl.trim();
       return convexMutationEffect(() =>
-        updateDraftVideo({
-          stableId: video.stableId,
-          title: fields.title.trim(),
-          description:
-            fields.description.trim().length > 0
-              ? fields.description.trim()
-              : null,
-          ...(video.provider !== "upload" && trimmedExternal.length > 0
-            ? { externalId: trimmedExternal }
-            : {}),
-          ...(video.provider === "mux"
-            ? {
-                playbackUrl:
-                  trimmedPlayback.length > 0 ? trimmedPlayback : null,
-              }
-            : {}),
-          thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
-        }),
+        updateDraftVideo(buildUpdateDraftVideoArgs(video, fields)),
       );
     });
 

--- a/src/app/admin/videos/videos-editor.tsx
+++ b/src/app/admin/videos/videos-editor.tsx
@@ -8,7 +8,7 @@ import {
   useQuery,
 } from "convex/react";
 import { useUser } from "@clerk/nextjs";
-import { Effect, pipe } from "effect";
+import { Effect } from "effect";
 import { toast } from "sonner";
 import {
   ArrowDown,
@@ -52,7 +52,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useRegisterCmsEditor } from "@/components/admin/cms-workspace";
 import { runAdminEffect } from "@/lib/admin-run-effect";
-import { convexMutationEffect, type CmsAppError } from "@/lib/effect-errors";
+import {
+  convexMutationEffect,
+  sequentialEffects,
+  type CmsAppError,
+} from "@/lib/effect-errors";
 import { cn } from "@/lib/utils";
 import {
   defaultTitleFromFileName,
@@ -178,7 +182,7 @@ function buildUpdateDraftVideoArgs(
       fields.description.trim().length > 0
         ? fields.description.trim()
         : null,
-    ...(video.provider !== "upload" && trimmedExternal.length > 0
+    ...(video.provider !== "upload"
       ? { externalId: trimmedExternal }
       : {}),
     ...(video.provider === "mux"
@@ -189,15 +193,6 @@ function buildUpdateDraftVideoArgs(
       : {}),
     thumbnailUrl: trimmedThumb.length > 0 ? trimmedThumb : null,
   };
-}
-
-function sequentialEffects(
-  effects: Array<Effect.Effect<unknown, CmsAppError>>,
-): Effect.Effect<void, CmsAppError> {
-  return effects.reduce(
-    (acc, effect) => pipe(acc, Effect.flatMap(() => effect)),
-    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
-  );
 }
 
 async function uploadFileWithProgress(

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
+import {
+  ADMIN_MANAGE_NAV_ITEMS,
+  PENDING_SECTION_NAV,
+  PENDING_SECTION_ORDER,
+  type PendingDraftKey,
+} from "@/lib/admin-nav";
 
 describe("ADMIN_MANAGE_NAV_ITEMS", () => {
   test("includes every CMS admin destination expected by the sidebar", () => {
@@ -34,5 +39,48 @@ describe("ADMIN_MANAGE_NAV_ITEMS", () => {
   test("hrefs are unique", () => {
     const hrefs = ADMIN_MANAGE_NAV_ITEMS.map((i) => i.href);
     expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});
+
+describe("PENDING_SECTION_NAV", () => {
+  test("includes the videos pending-draft surface", () => {
+    expect(PENDING_SECTION_NAV.videos).toEqual({
+      href: "/admin/videos",
+      label: "Videos",
+    });
+  });
+
+  test("every PendingDraftKey has a nav entry", () => {
+    const keys: PendingDraftKey[] = [
+      "settings",
+      "pricing",
+      "about",
+      "recordings",
+      "faq",
+      "amenitiesNearby",
+      "gear",
+      "photos",
+      "videos",
+    ];
+    for (const key of keys) {
+      expect(PENDING_SECTION_NAV[key]).toBeDefined();
+      expect(PENDING_SECTION_NAV[key].href.startsWith("/admin/")).toBe(true);
+    }
+  });
+});
+
+describe("PENDING_SECTION_ORDER", () => {
+  test("contains videos and matches the canonical chip order", () => {
+    expect(PENDING_SECTION_ORDER).toEqual([
+      "settings",
+      "pricing",
+      "about",
+      "faq",
+      "amenitiesNearby",
+      "gear",
+      "photos",
+      "videos",
+      "recordings",
+    ]);
   });
 });

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -87,7 +87,8 @@ export type PendingDraftKey =
   | "faq"
   | "amenitiesNearby"
   | "gear"
-  | "photos";
+  | "photos"
+  | "videos";
 
 /**
  * Nav target + user-facing label for each pending-draft key. `recordings` is
@@ -108,6 +109,7 @@ export const PENDING_SECTION_NAV: Record<
   },
   gear: { href: "/admin/gear", label: "Gear" },
   photos: { href: "/admin/photos", label: "Photos" },
+  videos: { href: "/admin/videos", label: "Videos" },
 };
 
 /** Stable display order for pending-draft chips / dots. */
@@ -119,5 +121,6 @@ export const PENDING_SECTION_ORDER: readonly PendingDraftKey[] = [
   "amenitiesNearby",
   "gear",
   "photos",
+  "videos",
   "recordings",
 ];

--- a/src/lib/effect-errors.ts
+++ b/src/lib/effect-errors.ts
@@ -2,7 +2,7 @@
  * CMS / admin Effect error catalog (INF-73).
  * Import tagged errors and `fromConvexCmsError` from here — single entry for app code.
  */
-import { Data, Effect } from "effect";
+import { Data, Effect, pipe } from "effect";
 import { ConvexError } from "convex/values";
 
 /** Convex `ConvexError` payload shape (mirrors `convex/errors.ts`). */
@@ -179,6 +179,16 @@ export function convexMutationEffect<A>(
     try: run,
     catch: fromConvexCmsError,
   });
+}
+
+/** Run effects in order, short-circuiting on the first error. */
+export function sequentialEffects(
+  effects: Array<Effect.Effect<unknown, CmsAppError>>,
+): Effect.Effect<void, CmsAppError> {
+  return effects.reduce(
+    (acc, e) => pipe(acc, Effect.flatMap(() => e)),
+    Effect.succeed(undefined) as Effect.Effect<void, CmsAppError>,
+  );
 }
 
 export function cmsErrorToastMessage(err: CmsAppError): string {

--- a/src/lib/video-embed.test.ts
+++ b/src/lib/video-embed.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildMuxPlayerUrl,
+  buildVimeoEmbedUrl,
+  buildYouTubeEmbedUrl,
+  defaultTitleFromFileName,
+  formatBytes,
+  formatDuration,
+  getProviderLabel,
+  isPlayableForPublish,
+  resolveVideoPreview,
+} from "./video-embed";
+
+describe("buildYouTubeEmbedUrl", () => {
+  test("uses the no-cookie host and privacy-enhanced params", () => {
+    const url = buildYouTubeEmbedUrl("dQw4w9WgXcQ");
+    expect(url.startsWith("https://www.youtube-nocookie.com/embed/")).toBe(
+      true,
+    );
+    expect(url).toContain("dQw4w9WgXcQ");
+    expect(url).toContain("rel=0");
+    expect(url).toContain("modestbranding=1");
+    expect(url).toContain("playsinline=1");
+  });
+
+  test("encodes the id (defense in depth — server already validated)", () => {
+    const url = buildYouTubeEmbedUrl("safe id");
+    expect(url).toContain("safe%20id");
+  });
+});
+
+describe("buildVimeoEmbedUrl", () => {
+  test("uses player.vimeo.com with dnt=1", () => {
+    const url = buildVimeoEmbedUrl("123456789");
+    expect(url.startsWith("https://player.vimeo.com/video/123456789")).toBe(
+      true,
+    );
+    expect(url).toContain("dnt=1");
+  });
+});
+
+describe("buildMuxPlayerUrl", () => {
+  test("uses player.mux.com", () => {
+    const url = buildMuxPlayerUrl("abc-123");
+    expect(url).toBe("https://player.mux.com/abc-123");
+  });
+
+  test("includes metadata-video-title when provided", () => {
+    const url = buildMuxPlayerUrl("abc-123", { title: "Live session" });
+    expect(url.startsWith("https://player.mux.com/abc-123?")).toBe(true);
+    expect(url).toContain("metadata-video-title=Live+session");
+  });
+});
+
+describe("resolveVideoPreview", () => {
+  test("youtube descriptor → iframe with privacy host", () => {
+    const result = resolveVideoPreview({
+      provider: "youtube",
+      externalId: "dQw4w9WgXcQ",
+    });
+    if (result.kind !== "iframe") {
+      throw new Error(`expected iframe, got ${result.kind}`);
+    }
+    expect(result.src).toContain("youtube-nocookie.com");
+    expect(result.providerLabel).toBe("YouTube");
+    expect(result.allowFullScreen).toBe(true);
+  });
+
+  test("vimeo descriptor → iframe", () => {
+    const result = resolveVideoPreview({
+      provider: "vimeo",
+      externalId: "123456789",
+    });
+    expect(result.kind).toBe("iframe");
+  });
+
+  test("mux descriptor → iframe at player.mux.com", () => {
+    const result = resolveVideoPreview(
+      { provider: "mux", externalId: "playback-id" },
+      { title: "Test" },
+    );
+    if (result.kind !== "iframe") {
+      throw new Error(`expected iframe, got ${result.kind}`);
+    }
+    expect(result.src).toContain("player.mux.com/playback-id");
+  });
+
+  test("upload with materialized URL → video element with poster", () => {
+    const result = resolveVideoPreview({
+      provider: "upload",
+      videoUrl: "https://example.com/x.mp4",
+      thumbnailUrl: "https://example.com/poster.jpg",
+    });
+    if (result.kind !== "video") {
+      throw new Error(`expected video, got ${result.kind}`);
+    }
+    expect(result.src).toBe("https://example.com/x.mp4");
+    expect(result.poster).toBe("https://example.com/poster.jpg");
+  });
+
+  test("upload without URL → missing", () => {
+    const result = resolveVideoPreview({ provider: "upload", videoUrl: null });
+    expect(result.kind).toBe("missing");
+  });
+
+  test.each([
+    ["youtube" as const],
+    ["vimeo" as const],
+    ["mux" as const],
+  ])("%s without externalId → missing with helpful reason", (provider) => {
+    const result = resolveVideoPreview({ provider, externalId: "" });
+    if (result.kind !== "missing") {
+      throw new Error(`expected missing, got ${result.kind}`);
+    }
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe("isPlayableForPublish", () => {
+  test("missing title → not playable regardless of provider", () => {
+    expect(
+      isPlayableForPublish({
+        title: "   ",
+        provider: "youtube",
+        externalId: "id",
+      }),
+    ).toBe(false);
+  });
+
+  test("youtube with externalId → playable", () => {
+    expect(
+      isPlayableForPublish({
+        title: "Hello",
+        provider: "youtube",
+        externalId: "dQw4w9WgXcQ",
+      }),
+    ).toBe(true);
+  });
+
+  test("upload requires storageId or videoUrl", () => {
+    expect(
+      isPlayableForPublish({ title: "Hello", provider: "upload" }),
+    ).toBe(false);
+    expect(
+      isPlayableForPublish({
+        title: "Hello",
+        provider: "upload",
+        videoStorageId: "storage_id",
+      }),
+    ).toBe(true);
+    expect(
+      isPlayableForPublish({
+        title: "Hello",
+        provider: "upload",
+        videoUrl: "https://example.com/x.mp4",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("formatBytes", () => {
+  test("bytes → KB → MB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(900)).toBe("900 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("formatDuration", () => {
+  test("null/undefined/negative → null", () => {
+    expect(formatDuration(null)).toBeNull();
+    expect(formatDuration(undefined)).toBeNull();
+    expect(formatDuration(-5)).toBeNull();
+  });
+
+  test("under an hour → m:ss", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(65)).toBe("1:05");
+    expect(formatDuration(599)).toBe("9:59");
+  });
+
+  test("over an hour → h:mm:ss", () => {
+    expect(formatDuration(3661)).toBe("1:01:01");
+  });
+});
+
+describe("defaultTitleFromFileName", () => {
+  test("strips extension and capitalises", () => {
+    expect(defaultTitleFromFileName("studio_session-01.mp4")).toBe(
+      "Studio session 01",
+    );
+  });
+
+  test("blank file name → studio video fallback", () => {
+    expect(defaultTitleFromFileName(".mp4")).toBe("Studio video");
+  });
+});
+
+describe("getProviderLabel", () => {
+  test("known providers", () => {
+    expect(getProviderLabel("youtube")).toBe("YouTube");
+    expect(getProviderLabel("vimeo")).toBe("Vimeo");
+    expect(getProviderLabel("mux")).toBe("Mux");
+    expect(getProviderLabel("upload")).toBe("Upload");
+  });
+});

--- a/src/lib/video-embed.test.ts
+++ b/src/lib/video-embed.test.ts
@@ -4,7 +4,6 @@ import {
   buildVimeoEmbedUrl,
   buildYouTubeEmbedUrl,
   defaultTitleFromFileName,
-  formatBytes,
   formatDuration,
   getProviderLabel,
   isPlayableForPublish,
@@ -155,15 +154,6 @@ describe("isPlayableForPublish", () => {
         videoUrl: "https://example.com/x.mp4",
       }),
     ).toBe(true);
-  });
-});
-
-describe("formatBytes", () => {
-  test("bytes → KB → MB", () => {
-    expect(formatBytes(0)).toBe("0 B");
-    expect(formatBytes(900)).toBe("900 B");
-    expect(formatBytes(2048)).toBe("2.0 KB");
-    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
   });
 });
 

--- a/src/lib/video-embed.ts
+++ b/src/lib/video-embed.ts
@@ -1,0 +1,268 @@
+/**
+ * Frontend helpers for rendering CMS video previews.
+ *
+ * Embed URLs are constructed from a known `provider` + `externalId` combo
+ * (already validated server-side in `convex/videoUrls.ts`), so the admin
+ * preview never assigns an arbitrary user-supplied iframe `src` string.
+ *
+ * Privacy-enhanced parameters are applied by default:
+ *   - YouTube → `youtube-nocookie.com` + `rel=0&modestbranding=1`
+ *   - Vimeo   → `dnt=1` (Do Not Track)
+ *   - Mux     → hosted Mux Player iframe (`player.mux.com/{playbackId}`)
+ *
+ * `provider: "upload"` uses a native `<video>` element with the materialized
+ * Convex storage URL; this module exposes a minimal type for that case so
+ * the editor can render both styles from a single descriptor.
+ */
+
+export type VideoProvider = "youtube" | "vimeo" | "mux" | "upload";
+
+export interface VideoEmbedDescriptor {
+  readonly provider: VideoProvider;
+  /** Provider-native id (YouTube 11-char, Vimeo numeric, Mux playback id). */
+  readonly externalId?: string | null;
+  /** Materialized Convex storage URL for `provider: "upload"`. */
+  readonly videoUrl?: string | null;
+  /** Optional Mux HLS playback URL. */
+  readonly playbackUrl?: string | null;
+  readonly thumbnailUrl?: string | null;
+}
+
+export type VideoPreviewEmbed =
+  | {
+      readonly kind: "iframe";
+      readonly src: string;
+      /** Provider-friendly label (e.g. "YouTube"). */
+      readonly providerLabel: string;
+      /**
+       * `allow` attr — keeps clipboard-write for share buttons and
+       * picture-in-picture for desktop viewers. Autoplay/encrypted-media
+       * are deliberately omitted in admin preview.
+       */
+      readonly allow: string;
+      readonly allowFullScreen: boolean;
+    }
+  | {
+      readonly kind: "video";
+      readonly src: string;
+      readonly poster?: string;
+      readonly providerLabel: string;
+    }
+  | {
+      readonly kind: "missing";
+      readonly providerLabel: string;
+      readonly reason: string;
+    };
+
+const DEFAULT_IFRAME_ALLOW =
+  "accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
+
+const PROVIDER_LABEL: Record<VideoProvider, string> = {
+  youtube: "YouTube",
+  vimeo: "Vimeo",
+  mux: "Mux",
+  upload: "Upload",
+};
+
+export function getProviderLabel(provider: VideoProvider): string {
+  return PROVIDER_LABEL[provider] ?? provider;
+}
+
+/**
+ * Build a privacy-enhanced YouTube embed URL from a validated 11-char id.
+ * Always uses the `youtube-nocookie.com` cookie-less variant.
+ */
+export function buildYouTubeEmbedUrl(externalId: string): string {
+  const id = encodeURIComponent(externalId);
+  const params = new URLSearchParams({
+    rel: "0",
+    modestbranding: "1",
+    playsinline: "1",
+  });
+  return `https://www.youtube-nocookie.com/embed/${id}?${params.toString()}`;
+}
+
+/**
+ * Build a privacy-enhanced Vimeo embed URL. `dnt=1` opts the embed out of
+ * Vimeo session tracking.
+ */
+export function buildVimeoEmbedUrl(externalId: string): string {
+  const id = encodeURIComponent(externalId);
+  const params = new URLSearchParams({
+    dnt: "1",
+    title: "1",
+    byline: "0",
+    portrait: "0",
+  });
+  return `https://player.vimeo.com/video/${id}?${params.toString()}`;
+}
+
+/**
+ * Build the hosted Mux Player iframe URL.
+ *
+ * `player.mux.com/{playbackId}` is the canonical Mux-hosted player page
+ * (see https://docs.mux.com/guides/mux-player-web/embed-mux-player). It
+ * accepts a `metadata-video-title` param for analytics labelling.
+ */
+export function buildMuxPlayerUrl(
+  playbackId: string,
+  options?: { readonly title?: string },
+): string {
+  const id = encodeURIComponent(playbackId);
+  const params = new URLSearchParams();
+  if (options?.title) {
+    params.set("metadata-video-title", options.title);
+  }
+  const query = params.toString();
+  return query.length > 0
+    ? `https://player.mux.com/${id}?${query}`
+    : `https://player.mux.com/${id}`;
+}
+
+/**
+ * Resolve a {@link VideoPreviewEmbed} from a descriptor. When the descriptor
+ * is incomplete (e.g. an upload row whose blob URL hasn't been materialized
+ * yet) the `missing` variant is returned with a human-readable reason.
+ */
+export function resolveVideoPreview(
+  descriptor: VideoEmbedDescriptor,
+  options?: { readonly title?: string },
+): VideoPreviewEmbed {
+  const providerLabel = getProviderLabel(descriptor.provider);
+
+  switch (descriptor.provider) {
+    case "youtube": {
+      const id = descriptor.externalId?.trim();
+      if (!id) {
+        return {
+          kind: "missing",
+          providerLabel,
+          reason: "Add a YouTube watch URL or video id to enable preview.",
+        };
+      }
+      return {
+        kind: "iframe",
+        src: buildYouTubeEmbedUrl(id),
+        providerLabel,
+        allow: DEFAULT_IFRAME_ALLOW,
+        allowFullScreen: true,
+      };
+    }
+    case "vimeo": {
+      const id = descriptor.externalId?.trim();
+      if (!id) {
+        return {
+          kind: "missing",
+          providerLabel,
+          reason: "Add a Vimeo URL or numeric video id to enable preview.",
+        };
+      }
+      return {
+        kind: "iframe",
+        src: buildVimeoEmbedUrl(id),
+        providerLabel,
+        allow: DEFAULT_IFRAME_ALLOW,
+        allowFullScreen: true,
+      };
+    }
+    case "mux": {
+      const id = descriptor.externalId?.trim();
+      if (!id) {
+        return {
+          kind: "missing",
+          providerLabel,
+          reason: "Add a Mux playback id (or stream URL) to enable preview.",
+        };
+      }
+      return {
+        kind: "iframe",
+        src: buildMuxPlayerUrl(id, options),
+        providerLabel,
+        allow: DEFAULT_IFRAME_ALLOW,
+        allowFullScreen: true,
+      };
+    }
+    case "upload": {
+      const url = descriptor.videoUrl?.trim();
+      if (!url) {
+        return {
+          kind: "missing",
+          providerLabel,
+          reason: "Upload a video file to enable preview.",
+        };
+      }
+      const poster = descriptor.thumbnailUrl?.trim();
+      return {
+        kind: "video",
+        src: url,
+        providerLabel,
+        ...(poster && poster.length > 0 ? { poster } : {}),
+      };
+    }
+  }
+}
+
+/**
+ * Returns `true` when the row has the minimum data required for the public
+ * site to render it: a non-empty title plus a playable reference matching
+ * its provider. Used by the admin to keep "Will block publish" hints in
+ * sync with the server-side `validateDraftVideosForPublish` check.
+ */
+export function isPlayableForPublish(row: {
+  readonly title: string;
+  readonly provider: VideoProvider;
+  readonly externalId?: string | null;
+  readonly videoStorageId?: string | null;
+  readonly videoUrl?: string | null;
+}): boolean {
+  if (row.title.trim().length === 0) return false;
+  switch (row.provider) {
+    case "upload":
+      return Boolean(row.videoStorageId ?? row.videoUrl);
+    case "youtube":
+    case "vimeo":
+    case "mux":
+      return Boolean(row.externalId && row.externalId.trim().length > 0);
+  }
+}
+
+/** Pretty-print bytes for upload size hints (B/KB/MB). */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Pretty-print a duration in seconds as `m:ss` or `h:mm:ss`. Returns `null`
+ * when the value is not a finite positive number, so the caller can drop
+ * the hint entirely.
+ */
+export function formatDuration(seconds: number | null | undefined): string | null {
+  if (seconds === null || seconds === undefined) return null;
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total - h * 3600) / 60);
+  const s = total - h * 3600 - m * 60;
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Title fallback for newly-uploaded videos (mirrors photos' alt fallback).
+ */
+export function defaultTitleFromFileName(fileName: string): string {
+  const withoutExtension = fileName.replace(/\.[^.]+$/, "");
+  const normalized = withoutExtension
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (normalized.length === 0) {
+    return "Studio video";
+  }
+  return normalized[0].toUpperCase() + normalized.slice(1);
+}

--- a/src/lib/video-embed.ts
+++ b/src/lib/video-embed.ts
@@ -226,14 +226,6 @@ export function isPlayableForPublish(row: {
   }
 }
 
-/** Pretty-print bytes for upload size hints (B/KB/MB). */
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
 /**
  * Pretty-print a duration in seconds as `m:ss` or `h:mm:ss`. Returns `null`
  * when the value is not a finite positive number, so the caller can drop


### PR DESCRIPTION
Wires the /admin/videos route to the existing CMS video mutations so the owner can manage the studio video list end-to-end without leaving the admin.

- Editor surfaces YouTube / Vimeo / Mux embeds and Convex uploads behind a unified card grid with live in-panel preview, reorder controls, save / delete per row, and a publish-blocking "needs title + playable reference" hint that mirrors the server-side validateDraftVideosForPublish check.
- Privacy-enhanced previews via youtube-nocookie.com (rel=0 / modestbranding), Vimeo dnt=1, and the hosted Mux Player iframe; uploads use a native <video controls> element. All previews wrap in an aspect-video container so mobile widths never break the iframe.
- Adds generateUploadUrl mutation + limits payload to admin/videos so the upload tray can reuse the photos.tsx XHR pattern (per-file progress, MIME
  + size guards) and respect MAX_VIDEOS / MAX_VIDEO_UPLOAD_BYTES.
- Threads videoMeta.hasDraftChanges into listPendingDrafts and adds "videos" to PendingDraftKey / PENDING_SECTION_NAV / PENDING_SECTION_ORDER so the cross-section pending banner picks up unpublished video drafts.
- A11y: editor uses h2 for the section, per-video h3 linked via aria-labelledby, iframes carry a title attr, native video has aria-label.

Tests cover the embed URL builders, resolveVideoPreview branching, isPlayableForPublish, formatBytes/Duration, defaultTitleFromFileName, the new pending-draft mappings, and validateVideoFields (398 pass total).

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new admin surface plus a new upload-URL mutation and client-side XHR upload flow, which increases risk around draft/publish correctness and storage handling. Changes are owner-gated and largely additive, but touch CMS pending-draft aggregation and shared Effect utilities.
> 
> **Overview**
> Enables full video portfolio management in `/admin/videos`, replacing the placeholder page with a dynamically loaded `VideosEditor` that supports **draft editing, reorder, delete, discard, and publish**, plus inline previews for YouTube/Vimeo/Mux and uploaded videos.
> 
> Adds an owner-only `generateUploadUrl` Convex mutation and extends `listDraftVideos` to return a `limits` payload (max count, max bytes, accepted MIME types) so the editor can upload video blobs with per-file progress and client-side guards.
> 
> Threads `videoMeta.hasDraftChanges` into `cms.listPendingDrafts` and updates admin pending-draft navigation/types/order to include `videos`. Also centralizes the shared `sequentialEffects` helper in `effect-errors` and updates existing editors to import it, with new unit tests covering video preview helpers, validation, and pending-draft mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee5c5cc0bbde254c772a249a7213452bd562cbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->