### PR TITLE
INF-104: Optimize admin loading

### DIFF
--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -44,6 +44,7 @@ import type { Id } from "../../../../convex/_generated/dataModel";
 import { api } from "../../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -1044,7 +1045,12 @@ const HeroImagePicker = memo(function HeroImagePicker({
   uploadBusyKey,
   setUploadBusyKey,
 }: HeroImagePickerProps) {
-  const draft = useQuery(api.admin.photos.listDraftPhotos);
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const draft = useQuery(
+    api.admin.photos.listDraftPhotos,
+    galleryOpen ? {} : "skip",
+  );
+  const galleryLoaded = draft !== undefined;
 
   const photos = useMemo<GalleryPickerPhoto[]>(
     () =>
@@ -1056,16 +1062,20 @@ const HeroImagePicker = memo(function HeroImagePicker({
   );
 
   const selectedInGallery = useMemo(
-    () => photos.find((p) => p.storageId === selectedStorageId),
-    [photos, selectedStorageId],
+    () =>
+      galleryLoaded
+        ? photos.find((p) => p.storageId === selectedStorageId)
+        : undefined,
+    [galleryLoaded, photos, selectedStorageId],
   );
 
   // Resolve a URL for bespoke (non-gallery) hero uploads so we can still
-  // show a preview. Skipped when the selected id is already in the gallery
-  // list (we reuse the gallery-provided URL) or nothing is selected.
+  // show a preview without loading the full gallery picker. Skipped when the
+  // selected id is already in the loaded gallery list (we reuse that URL) or
+  // nothing is selected.
   const bespokeUrl = useQuery(
     api.admin.about.getHeroImageUrl,
-    selectedStorageId !== undefined && !selectedInGallery
+    selectedStorageId !== undefined && (!galleryLoaded || !selectedInGallery)
       ? { storageId: selectedStorageId }
       : "skip",
   );
@@ -1097,12 +1107,17 @@ const HeroImagePicker = memo(function HeroImagePicker({
   };
 
   const selectedUrl = selectedInGallery?.url ?? bespokeUrl ?? null;
-  // Only treat the selection as orphaned once we've heard back from both
-  // the gallery list and the bespoke URL query. Otherwise the first render
-  // after selection flashes a false warning.
-  const selectedIsOrphaned =
+  const selectedLookupComplete =
     selectedStorageId !== undefined &&
-    draft !== undefined &&
+    (!galleryOpen
+      ? bespokeUrl !== undefined
+      : galleryLoaded &&
+        (selectedInGallery !== undefined || bespokeUrl !== undefined));
+  // Only treat the selection as orphaned once every query needed for the
+  // current picker state has responded. Otherwise opening the gallery can
+  // flash a false warning while the list is still loading.
+  const selectedIsOrphaned =
+    selectedLookupComplete &&
     !selectedInGallery &&
     bespokeUrl === null;
 
@@ -1138,14 +1153,6 @@ const HeroImagePicker = memo(function HeroImagePicker({
       </Button>
     </>
   );
-
-  if (draft === undefined) {
-    return (
-      <p className="rounded-md border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">
-        Loading gallery photos…
-      </p>
-    );
-  }
 
   return (
     <div className="space-y-3">
@@ -1207,14 +1214,38 @@ const HeroImagePicker = memo(function HeroImagePicker({
 
       <div className="flex items-center justify-between gap-3">
         <p className="body-text-small text-muted-foreground">
-          {photos.length === 0
-            ? "No gallery photos yet — upload a bespoke image for the hero."
-            : "Pick from the gallery below or upload a bespoke image."}
+          {!galleryOpen
+            ? "Open the gallery picker only when you need an existing upload."
+            : !galleryLoaded
+              ? "Loading gallery photos…"
+              : photos.length === 0
+                ? "No gallery photos yet — upload a bespoke image for the hero."
+                : "Pick from the gallery below or upload a bespoke image."}
         </p>
-        {uploadButton}
+        <div className="flex shrink-0 items-center gap-2">
+          {!galleryOpen ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setGalleryOpen(true)}
+            >
+              Browse gallery photos
+            </Button>
+          ) : null}
+          {uploadButton}
+        </div>
       </div>
 
-      {photos.length > 0 ? (
+      {galleryOpen && !galleryLoaded ? (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <Skeleton key={i} className="aspect-square rounded-md" />
+          ))}
+        </div>
+      ) : null}
+
+      {galleryOpen && photos.length > 0 ? (
         <div
           role="radiogroup"
           aria-label="Hero image"

--- a/src/app/admin/audio/audio-editor-skeleton.tsx
+++ b/src/app/admin/audio/audio-editor-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Form-shaped skeleton for audio editor (route loading + dynamic import fallback). */
+export function AudioEditorSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-3.5 w-full max-w-2xl" />
+      </div>
+      <div className="rounded-xl border border-border bg-card p-5 shadow-sm">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="h-9 w-32 rounded-md" />
+        </div>
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="grid gap-3 rounded-lg border border-border/70 p-4 sm:grid-cols-[1fr_8rem]"
+            >
+              <div className="space-y-3">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="border-t border-border/70 pt-8">
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-9 w-28 rounded-md" />
+          <Skeleton className="h-9 w-24 rounded-md" />
+          <Skeleton className="h-9 w-36 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/audio/audio-editor.tsx
+++ b/src/app/admin/audio/audio-editor.tsx
@@ -58,6 +58,7 @@ import {
   useMarketingFeatureFlagsAdmin,
 } from "@/lib/use-marketing-feature-flags-admin";
 import { cn } from "@/lib/utils";
+import { AudioEditorSkeleton } from "./audio-editor-skeleton";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_ARTIST_LENGTH = 200;
@@ -1344,7 +1345,7 @@ function AudioEditorForm() {
   );
 
   if (data === undefined || featureFlagsLoading) {
-    return <p className="body-text text-foreground/80">Loading audio…</p>;
+    return <AudioEditorSkeleton />;
   }
 
   const anyUploading = uploadQueue.some(

--- a/src/app/admin/audio/page.tsx
+++ b/src/app/admin/audio/page.tsx
@@ -1,14 +1,11 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AudioEditorSkeleton } from "./audio-editor-skeleton";
 
 const AudioEditor = dynamic(
   () => import("./audio-editor").then((m) => ({ default: m.AudioEditor })),
-  {
-    loading: () => (
-      <p className="body-text text-muted-foreground">Loading audio…</p>
-    ),
-  },
+  { loading: () => <AudioEditorSkeleton /> },
 );
 
 export const metadata: Metadata = {

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -1,14 +1,11 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { PhotosEditorSkeleton } from "./photos-editor-skeleton";
 
 const PhotosEditor = dynamic(
   () => import("./photos-editor").then((m) => ({ default: m.PhotosEditor })),
-  {
-    loading: () => (
-      <p className="body-text text-muted-foreground">Loading photos…</p>
-    ),
-  },
+  { loading: () => <PhotosEditorSkeleton /> },
 );
 
 export const metadata: Metadata = {

--- a/src/app/admin/photos/photos-editor-skeleton.tsx
+++ b/src/app/admin/photos/photos-editor-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Gallery-shaped skeleton for photos editor (route loading + dynamic import fallback). */
+export function PhotosEditorSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-3.5 w-full max-w-2xl" />
+      </div>
+      <div className="rounded-xl border border-border bg-card p-5 shadow-sm">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-56" />
+          </div>
+          <Skeleton className="h-9 w-32 rounded-md" />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="overflow-hidden rounded-lg border border-border/70"
+            >
+              <Skeleton className="aspect-[4/3] w-full rounded-none" />
+              <div className="space-y-2 p-3">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="border-t border-border/70 pt-8">
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-9 w-28 rounded-md" />
+          <Skeleton className="h-9 w-24 rounded-md" />
+          <Skeleton className="h-9 w-36 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/photos/photos-editor.tsx
+++ b/src/app/admin/photos/photos-editor.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/lib/effect-errors";
 import { runAdminEffect } from "@/lib/admin-run-effect";
 import { cn } from "@/lib/utils";
+import { PhotosEditorSkeleton } from "./photos-editor-skeleton";
 
 const MAX_ALT_LENGTH = 240;
 const MAX_CAPTION_LENGTH = 600;
@@ -1041,7 +1042,7 @@ function PhotosEditorForm() {
   });
 
   if (data === undefined) {
-    return <p className="body-text text-foreground/80">Loading photos…</p>;
+    return <PhotosEditorSkeleton />;
   }
 
   const galleryPageEffective =

--- a/src/app/admin/videos/page.tsx
+++ b/src/app/admin/videos/page.tsx
@@ -1,15 +1,12 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { VideosEditorSkeleton } from "./videos-editor-skeleton";
 
 const VideosEditor = dynamic(
   () =>
     import("./videos-editor").then((m) => ({ default: m.VideosEditor })),
-  {
-    loading: () => (
-      <p className="body-text text-muted-foreground">Loading videos…</p>
-    ),
-  },
+  { loading: () => <VideosEditorSkeleton /> },
 );
 
 export const metadata: Metadata = {

--- a/src/app/admin/videos/videos-editor-skeleton.tsx
+++ b/src/app/admin/videos/videos-editor-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Gallery-shaped skeleton for videos editor (route loading + dynamic import fallback). */
+export function VideosEditorSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-3.5 w-full max-w-2xl" />
+      </div>
+      <div className="rounded-xl border border-border bg-card p-5 shadow-sm">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="h-9 w-32 rounded-md" />
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="overflow-hidden rounded-lg border border-border/70"
+            >
+              <Skeleton className="aspect-video w-full rounded-none" />
+              <div className="space-y-2 p-4">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-56" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="border-t border-border/70 pt-8">
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-9 w-28 rounded-md" />
+          <Skeleton className="h-9 w-24 rounded-md" />
+          <Skeleton className="h-9 w-36 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/videos/videos-editor.tsx
+++ b/src/app/admin/videos/videos-editor.tsx
@@ -39,7 +39,6 @@ import type { Id } from "../../../../convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import {
   AlertDialog,
@@ -66,6 +65,7 @@ import {
   resolveVideoPreview,
   type VideoProvider,
 } from "@/lib/video-embed";
+import { VideosEditorSkeleton } from "./videos-editor-skeleton";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_DESCRIPTION_LENGTH = 2000;
@@ -255,19 +255,6 @@ export function VideosEditor() {
         <VideosEditorForm />
       </Authenticated>
     </>
-  );
-}
-
-function VideosEditorSkeleton() {
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-8 w-48" />
-      <Skeleton className="h-32 w-full" />
-      <div className="grid gap-4 md:grid-cols-2">
-        <Skeleton className="h-72 w-full" />
-        <Skeleton className="h-72 w-full" />
-      </div>
-    </div>
   );
 }
 

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -18,7 +18,10 @@ import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 import { CrossSectionPendingBanner } from "@/components/admin/cross-section-pending-banner";
 import { UnsavedChangesDialog } from "@/components/admin/unsaved-changes-dialog";
 import { BeforeUnloadGuard } from "@/components/admin/before-unload-guard";
-import { usePendingDraftSections } from "@/components/admin/use-pending-drafts";
+import {
+  PendingDraftSectionsProvider,
+  usePendingDraftSections,
+} from "@/components/admin/use-pending-drafts";
 import { cn } from "@/lib/utils";
 
 /**
@@ -138,13 +141,15 @@ export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
 
   return (
     <CmsWorkspaceContext.Provider value={value}>
-      {children}
-      <BeforeUnloadGuard />
-      <UnsavedChangesDialog
-        open={confirmOpen}
-        onLeave={() => handleConfirmResult("leave")}
-        onStay={() => handleConfirmResult("stay")}
-      />
+      <PendingDraftSectionsProvider>
+        {children}
+        <BeforeUnloadGuard />
+        <UnsavedChangesDialog
+          open={confirmOpen}
+          onLeave={() => handleConfirmResult("leave")}
+          onStay={() => handleConfirmResult("stay")}
+        />
+      </PendingDraftSectionsProvider>
     </CmsWorkspaceContext.Provider>
   );
 }

--- a/src/components/admin/use-pending-drafts.ts
+++ b/src/components/admin/use-pending-drafts.ts
@@ -1,6 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import {
+  createContext,
+  createElement,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import {
@@ -15,15 +21,10 @@ export interface PendingDraftSection {
   readonly label: string;
 }
 
-/**
- * Live list of CMS surfaces that currently have a pending draft. Reads
- * `api.cms.listPendingDrafts` so the result stays in sync whenever any admin
- * editor saves / publishes / discards a draft elsewhere in the app.
- *
- * Ordering is stable across re-renders (see `PENDING_SECTION_ORDER`) so chips
- * and sidebar dots don't reshuffle while Convex subscriptions refresh.
- */
-export function usePendingDraftSections(): PendingDraftSection[] {
+const PendingDraftSectionsContext =
+  createContext<readonly PendingDraftSection[] | null>(null);
+
+function usePendingDraftSectionsSource(): readonly PendingDraftSection[] {
   const data = useQuery(api.cms.listPendingDrafts);
   return useMemo<PendingDraftSection[]>(() => {
     if (!data) return [];
@@ -33,4 +34,36 @@ export function usePendingDraftSections(): PendingDraftSection[] {
       ...PENDING_SECTION_NAV[key],
     }));
   }, [data]);
+}
+
+export function PendingDraftSectionsProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const pending = usePendingDraftSectionsSource();
+
+  return createElement(
+    PendingDraftSectionsContext.Provider,
+    { value: pending },
+    children,
+  );
+}
+
+/**
+ * Live list of CMS surfaces that currently have a pending draft. Reads
+ * `api.cms.listPendingDrafts` so the result stays in sync whenever any admin
+ * editor saves / publishes / discards a draft elsewhere in the app.
+ *
+ * Ordering is stable across re-renders (see `PENDING_SECTION_ORDER`) so chips
+ * and sidebar dots don't reshuffle while Convex subscriptions refresh.
+ */
+export function usePendingDraftSections(): readonly PendingDraftSection[] {
+  const pending = useContext(PendingDraftSectionsContext);
+  if (!pending) {
+    throw new Error(
+      "usePendingDraftSections must be used inside <PendingDraftSectionsProvider>",
+    );
+  }
+  return pending;
 }

--- a/src/lib/route-prewarm.test.ts
+++ b/src/lib/route-prewarm.test.ts
@@ -123,7 +123,7 @@ describe("prewarmAdminNavigation", () => {
     expect(prewarmQuery.mock.calls.length).toBe(0);
   });
 
-  test("prewarms pricing (section + marketing flags)", () => {
+  test("prewarms pricing (draft rows + marketing flags)", () => {
     const { client, prewarmQuery } = makeFakeClient();
     prewarmAdminNavigation(client, "/admin/pricing");
     expect(prewarmQuery.mock.calls.length).toBe(2);
@@ -135,16 +135,29 @@ describe("prewarmAdminNavigation", () => {
     expect(prewarmQuery.mock.calls.length).toBe(1);
   });
 
-  test("prewarms about (section + marketing flags)", () => {
+  test("prewarms about (section + marketing flags only)", () => {
     const { client, prewarmQuery } = makeFakeClient();
     prewarmAdminNavigation(client, "/admin/about");
     expect(prewarmQuery.mock.calls.length).toBe(2);
   });
 
-  test("prewarms audio (marketing flags only)", () => {
+  test("prewarms audio (tracks + marketing flags)", () => {
     const { client, prewarmQuery } = makeFakeClient();
     prewarmAdminNavigation(client, "/admin/audio");
-    expect(prewarmQuery.mock.calls.length).toBe(1);
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("prewarms media routes with their draft lists", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/photos");
+    prewarmAdminNavigation(client, "/admin/videos");
+    expect(prewarmQuery.mock.calls.length).toBe(2);
+  });
+
+  test("prewarms amenities data and validation", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/amenities-nearby");
+    expect(prewarmQuery.mock.calls.length).toBe(2);
   });
 });
 

--- a/src/lib/route-prewarm.ts
+++ b/src/lib/route-prewarm.ts
@@ -90,7 +90,7 @@ export function prewarmAdminNavigation(
   }
   if (href === "/admin/pricing") {
     prewarmSpecs(convex, [
-      makeRouteQuerySpec(api.cms.getSection, { section: "pricing" }),
+      makeRouteQuerySpec(api.admin.pricing.listDraft, {}),
       makeRouteQuerySpec(api.cms.listMarketingFlagsDraft, {}),
     ]);
   }
@@ -103,11 +103,36 @@ export function prewarmAdminNavigation(
   if (href === "/admin/faq") {
     prewarmSpecs(convex, [
       makeRouteQuerySpec(api.cms.getSection, { section: "faq" }),
+      makeRouteQuerySpec(api.cms.validatePublishSection, { section: "faq" }),
+    ]);
+  }
+  if (href === "/admin/amenities-nearby") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.amenitiesNearbyCms.getAdminAmenitiesNearby, {}),
+      makeRouteQuerySpec(api.cms.validatePublishSection, {
+        section: "amenitiesNearby",
+      }),
+    ]);
+  }
+  if (href === "/admin/gear") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.gear.listDraftGear, {}),
+    ]);
+  }
+  if (href === "/admin/photos") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.photos.listDraftPhotos, {}),
     ]);
   }
   if (href === "/admin/audio") {
     prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.audio.listDraftAudioTracks, {}),
       makeRouteQuerySpec(api.cms.listMarketingFlagsDraft, {}),
+    ]);
+  }
+  if (href === "/admin/videos") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.videos.listDraftVideos, {}),
     ]);
   }
 }


