### PR TITLE
Align CMS dashboard page shells

### DIFF
--- a/src/app/admin/about/loading.tsx
+++ b/src/app/admin/about/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { AboutEditorSkeleton } from "./about-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/about");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function AboutLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <AboutEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/about/page.tsx
+++ b/src/app/admin/about/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { AboutEditorSkeleton } from "./about-editor-skeleton";
 
 const AboutEditor = dynamic(
@@ -16,8 +20,8 @@ export default function AboutPage() {
   return (
     <>
       <AdminHeader title="About" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-6xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <AboutEditor />
         </div>
       </div>

--- a/src/app/admin/amenities-nearby/loading.tsx
+++ b/src/app/admin/amenities-nearby/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { AmenitiesEditorSkeleton } from "./amenities-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/amenities-nearby");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function AmenitiesNearbyLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <AmenitiesEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/amenities-nearby/page.tsx
+++ b/src/app/admin/amenities-nearby/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { AmenitiesEditorSkeleton } from "./amenities-editor-skeleton";
 
 const AmenitiesEditor = dynamic(
@@ -17,8 +21,8 @@ export default function AmenitiesNearbyAdminPage() {
   return (
     <>
       <AdminHeader title="Amenities nearby" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-3xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <AmenitiesEditor />
         </div>
       </div>

--- a/src/app/admin/audio/loading.tsx
+++ b/src/app/admin/audio/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { AudioEditorSkeleton } from "./audio-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/audio");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function AudioLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <AudioEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/audio/page.tsx
+++ b/src/app/admin/audio/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { AudioEditorSkeleton } from "./audio-editor-skeleton";
 
 const AudioEditor = dynamic(
@@ -16,8 +20,8 @@ export default function AudioPage() {
   return (
     <>
       <AdminHeader title="Audio" />
-      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
-        <div className="mx-auto max-w-5xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <AudioEditor />
         </div>
       </div>

--- a/src/app/admin/faq/loading.tsx
+++ b/src/app/admin/faq/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { FaqEditorSkeleton } from "./faq-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/faq");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function FaqLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <FaqEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/faq/page.tsx
+++ b/src/app/admin/faq/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { FaqEditorSkeleton } from "./faq-editor-skeleton";
 
 const FaqEditor = dynamic(
@@ -16,8 +20,8 @@ export default function AdminFaqPage() {
   return (
     <>
       <AdminHeader title="FAQ" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-3xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <FaqEditor />
         </div>
       </div>

--- a/src/app/admin/gear/loading.tsx
+++ b/src/app/admin/gear/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { GearEditorSkeleton } from "./gear-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/gear");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function GearLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <GearEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/gear/page.tsx
+++ b/src/app/admin/gear/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { GearEditorSkeleton } from "./gear-editor-skeleton";
 
 const GearEditor = dynamic(
@@ -16,8 +20,8 @@ export default function GearPage() {
   return (
     <>
       <AdminHeader title="Gear" />
-      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
-        <div className="mx-auto max-w-4xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <GearEditor />
         </div>
       </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AdminSidebar } from "@/components/admin/admin-sidebar";
 import {
   CmsWorkspaceProvider,
+  CmsAdminPageSlot,
   CmsPersistentToolbarHost,
 } from "@/components/admin/cms-workspace";
 import {
@@ -43,7 +44,7 @@ export default async function AdminLayout({
         <CmsWorkspaceProvider>
           <AdminSidebar />
           <SidebarInset className="text-foreground">
-            {children}
+            <CmsAdminPageSlot>{children}</CmsAdminPageSlot>
             <CmsPersistentToolbarHost />
           </SidebarInset>
         </CmsWorkspaceProvider>

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,40 +1,21 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
+import { AdminDashboardLoadingSkeleton } from "@/components/admin/admin-dashboard-loading-skeleton";
+import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
+
+const layout = getAdminPendingLayout("/admin");
 
 /**
- * Instant feedback during admin route transitions (equivalent to lawn's
- * defaultPendingComponent). Layout (sidebar) stays mounted; this replaces the page slot.
+ * Dashboard route loading: welcome + manage grid shell (not editor-shaped).
+ * Section routes use their own segment `loading.tsx` files for editor-matched skeletons.
  */
 export default function AdminLoading() {
   return (
-    <>
-      <header className="flex h-14 shrink-0 items-center gap-3 border-b border-sidebar-border bg-background px-4">
-        <Skeleton className="size-8 rounded-md" />
-        <Skeleton className="h-4 w-32" />
-        <div className="ml-auto flex items-center gap-2">
-          <Skeleton className="size-8 rounded-md" />
-          <Skeleton className="size-8 rounded-full" />
-        </div>
-      </header>
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-4xl space-y-6">
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-3 w-64 max-w-full" />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="rounded-lg border border-border/60 bg-muted/20 p-5"
-              >
-                <Skeleton className="mb-3 size-9 rounded-md" />
-                <Skeleton className="mb-2 h-4 w-24" />
-                <Skeleton className="h-3 w-full max-w-[12rem]" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </>
+    <AdminSectionLoadingFrame
+      title={layout.title}
+      outerClassName={layout.outerClassName}
+      innerClassName={layout.innerClassName}
+    >
+      <AdminDashboardLoadingSkeleton />
+    </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,9 @@
-import Link from "next/link";
 import { AdminHeader } from "@/components/admin/admin-header";
-import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
+import { AdminDashboardNavCards } from "@/components/admin/admin-dashboard-nav-cards";
+import {
+  ADMIN_DASHBOARD_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 
 export const revalidate = 300;
 
@@ -8,8 +11,8 @@ export default function DashboardPage() {
   return (
     <>
       <AdminHeader title="Dashboard" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-4xl space-y-8">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_DASHBOARD_INNER_CLASS}>
           <div>
             <h2 className="headline-secondary text-foreground text-lg mb-1">
               Welcome back
@@ -19,25 +22,7 @@ export default function DashboardPage() {
             </p>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {ADMIN_MANAGE_NAV_ITEMS.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="group rounded-lg border border-border bg-card p-5 transition-all hover:border-border hover:bg-muted/60"
-              >
-                <div className="mb-3 flex size-9 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors group-hover:bg-accent group-hover:text-foreground">
-                  <item.icon className="size-4" />
-                </div>
-                <h3 className="headline-secondary text-foreground text-sm mb-1">
-                  {item.title}
-                </h3>
-                <p className="body-text-small text-muted-foreground">
-                  {item.description}
-                </p>
-              </Link>
-            ))}
-          </div>
+          <AdminDashboardNavCards />
         </div>
       </div>
     </>

--- a/src/app/admin/photos/loading.tsx
+++ b/src/app/admin/photos/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { PhotosEditorSkeleton } from "./photos-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/photos");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function PhotosLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <PhotosEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { PhotosEditorSkeleton } from "./photos-editor-skeleton";
 
 const PhotosEditor = dynamic(
@@ -16,8 +20,8 @@ export default function PhotosPage() {
   return (
     <>
       <AdminHeader title="Photos" />
-      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
-        <div className="mx-auto max-w-5xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <PhotosEditor />
         </div>
       </div>

--- a/src/app/admin/pricing/loading.tsx
+++ b/src/app/admin/pricing/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { PricingEditorSkeleton } from "./pricing-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/pricing");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function PricingLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <PricingEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/pricing/page.tsx
+++ b/src/app/admin/pricing/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { PricingEditorSkeleton } from "./pricing-editor-skeleton";
 
 const PricingEditor = dynamic(
@@ -17,8 +21,8 @@ export default function PricingPage() {
   return (
     <>
       <AdminHeader title="Pricing" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-3xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <PricingEditor />
         </div>
       </div>

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,6 +1,10 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
 
 const SettingsEditor = dynamic(
@@ -17,8 +21,8 @@ export default function SettingsPage() {
   return (
     <>
       <AdminHeader title="Settings" />
-      <div className="flex-1 p-6">
-        <div className="mx-auto max-w-3xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <SettingsEditor />
         </div>
       </div>

--- a/src/app/admin/videos/loading.tsx
+++ b/src/app/admin/videos/loading.tsx
@@ -1,18 +1,17 @@
 import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
-import { SettingsEditorSkeleton } from "./settings-editor-skeleton";
+import { VideosEditorSkeleton } from "./videos-editor-skeleton";
 import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
 
-const layout = getAdminPendingLayout("/admin/settings");
+const layout = getAdminPendingLayout("/admin/videos");
 
-/** Settings route: form-shaped skeleton while RSC + Convex section loads. */
-export default function SettingsLoading() {
+export default function VideosLoading() {
   return (
     <AdminSectionLoadingFrame
       title={layout.title}
       outerClassName={layout.outerClassName}
       innerClassName={layout.innerClassName}
     >
-      <SettingsEditorSkeleton />
+      <VideosEditorSkeleton />
     </AdminSectionLoadingFrame>
   );
 }

--- a/src/app/admin/videos/page.tsx
+++ b/src/app/admin/videos/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
 import { VideosEditorSkeleton } from "./videos-editor-skeleton";
 
 const VideosEditor = dynamic(
@@ -17,8 +21,8 @@ export default function VideosPage() {
   return (
     <>
       <AdminHeader title="Videos" />
-      <div className="flex-1 px-5 py-8 pb-12 sm:px-8">
-        <div className="mx-auto max-w-5xl">
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={ADMIN_PAGE_INNER_CLASS}>
           <VideosEditor />
         </div>
       </div>

--- a/src/components/admin/admin-dashboard-loading-skeleton.tsx
+++ b/src/components/admin/admin-dashboard-loading-skeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Matches the dashboard welcome block + manage grid on `/admin`. */
+export function AdminDashboardLoadingSkeleton() {
+  return (
+    <>
+      <div>
+        <Skeleton className="mb-1 h-6 w-40" />
+        <Skeleton className="h-3.5 w-80 max-w-full" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-lg border border-border/60 bg-muted/20 p-5"
+          >
+            <Skeleton className="mb-3 size-9 rounded-md" />
+            <Skeleton className="mb-2 h-4 w-28" />
+            <Skeleton className="h-3 w-full max-w-[12rem]" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/admin-dashboard-nav-cards.tsx
+++ b/src/components/admin/admin-dashboard-nav-cards.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useConvex } from "convex/react";
+import { useRouter } from "next/navigation";
+import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
+import {
+  useCmsNavGuard,
+  useCmsAdminNavigation,
+} from "@/components/admin/cms-workspace";
+import {
+  prewarmAdminNavigation,
+  useRoutePrewarmIntent,
+} from "@/lib/route-prewarm";
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+function DashboardNavCard({
+  item,
+  activeHref,
+}: {
+  item: (typeof ADMIN_MANAGE_NAV_ITEMS)[number];
+  activeHref: string;
+}) {
+  const convex = useConvex();
+  const router = useRouter();
+  const { attemptNavigate } = useCmsNavGuard();
+  const { navigateWithinCms } = useCmsAdminNavigation();
+  const { handlers: prewarmHandlers, intentRootRef } = useRoutePrewarmIntent(
+    () => {
+      router.prefetch(item.href);
+      prewarmAdminNavigation(convex, item.href);
+    },
+  );
+
+  function isActive(href: string) {
+    return activeHref.startsWith(href);
+  }
+
+  async function handleClick(event: ReactMouseEvent<HTMLAnchorElement>) {
+    if (isActive(item.href)) return;
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const ok = await attemptNavigate();
+    if (ok) navigateWithinCms(item.href);
+  }
+
+  return (
+    <Link
+      ref={intentRootRef}
+      href={item.href}
+      onClick={handleClick}
+      {...prewarmHandlers}
+      className="group rounded-lg border border-border bg-card p-5 transition-all hover:border-border hover:bg-muted/60"
+    >
+      <div className="mb-3 flex size-9 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors group-hover:bg-accent group-hover:text-foreground">
+        <item.icon className="size-4" />
+      </div>
+      <h3 className="headline-secondary text-foreground text-sm mb-1">
+        {item.title}
+      </h3>
+      <p className="body-text-small text-muted-foreground">{item.description}</p>
+    </Link>
+  );
+}
+
+export function AdminDashboardNavCards() {
+  const { activeAdminHref } = useCmsAdminNavigation();
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {ADMIN_MANAGE_NAV_ITEMS.map((item) => (
+        <DashboardNavCard
+          key={item.href}
+          item={item}
+          activeHref={activeAdminHref}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/admin/admin-route-pending-shell.tsx
+++ b/src/components/admin/admin-route-pending-shell.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminDashboardLoadingSkeleton } from "@/components/admin/admin-dashboard-loading-skeleton";
+import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
+import { AboutEditorSkeleton } from "@/app/admin/about/about-editor-skeleton";
+import { PhotosEditorSkeleton } from "@/app/admin/photos/photos-editor-skeleton";
+import { GearEditorSkeleton } from "@/app/admin/gear/gear-editor-skeleton";
+import { AudioEditorSkeleton } from "@/app/admin/audio/audio-editor-skeleton";
+import { PricingEditorSkeleton } from "@/app/admin/pricing/pricing-editor-skeleton";
+import { AmenitiesEditorSkeleton } from "@/app/admin/amenities-nearby/amenities-editor-skeleton";
+import { FaqEditorSkeleton } from "@/app/admin/faq/faq-editor-skeleton";
+import { VideosEditorSkeleton } from "@/app/admin/videos/videos-editor-skeleton";
+import { SettingsEditorSkeleton } from "@/app/admin/settings/settings-editor-skeleton";
+
+const BODY_BY_PREFIX: { prefix: string; Body: ComponentType }[] = [
+  { prefix: "/admin/settings", Body: SettingsEditorSkeleton },
+  { prefix: "/admin/videos", Body: VideosEditorSkeleton },
+  { prefix: "/admin/faq", Body: FaqEditorSkeleton },
+  { prefix: "/admin/amenities-nearby", Body: AmenitiesEditorSkeleton },
+  { prefix: "/admin/pricing", Body: PricingEditorSkeleton },
+  { prefix: "/admin/audio", Body: AudioEditorSkeleton },
+  { prefix: "/admin/gear", Body: GearEditorSkeleton },
+  { prefix: "/admin/photos", Body: PhotosEditorSkeleton },
+  { prefix: "/admin/about", Body: AboutEditorSkeleton },
+];
+
+function resolveBody(path: string): ComponentType {
+  const normalized = path.split("?")[0]?.split("#")[0] || "/admin";
+  if (normalized === "/admin") {
+    return AdminDashboardLoadingSkeleton;
+  }
+  for (const { prefix, Body } of BODY_BY_PREFIX) {
+    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
+      return Body;
+    }
+  }
+  if (normalized.startsWith("/admin")) {
+    return AdminDashboardLoadingSkeleton;
+  }
+  return AdminDashboardLoadingSkeleton;
+}
+
+/**
+ * Full-page pending UI for a target admin href: real header + page shell +
+ * section-specific editor skeleton (or dashboard grid skeleton for `/admin`).
+ */
+export function AdminRoutePendingShell({ targetHref }: { targetHref: string }) {
+  const { title, outerClassName, innerClassName } =
+    getAdminPendingLayout(targetHref);
+  const Body = resolveBody(targetHref.split("?")[0]?.split("#")[0] || "/admin");
+
+  return (
+    <>
+      <AdminHeader title={title} />
+      <div className={outerClassName}>
+        <div className={innerClassName}>
+          <Body />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/admin-route-pending-shell.tsx
+++ b/src/components/admin/admin-route-pending-shell.tsx
@@ -1,46 +1,10 @@
 "use client";
 
-import type { ComponentType } from "react";
 import { AdminHeader } from "@/components/admin/admin-header";
-import { AdminDashboardLoadingSkeleton } from "@/components/admin/admin-dashboard-loading-skeleton";
-import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
-import { AboutEditorSkeleton } from "@/app/admin/about/about-editor-skeleton";
-import { PhotosEditorSkeleton } from "@/app/admin/photos/photos-editor-skeleton";
-import { GearEditorSkeleton } from "@/app/admin/gear/gear-editor-skeleton";
-import { AudioEditorSkeleton } from "@/app/admin/audio/audio-editor-skeleton";
-import { PricingEditorSkeleton } from "@/app/admin/pricing/pricing-editor-skeleton";
-import { AmenitiesEditorSkeleton } from "@/app/admin/amenities-nearby/amenities-editor-skeleton";
-import { FaqEditorSkeleton } from "@/app/admin/faq/faq-editor-skeleton";
-import { VideosEditorSkeleton } from "@/app/admin/videos/videos-editor-skeleton";
-import { SettingsEditorSkeleton } from "@/app/admin/settings/settings-editor-skeleton";
-
-const BODY_BY_PREFIX: { prefix: string; Body: ComponentType }[] = [
-  { prefix: "/admin/settings", Body: SettingsEditorSkeleton },
-  { prefix: "/admin/videos", Body: VideosEditorSkeleton },
-  { prefix: "/admin/faq", Body: FaqEditorSkeleton },
-  { prefix: "/admin/amenities-nearby", Body: AmenitiesEditorSkeleton },
-  { prefix: "/admin/pricing", Body: PricingEditorSkeleton },
-  { prefix: "/admin/audio", Body: AudioEditorSkeleton },
-  { prefix: "/admin/gear", Body: GearEditorSkeleton },
-  { prefix: "/admin/photos", Body: PhotosEditorSkeleton },
-  { prefix: "/admin/about", Body: AboutEditorSkeleton },
-];
-
-function resolveBody(path: string): ComponentType {
-  const normalized = path.split("?")[0]?.split("#")[0] || "/admin";
-  if (normalized === "/admin") {
-    return AdminDashboardLoadingSkeleton;
-  }
-  for (const { prefix, Body } of BODY_BY_PREFIX) {
-    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
-      return Body;
-    }
-  }
-  if (normalized.startsWith("/admin")) {
-    return AdminDashboardLoadingSkeleton;
-  }
-  return AdminDashboardLoadingSkeleton;
-}
+import {
+  getAdminPendingBody,
+  getAdminPendingLayout,
+} from "@/lib/admin-pending-layout";
 
 /**
  * Full-page pending UI for a target admin href: real header + page shell +
@@ -49,7 +13,9 @@ function resolveBody(path: string): ComponentType {
 export function AdminRoutePendingShell({ targetHref }: { targetHref: string }) {
   const { title, outerClassName, innerClassName } =
     getAdminPendingLayout(targetHref);
-  const Body = resolveBody(targetHref.split("?")[0]?.split("#")[0] || "/admin");
+  const Body = getAdminPendingBody(
+    targetHref.split("?")[0]?.split("#")[0] || "/admin",
+  );
 
   return (
     <>

--- a/src/components/admin/admin-section-loading-frame.tsx
+++ b/src/components/admin/admin-section-loading-frame.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { AdminHeader } from "@/components/admin/admin-header";
+
+export function AdminSectionLoadingFrame({
+  title,
+  outerClassName,
+  innerClassName,
+  children,
+}: {
+  readonly title: string;
+  readonly outerClassName: string;
+  readonly innerClassName: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <>
+      <AdminHeader title={title} />
+      <div className={outerClassName}>
+        <div className={innerClassName}>{children}</div>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useConvex } from "convex/react";
 import { LayoutDashboard, ArrowLeft } from "lucide-react";
 import { ADMIN_MANAGE_NAV_ITEMS } from "@/lib/admin-nav";
@@ -22,7 +22,10 @@ import {
   prewarmAdminNavigation,
   useRoutePrewarmIntent,
 } from "@/lib/route-prewarm";
-import { useCmsNavGuard } from "@/components/admin/cms-workspace";
+import {
+  useCmsNavGuard,
+  useCmsAdminNavigation,
+} from "@/components/admin/cms-workspace";
 import { usePendingDraftSections } from "@/components/admin/use-pending-drafts";
 import { useMemo, type MouseEvent as ReactMouseEvent } from "react";
 
@@ -33,23 +36,27 @@ const navItems = [
 
 function AdminNavLinkItem({
   item,
-  pathname,
+  activeHref,
   hasPendingChanges,
 }: {
   item: (typeof navItems)[number];
-  pathname: string;
+  activeHref: string;
   hasPendingChanges: boolean;
 }) {
   const convex = useConvex();
   const router = useRouter();
   const { attemptNavigate } = useCmsNavGuard();
+  const { navigateWithinCms } = useCmsAdminNavigation();
   const { handlers: prewarmHandlers, intentRootRef } = useRoutePrewarmIntent(
-    () => prewarmAdminNavigation(convex, item.href),
+    () => {
+      router.prefetch(item.href);
+      prewarmAdminNavigation(convex, item.href);
+    },
   );
 
   function isActive(href: string) {
-    if (href === "/admin") return pathname === "/admin";
-    return pathname.startsWith(href);
+    if (href === "/admin") return activeHref === "/admin";
+    return activeHref.startsWith(href);
   }
 
   async function handleClick(event: ReactMouseEvent<HTMLAnchorElement>) {
@@ -68,7 +75,7 @@ function AdminNavLinkItem({
     }
     event.preventDefault();
     const ok = await attemptNavigate();
-    if (ok) router.push(item.href);
+    if (ok) navigateWithinCms(item.href);
   }
 
   const tooltipLabel = hasPendingChanges
@@ -141,7 +148,7 @@ function BackToSiteLink() {
 }
 
 export function AdminSidebar() {
-  const pathname = usePathname();
+  const { activeAdminHref } = useCmsAdminNavigation();
   const pending = usePendingDraftSections();
   const pendingHrefs = useMemo(
     () => new Set(pending.map((section) => section.href)),
@@ -190,7 +197,7 @@ export function AdminSidebar() {
                 <AdminNavLinkItem
                   key={item.href}
                   item={item}
-                  pathname={pathname}
+                  activeHref={activeAdminHref}
                   hasPendingChanges={pendingHrefs.has(item.href)}
                 />
               ))}

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -192,12 +192,20 @@ export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (
-      prevPathname !== pathname &&
-      !isRouteTransitionPending &&
-      !pathMatchesPending(pathname, pendingNavigationHref)
-    ) {
-      setPendingNavigationHref(null);
+    if (!isRouteTransitionPending) {
+      if (
+        prevPathname !== pathname &&
+        !pathMatchesPending(pathname, pendingNavigationHref)
+      ) {
+        setPendingNavigationHref(null);
+        return;
+      }
+      if (
+        prevPathname === pathname &&
+        !pathMatchesPending(pathname, pendingNavigationHref)
+      ) {
+        setPendingNavigationHref(null);
+      }
     }
   }, [pathname, pendingNavigationHref, isRouteTransitionPending]);
 

--- a/src/components/admin/cms-workspace.tsx
+++ b/src/components/admin/cms-workspace.tsx
@@ -4,15 +4,18 @@ import {
   createContext,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  useTransition,
   type MutableRefObject,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { AdminRoutePendingShell } from "@/components/admin/admin-route-pending-shell";
 import type { AutosaveStatus } from "@/components/admin/cms-publish-toolbar";
 import { CmsPublishToolbar } from "@/components/admin/cms-publish-toolbar";
 import { CrossSectionPendingBanner } from "@/components/admin/cross-section-pending-banner";
@@ -72,6 +75,20 @@ interface CmsWorkspaceContextValue {
   readonly activeEditorMountRef: MutableRefObject<unknown>;
   readonly attemptNavigate: () => Promise<boolean>;
   readonly openConfirm: () => Promise<ConfirmResult>;
+  /** After nav guard passes, moves URL and shows optimistic active + skeleton until the route lands. */
+  readonly navigateWithinCms: (href: string) => void;
+  /** Sidebar highlight: pending target until pathname catches up, else current path. */
+  readonly activeAdminHref: string;
+  /** True while optimistic target differs from current pathname (client transition in flight). */
+  readonly routePending: boolean;
+  /** In-flight client navigation target (null when not optimistically navigating). */
+  readonly pendingNavigationHref: string | null;
+}
+
+export function pathMatchesPending(pathname: string, pending: string): boolean {
+  const p = pathname || "";
+  if (pending === "/admin") return p === "/admin";
+  return p === pending || p.startsWith(`${pending}/`);
 }
 
 const CmsWorkspaceContext = createContext<CmsWorkspaceContextValue | null>(
@@ -86,6 +103,13 @@ const CmsWorkspaceContext = createContext<CmsWorkspaceContextValue | null>(
  * if we notified subscribers from the editor's render body.
  */
 export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
+  const [isRouteTransitionPending, startTransition] = useTransition();
+  const [pendingNavigationHref, setPendingNavigationHref] = useState<
+    string | null
+  >(null);
+
   const [hostNode, setHostNode] = useState<HTMLDivElement | null>(null);
   const navStateRef = useRef<CmsNavState>({ hasLocalEdits: false });
   const activeEditorMountRef = useRef<unknown>(null);
@@ -127,6 +151,56 @@ export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
     return result === "leave";
   }, [openConfirm]);
 
+  const navigateWithinCms = useCallback(
+    (href: string) => {
+      setPendingNavigationHref(href);
+      startTransition(() => {
+        router.push(href);
+      });
+    },
+    [router],
+  );
+
+  const activeAdminHref = useMemo(() => {
+    if (
+      pendingNavigationHref &&
+      !pathMatchesPending(pathname, pendingNavigationHref)
+    ) {
+      return pendingNavigationHref;
+    }
+    return pathname;
+  }, [pathname, pendingNavigationHref]);
+
+  const routePending = useMemo(
+    () =>
+      Boolean(
+        pendingNavigationHref &&
+          !pathMatchesPending(pathname, pendingNavigationHref),
+      ),
+    [pathname, pendingNavigationHref],
+  );
+
+  const prevPathnameRef = useRef(pathname);
+  useLayoutEffect(() => {
+    const prevPathname = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    if (!pendingNavigationHref) return;
+
+    if (pathMatchesPending(pathname, pendingNavigationHref)) {
+      setPendingNavigationHref(null);
+      return;
+    }
+
+    if (
+      prevPathname !== pathname &&
+      !isRouteTransitionPending &&
+      !pathMatchesPending(pathname, pendingNavigationHref)
+    ) {
+      setPendingNavigationHref(null);
+    }
+  }, [pathname, pendingNavigationHref, isRouteTransitionPending]);
+
   const value = useMemo<CmsWorkspaceContextValue>(
     () => ({
       hostNode,
@@ -135,8 +209,21 @@ export function CmsWorkspaceProvider({ children }: { children: ReactNode }) {
       activeEditorMountRef,
       attemptNavigate,
       openConfirm,
+      navigateWithinCms,
+      activeAdminHref,
+      routePending,
+      pendingNavigationHref,
     }),
-    [hostNode, registerHostNode, attemptNavigate, openConfirm],
+    [
+      hostNode,
+      registerHostNode,
+      attemptNavigate,
+      openConfirm,
+      navigateWithinCms,
+      activeAdminHref,
+      routePending,
+      pendingNavigationHref,
+    ],
   );
 
   return (
@@ -174,6 +261,32 @@ export function useCmsNavGuard(): {
 } {
   const { attemptNavigate } = useCmsWorkspace();
   return { attemptNavigate };
+}
+
+/**
+ * Optimistic admin in-app navigation + tab highlighting for sidebar and dashboard cards.
+ */
+export function useCmsAdminNavigation(): {
+  readonly navigateWithinCms: (href: string) => void;
+  readonly activeAdminHref: string;
+  readonly routePending: boolean;
+} {
+  const { navigateWithinCms, activeAdminHref, routePending } = useCmsWorkspace();
+  return { navigateWithinCms, activeAdminHref, routePending };
+}
+
+/**
+ * Swaps the admin page slot to a skeleton during client-side navigations so the
+ * UI does not keep showing the previous editor until RSC payload arrives.
+ */
+export function CmsAdminPageSlot({ children }: { children: ReactNode }) {
+  const { routePending, pendingNavigationHref } = useCmsWorkspace();
+  if (routePending && pendingNavigationHref) {
+    return (
+      <AdminRoutePendingShell targetHref={pendingNavigationHref} />
+    );
+  }
+  return children;
 }
 
 /**

--- a/src/lib/admin-pending-layout.ts
+++ b/src/lib/admin-pending-layout.ts
@@ -1,0 +1,86 @@
+/** Shared layout shell classes for admin CMS pages and their loading states. */
+export const ADMIN_PAGE_OUTER_CLASS = "flex-1 px-5 py-8 pb-12 sm:px-8";
+export const ADMIN_PAGE_INNER_CLASS = "mx-auto max-w-6xl";
+export const ADMIN_DASHBOARD_INNER_CLASS = `${ADMIN_PAGE_INNER_CLASS} space-y-8`;
+
+/** Layout shell for admin route loading / optimistic navigation (matches each page.tsx wrapper). */
+export type AdminPendingLayout = {
+  readonly title: string;
+  readonly outerClassName: string;
+  readonly innerClassName: string;
+};
+
+const LAYOUTS = {
+  "/admin": {
+    title: "Dashboard",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_DASHBOARD_INNER_CLASS,
+  },
+  "/admin/about": {
+    title: "About",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/photos": {
+    title: "Photos",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/gear": {
+    title: "Gear",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/audio": {
+    title: "Audio",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/pricing": {
+    title: "Pricing",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/amenities-nearby": {
+    title: "Amenities nearby",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/faq": {
+    title: "FAQ",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/videos": {
+    title: "Videos",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+  "/admin/settings": {
+    title: "Settings",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+  },
+} as const satisfies Record<string, AdminPendingLayout>;
+
+const ENTRIES = Object.entries(LAYOUTS) as [string, AdminPendingLayout][];
+
+/**
+ * Resolve layout metadata for an admin href (pathname or full URL without hash).
+ * Unknown `/admin/*` paths fall back to the dashboard layout.
+ */
+export function getAdminPendingLayout(pathOrHref: string): AdminPendingLayout {
+  const path = (pathOrHref.split("?")[0] ?? "").split("#")[0] || "/admin";
+
+  const exact = LAYOUTS[path as keyof typeof LAYOUTS];
+  if (exact) return exact;
+
+  for (const [prefix, layout] of ENTRIES) {
+    if (prefix === "/admin") continue;
+    if (path === prefix || path.startsWith(`${prefix}/`)) return layout;
+  }
+
+  if (path.startsWith("/admin")) return LAYOUTS["/admin"];
+
+  return LAYOUTS["/admin"];
+}

--- a/src/lib/admin-pending-layout.ts
+++ b/src/lib/admin-pending-layout.ts
@@ -1,3 +1,15 @@
+import type { ComponentType } from "react";
+import { AdminDashboardLoadingSkeleton } from "@/components/admin/admin-dashboard-loading-skeleton";
+import { AboutEditorSkeleton } from "@/app/admin/about/about-editor-skeleton";
+import { PhotosEditorSkeleton } from "@/app/admin/photos/photos-editor-skeleton";
+import { GearEditorSkeleton } from "@/app/admin/gear/gear-editor-skeleton";
+import { AudioEditorSkeleton } from "@/app/admin/audio/audio-editor-skeleton";
+import { PricingEditorSkeleton } from "@/app/admin/pricing/pricing-editor-skeleton";
+import { AmenitiesEditorSkeleton } from "@/app/admin/amenities-nearby/amenities-editor-skeleton";
+import { FaqEditorSkeleton } from "@/app/admin/faq/faq-editor-skeleton";
+import { VideosEditorSkeleton } from "@/app/admin/videos/videos-editor-skeleton";
+import { SettingsEditorSkeleton } from "@/app/admin/settings/settings-editor-skeleton";
+
 /** Shared layout shell classes for admin CMS pages and their loading states. */
 export const ADMIN_PAGE_OUTER_CLASS = "flex-1 px-5 py-8 pb-12 sm:px-8";
 export const ADMIN_PAGE_INNER_CLASS = "mx-auto max-w-6xl";
@@ -10,77 +22,109 @@ export type AdminPendingLayout = {
   readonly innerClassName: string;
 };
 
-const LAYOUTS = {
+type AdminPendingRouteEntry = AdminPendingLayout & {
+  readonly Body: ComponentType;
+};
+
+const ROUTES = {
   "/admin": {
     title: "Dashboard",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_DASHBOARD_INNER_CLASS,
+    Body: AdminDashboardLoadingSkeleton,
   },
   "/admin/about": {
     title: "About",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: AboutEditorSkeleton,
   },
   "/admin/photos": {
     title: "Photos",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: PhotosEditorSkeleton,
   },
   "/admin/gear": {
     title: "Gear",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: GearEditorSkeleton,
   },
   "/admin/audio": {
     title: "Audio",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: AudioEditorSkeleton,
   },
   "/admin/pricing": {
     title: "Pricing",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: PricingEditorSkeleton,
   },
   "/admin/amenities-nearby": {
     title: "Amenities nearby",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: AmenitiesEditorSkeleton,
   },
   "/admin/faq": {
     title: "FAQ",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: FaqEditorSkeleton,
   },
   "/admin/videos": {
     title: "Videos",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: VideosEditorSkeleton,
   },
   "/admin/settings": {
     title: "Settings",
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: SettingsEditorSkeleton,
   },
-} as const satisfies Record<string, AdminPendingLayout>;
+} as const satisfies Record<string, AdminPendingRouteEntry>;
 
-const ENTRIES = Object.entries(LAYOUTS) as [string, AdminPendingLayout][];
+const ENTRIES = Object.entries(ROUTES) as [string, AdminPendingRouteEntry][];
+
+function normalizePath(pathOrHref: string): string {
+  return (pathOrHref.split("?")[0] ?? "").split("#")[0] || "/admin";
+}
+
+function resolveAdminPendingRoute(pathOrHref: string): AdminPendingRouteEntry {
+  const path = normalizePath(pathOrHref);
+
+  const exact = ROUTES[path as keyof typeof ROUTES];
+  if (exact) return exact;
+
+  for (const [prefix, entry] of ENTRIES) {
+    if (prefix === "/admin") continue;
+    if (path === prefix || path.startsWith(`${prefix}/`)) return entry;
+  }
+
+  if (path.startsWith("/admin")) return ROUTES["/admin"];
+
+  return ROUTES["/admin"];
+}
 
 /**
  * Resolve layout metadata for an admin href (pathname or full URL without hash).
  * Unknown `/admin/*` paths fall back to the dashboard layout.
  */
 export function getAdminPendingLayout(pathOrHref: string): AdminPendingLayout {
-  const path = (pathOrHref.split("?")[0] ?? "").split("#")[0] || "/admin";
+  const entry = resolveAdminPendingRoute(pathOrHref);
+  return {
+    title: entry.title,
+    outerClassName: entry.outerClassName,
+    innerClassName: entry.innerClassName,
+  };
+}
 
-  const exact = LAYOUTS[path as keyof typeof LAYOUTS];
-  if (exact) return exact;
-
-  for (const [prefix, layout] of ENTRIES) {
-    if (prefix === "/admin") continue;
-    if (path === prefix || path.startsWith(`${prefix}/`)) return layout;
-  }
-
-  if (path.startsWith("/admin")) return LAYOUTS["/admin"];
-
-  return LAYOUTS["/admin"];
+/** Skeleton component for optimistic navigation / loading for the given admin path. */
+export function getAdminPendingBody(pathOrHref: string): ComponentType {
+  return resolveAdminPendingRoute(pathOrHref).Body;
 }


### PR DESCRIPTION
## Summary
- Normalize CMS admin page width and padding through shared layout constants.
- Add route-specific loading shells and pending navigation skeletons that match each admin section.
- Move dashboard navigation cards into a reusable client component for guarded in-app navigation.

## Test plan
- bun run lint


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core admin navigation/rendering behavior (optimistic routing, pending UI, active state), so regressions could manifest as incorrect skeletons, stuck pending states, or broken link handling; changes are UI/UX-focused with no auth/data mutations.
> 
> **Overview**
> Normalizes CMS admin page shells by centralizing padding/width classnames in `admin-pending-layout` and updating the dashboard and all editor pages to use those shared constants.
> 
> Adds route-specific `loading.tsx` for multiple admin sections plus a reusable `AdminSectionLoadingFrame`, and introduces an optimistic navigation flow (`useCmsAdminNavigation`, `CmsAdminPageSlot`, `AdminRoutePendingShell`) that swaps the page slot to the correct section skeleton during client-side transitions while keeping sidebar highlighting in sync.
> 
> Refactors the dashboard “manage” grid into `AdminDashboardNavCards`, and updates sidebar/dashboard links to prefetch routes, prewarm Convex queries, and navigate via the new guarded in-app navigation API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92fcbc7df1a793019992adbf6354b7e6adae3f9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->