### PR TITLE
INF-103: Harden Convex read paths

### DIFF
--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -30,6 +30,8 @@ import {
   validateDraftVideosForPublish,
 } from "./videos";
 
+const CMS_PENDING_DRAFT_QUERY_LIMIT = 16;
+
 export const publish = mutation({
   args: { section: cmsSectionValidator },
   handler: async (ctx, args) => {
@@ -50,7 +52,10 @@ export const publishSite = mutation({
   handler: async (ctx) => {
     const { userId, updatedBy } = await requireCmsOwner(ctx);
 
-    const rows = await ctx.db.query("cmsSections").take(50);
+    const rows = await ctx.db
+      .query("cmsSections")
+      .withIndex("by_hasDraftChanges", (q) => q.eq("hasDraftChanges", true))
+      .take(CMS_PENDING_DRAFT_QUERY_LIMIT);
     const targets = rowsWithPublishableDraft(rows);
 
     const galleryMeta = await ctx.db

--- a/convex/admin/publish.ts
+++ b/convex/admin/publish.ts
@@ -29,8 +29,7 @@ import {
   publishVideosDraftCore,
   validateDraftVideosForPublish,
 } from "./videos";
-
-const CMS_PENDING_DRAFT_QUERY_LIMIT = 16;
+import { CMS_PENDING_DRAFT_QUERY_LIMIT } from "../cmsShared";
 
 export const publish = mutation({
   args: { section: cmsSectionValidator },

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -8,6 +8,7 @@ import {
   settingsContentValidator,
 } from "./schema.shared";
 import {
+  CMS_PENDING_DRAFT_QUERY_LIMIT,
   defaultSnapshotForSection,
   type AboutSnapshot,
   type AmenitiesNearbySnapshot,
@@ -67,7 +68,6 @@ import {
 import { cmsValidationError } from "./errors";
 
 const MARKETING_FLAG_SECTIONS = ["about", "recordings", "pricing"] as const;
-const CMS_PENDING_DRAFT_QUERY_LIMIT = 16;
 
 /**
  * Snapshot-shaped admin view of a section. Reads per-section scoped tables

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -67,6 +67,7 @@ import {
 import { cmsValidationError } from "./errors";
 
 const MARKETING_FLAG_SECTIONS = ["about", "recordings", "pricing"] as const;
+const CMS_PENDING_DRAFT_QUERY_LIMIT = 16;
 
 /**
  * Snapshot-shaped admin view of a section. Reads per-section scoped tables
@@ -264,7 +265,10 @@ export const listPendingDrafts = query({
     await requireCmsOwner(ctx);
 
     const [cmsRows, gearMeta, galleryMeta, videoMeta] = await Promise.all([
-      ctx.db.query("cmsSections").collect(),
+      ctx.db
+        .query("cmsSections")
+        .withIndex("by_hasDraftChanges", (q) => q.eq("hasDraftChanges", true))
+        .take(CMS_PENDING_DRAFT_QUERY_LIMIT),
       ctx.db
         .query("gearMeta")
         .withIndex("by_singleton", (q) => q.eq("singletonKey", "default"))

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -16,6 +16,9 @@ import { DEFAULT_FAQ_CATEGORIES } from "./faqSeedData";
 
 export type CmsSection = Infer<typeof cmsSectionValidator>;
 
+/** Max rows when scanning `cmsSections` for pending drafts (list + publish-all). */
+export const CMS_PENDING_DRAFT_QUERY_LIMIT = 16;
+
 /**
  * @deprecated Represents the pre-refactor `publishedSnapshot`/`draftSnapshot`
  * JSON blob on `cmsSections`. Kept so the one-shot migration can type the

--- a/convex/public.ts
+++ b/convex/public.ts
@@ -20,6 +20,76 @@ import {
 import { FAQ_DEFAULTS } from "./cmsShared";
 import { loadFaqTree, materializeFaqCategories } from "./faqTree";
 
+type MaterializedGalleryPhoto = Awaited<
+  ReturnType<typeof materializeGalleryPhotos>
+>[number];
+type MaterializedAudioTrack = Awaited<
+  ReturnType<typeof materializeAudioTracks>
+>[number];
+type MaterializedVideo = Awaited<ReturnType<typeof materializeVideos>>[number];
+
+function hasResolvedUrl<T extends { url: string | null }>(
+  row: T,
+): row is T & { url: string } {
+  return row.url !== null;
+}
+
+function publicGalleryPhoto(photo: MaterializedGalleryPhoto) {
+  return {
+    stableId: photo.stableId,
+    url: photo.url,
+    alt: photo.alt,
+    caption: photo.caption,
+    width: photo.width,
+    height: photo.height,
+    sortOrder: photo.sortOrder,
+    contentType: photo.contentType,
+    categories: photo.categories,
+  };
+}
+
+function publicCarouselPhoto(photo: MaterializedGalleryPhoto) {
+  return {
+    stableId: photo.stableId,
+    url: photo.url,
+    alt: photo.alt,
+    width: photo.width,
+    height: photo.height,
+    sortOrder: photo.sortOrder,
+  };
+}
+
+function publicAudioTrack(track: MaterializedAudioTrack & { url: string }) {
+  return {
+    stableId: track.stableId,
+    url: track.url,
+    title: track.title,
+    artist: track.artist,
+    genre: track.genre,
+    year: track.year,
+    role: track.role,
+    sortOrder: track.sortOrder,
+    albumThumbnailDisplayUrl: track.albumThumbnailDisplayUrl,
+    spotifyUrl: track.spotifyUrl,
+    appleMusicUrl: track.appleMusicUrl,
+  };
+}
+
+function publicVideo(video: MaterializedVideo) {
+  return {
+    stableId: video.stableId,
+    title: video.title,
+    description: video.description,
+    sortOrder: video.sortOrder,
+    provider: video.provider,
+    externalId: video.externalId,
+    playbackUrl: video.playbackUrl,
+    videoUrl: video.videoUrl,
+    resolvedThumbnailUrl: video.resolvedThumbnailUrl,
+    durationSec: video.durationSec,
+  };
+}
+
 /**
  * **Public (anonymous) site reads** — published only.
  *
@@ -97,9 +167,9 @@ export const getPublishedGalleryPhotos = query({
   handler: async (ctx) => {
     const rows = await loadGalleryPhotos(ctx, "published");
     const photos = await materializeGalleryPhotos(ctx, rows);
-    return photos.filter(
-      (photo) => photo.url !== null && photo.showInGallery !== false,
-    );
+    return photos
+      .filter((photo) => photo.url !== null && photo.showInGallery !== false)
+      .map(publicGalleryPhoto);
   },
 });
 
@@ -111,9 +181,9 @@ export const getPublishedCarouselPhotos = query({
   handler: async (ctx) => {
     const rows = await loadGalleryPhotos(ctx, "published");
     const photos = await materializeGalleryPhotos(ctx, rows);
-    return photos.filter(
-      (photo) => photo.url !== null && photo.showInCarousel !== false,
-    );
+    return photos
+      .filter((photo) => photo.url !== null && photo.showInCarousel !== false)
+      .map(publicCarouselPhoto);
   },
 });
 
@@ -131,7 +201,7 @@ export const getPublishedAudioTracks = query({
   handler: async (ctx) => {
     const rows = await loadAudioTracks(ctx, "published");
     const tracks = await materializeAudioTracks(ctx, rows);
-    return tracks.filter((t) => t.url !== null);
+    return tracks.filter(hasResolvedUrl).map(publicAudioTrack);
   },
 });
 
@@ -144,7 +214,8 @@ export const getPublishedVideos = query({
   args: {},
   handler: async (ctx) => {
     const rows = await loadVideos(ctx, "published");
-    return await materializeVideos(ctx, rows);
+    const videos = await materializeVideos(ctx, rows);
+    return videos.map(publicVideo);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -56,7 +56,10 @@ export default defineSchema({
     updatedAt: v.number(),
     /** Clerk user id (`subject`) when the last write was authenticated. */
     updatedBy: v.optional(v.string()),
-  }).index("by_section", ["section"]),
+  })
+    .index("by_section", ["section"])
+    // Admin pending-draft badges and publish-all only need rows with drafts.
+    .index("by_hasDraftChanges", ["hasDraftChanges"]),
 
   aboutContent: defineTable(aboutContentRowValidator).index("by_scope", [
     "scope",

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -97,15 +97,15 @@ function classifyKind(contentType: string): "image" | "video" {
 function toGalleryItems(photos: readonly GalleryPhoto[]): GalleryItem[] {
   return photos.map((photo) => ({
     id: photo.stableId,
-    kind: classifyKind(photo.contentType),
+    kind: classifyKind(photo.contentType ?? "image/jpeg"),
     src: photo.url,
     poster: null,
     alt: photo.alt,
-    caption: photo.caption,
+    caption: photo.caption ?? null,
     width: photo.width,
     height: photo.height,
     categories: photo.categories ?? [],
-    contentType: photo.contentType,
+    contentType: photo.contentType ?? "image/jpeg",
   }));
 }
 

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -9,20 +9,20 @@ export type GalleryPhoto = {
   stableId: string;
   url: string | null;
   alt: string;
-  caption: string | null;
+  caption?: string | null;
   width: number | null;
   height: number | null;
   sortOrder: number;
-  contentType: string;
-  sizeBytes: number;
-  originalFileName: string | null;
+  contentType?: string;
+  sizeBytes?: number;
+  originalFileName?: string | null;
   /**
    * INF-47 — controlled-vocabulary tags from `GALLERY_CATEGORY_SLUGS`
    * (`rooms` / `gear` / `grounds`). Drives the public `/gallery` page
    * filter pills. Empty when the photo is uncategorized; the homepage
    * carousel ignores this field.
    */
-  categories: readonly string[];
+  categories?: readonly string[];
   /** Omitted in older payloads; treat as `true` when undefined. */
   showInCarousel?: boolean;
   showInGallery?: boolean;


### PR DESCRIPTION
## Summary
- Add an index-backed pending draft read path for CMS publish checks.
- Narrow public gallery, carousel, audio, and video query payloads to required fields.
- Keep current admin media list limits unchanged while documenting the hot path improvements.

## Test plan
- bun run lint
- bun run build

Stack: 1/3. Base for INF-104.
Linear: https://linear.app/only-football-fans/issue/INF-103/lls-convex-queries-indexes-pagination-narrow-subscriptions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches publish-all and public query response shapes; main risk is subtle UI/runtime breakage for consumers expecting previously-returned fields or larger result sets.
> 
> **Overview**
> Speeds up CMS “pending drafts” checks and publish-all by adding a `cmsSections.by_hasDraftChanges` index and switching draft scans to an index-backed query with a shared `CMS_PENDING_DRAFT_QUERY_LIMIT` cap.
> 
> Hardens anonymous/public read paths by trimming `getPublishedGalleryPhotos`, `getPublishedCarouselPhotos`, `getPublishedAudioTracks`, and `getPublishedVideos` to return only needed fields (and filtering out unresolved storage URLs), with small frontend type/nullable handling updates to tolerate the narrower payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b19ff37691b9bb8afa03fad27038f42653ce8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->