### PR DESCRIPTION
## Summary
- Centralize pending draft data to avoid duplicate admin subscriptions.
- Scope route prewarming to the actual admin route queries.
- Defer heavy About gallery loading until needed and add skeleton states for media admin pages.

## Test plan
- bun test src/lib/route-prewarm.test.ts
- bun run build

Stack: 2/3. Depends on INF-103.
Linear: https://linear.app/only-football-fans/issue/INF-104/lls-admin-loading-parallel-queries-tab-scoped-data

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin navigation data-flow (prewarm query set) and introduces a required provider for `usePendingDraftSections`, so incorrect wiring could cause missing preloads or runtime errors in admin UI, though changes are isolated to admin surfaces.
> 
> **Overview**
> Reduces admin-side Convex subscription churn by moving `api.cms.listPendingDrafts` behind a new `PendingDraftSectionsProvider` and making `usePendingDraftSections()` read from context (now mounted in `CmsWorkspaceProvider`).
> 
> Refines `prewarmAdminNavigation` to prewarm the *actual* draft/validation queries used by each admin route (e.g., pricing draft rows, audio/photos/videos draft lists, FAQ + amenities publish validation, gear draft list), and updates the associated tests.
> 
> Improves perceived loading in media editors by introducing shared skeleton components for Audio/Photos/Videos (used both for route dynamic-import fallback and in-editor initial load), and updates About’s hero image picker to **defer gallery list loading** until the user opens it (with a new “Browse gallery photos” action and skeleton grid while the gallery query resolves).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f206a972f77a1711d9893c8230794db10fb311. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->