### PR TITLE
fix(cms): preview routes no-store headers + docs (INF-107)

### DIFF
--- a/docs/cms-preview.md
+++ b/docs/cms-preview.md
@@ -1,7 +1,64 @@
+# CMS preview (owner session + cache safety)
+
+This file combines the **ADR for preview delivery** (INF-68) with **operational
+notes for caching and Vercel** (INF-107).
+
+---
+
+## Caching, CDN, and draft leakage (INF-107)
+
+### Goal
+
+Preview HTML and RSC payloads must **never** be treated as publicly cacheable at
+the edge. If they were, a shared cache could theoretically serve one owner’s
+draft HTML to another visitor.
+
+### What the app does
+
+| Layer | Behavior |
+|-------|----------|
+| **`src/app/preview/layout.tsx`** | `export const dynamic = "force-dynamic"` so the segment opts out of static rendering and full route cache. |
+| **`next.config.ts` → `headers()`** | For `/preview` and `/preview/:path*`, sets `Cache-Control`, `CDN-Cache-Control`, and `Vercel-CDN-Cache-Control` to the value in `src/lib/preview-cache-headers.ts` (`private, no-cache, no-store, max-age=0, must-revalidate`). This applies to **every** response on those paths, including Clerk **`auth.protect()` redirects** from `src/middleware.ts`, which would not inherit layout segment cache rules. |
+| **Convex** | Draft reads stay owner-gated in preview queries; published site uses separate published-scope reads. |
+
+### `VERCEL_ENV` on Vercel
+
+| Value | Typical URL | Meaning |
+|-------|-------------|---------|
+| `production` | Production domain (e.g. custom domain or `*.vercel.app` production alias) | Production deployment. |
+| `preview` | Git branch / PR preview URLs (`*.vercel.app` without production assignment) | Preview deployment — **not** the same as the `/preview` **route** in this app. |
+| `development` | `next dev` locally | Local only. |
+
+`VERCEL_ENV === "preview"` means “this **deployment** is a Vercel preview,” not
+“the request path is `/preview`.” The CMS owner preview **route** is always
+under `/preview` on whichever deployment you open.
+
+**Gotcha:** Do not rely on `VERCEL_ENV` alone to decide whether to serve draft
+content. Draft vs published is enforced by **Clerk + Convex** on `/preview/*`.
+Use cache headers + dynamic rendering so draft HTML is not CDN-cached as
+public static assets.
+
+### Manual verification (production or any deployment)
+
+After signing in as the owner and loading a draft preview, anonymous users
+should still see **published** content on `/`, `/about`, etc. Verify cache
+headers on preview paths (no auth needed to see redirect/sign-in responses;
+headers should still be `no-store`):
+
+```bash
+curl -sI "https://<your-host>/preview" | grep -i cache-control
+curl -sI "https://<your-host>/preview/about" | grep -i cache-control
+```
+
+Expect `Cache-Control` (and Vercel-specific headers if present) to include
+`no-store` and `private`. Automated coverage: `src/lib/preview-cache-headers.test.ts`.
+
+---
+
 # ADR: CMS Preview Delivery Mechanism
 
-**Status:** Proposed
-**Date:** 2026-04-14
+**Status:** Proposed  
+**Date:** 2026-04-14  
 **Ticket:** INF-68
 
 ## Context
@@ -57,7 +114,7 @@ incremental enhancement if external collaborators need link-based preview access
 | Threat | Mitigation |
 |--------|------------|
 | **Draft leakage via URL guessing** | Preview routes require a valid Clerk session; unauthenticated requests get 404. |
-| **Draft leakage via CDN cache** | All preview routes use `export const dynamic = "force-dynamic"` (equivalent to `Cache-Control: no-store`). Vercel will not cache these at the edge. |
+| **Draft leakage via CDN cache** | Preview segment uses `force-dynamic` plus `next.config.ts` `headers()` on `/preview` paths (`no-store`, `private`, Vercel CDN override headers). See the INF-107 section at the top of this file. |
 | **Session hijacking** | Delegated to Clerk's session management (HttpOnly cookies, short-lived JWTs, rotation). No custom token handling. |
 | **Privilege escalation (non-owner sees drafts)** | Convex `preview` query checks `tokenIdentifier` against an owner allowlist stored in the DB or env. Returns `null` for non-owners. |
 | **Referrer leakage** | Preview URLs contain no secret tokens, so referrer headers are benign. Add `<meta name="referrer" content="no-referrer">` on preview pages as defense-in-depth. |

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
+import { PREVIEW_CACHE_CONTROL } from "./src/lib/preview-cache-headers";
 
 // Node can install a broken `globalThis.localStorage` when `--localstorage-file` is set
 // without a valid path (often via NODE_OPTIONS). Next.js dev UI checks for `localStorage`
@@ -32,7 +33,26 @@ const hasSentryBuildUploadConfig = Boolean(
     process.env.SENTRY_PROJECT
 );
 
+const previewCacheHeaders = [
+  { key: "Cache-Control", value: PREVIEW_CACHE_CONTROL },
+  /** Vercel: override any default CDN caching for this path (defense in depth). */
+  { key: "CDN-Cache-Control", value: PREVIEW_CACHE_CONTROL },
+  { key: "Vercel-CDN-Cache-Control", value: PREVIEW_CACHE_CONTROL },
+] as const;
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/preview",
+        headers: [...previewCacheHeaders],
+      },
+      {
+        source: "/preview/:path*",
+        headers: [...previewCacheHeaders],
+      },
+    ];
+  },
   env: {
     NEXT_PUBLIC_SENTRY_DSN: sentryPublicDsn,
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: sentryEnvironment,

--- a/src/lib/preview-cache-headers.test.ts
+++ b/src/lib/preview-cache-headers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { PREVIEW_CACHE_CONTROL } from "@/lib/preview-cache-headers";
+
+describe("PREVIEW_CACHE_CONTROL", () => {
+  test("disallows shared caches and stale reuse (no-store + private)", () => {
+    const v = PREVIEW_CACHE_CONTROL.toLowerCase();
+    expect(v).toContain("no-store");
+    expect(v).toContain("private");
+    expect(v).toContain("no-cache");
+    expect(v).toContain("must-revalidate");
+    expect(v).toContain("max-age=0");
+  });
+});

--- a/src/lib/preview-cache-headers.ts
+++ b/src/lib/preview-cache-headers.ts
@@ -1,0 +1,10 @@
+/**
+ * HTTP cache directives for owner CMS preview routes (`/preview`, `/preview/*`).
+ * Used by `next.config.ts` `headers()` so every response on those paths —
+ * including Clerk `auth.protect()` redirects — avoids public edge/CDN caching
+ * of HTML/RSC payloads (draft leakage risk).
+ *
+ * @see docs/cms-preview.md
+ */
+export const PREVIEW_CACHE_CONTROL =
+  "private, no-cache, no-store, max-age=0, must-revalidate";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **INF-107**: ensure CMS preview HTML/RSC is never cached as public edge/CDN content, including responses produced before the App Router layout runs (e.g. Clerk `auth.protect()` redirects from middleware).

## Changes

- **`next.config.ts`**: `headers()` for `/preview` and `/preview/:path*` with `Cache-Control`, `CDN-Cache-Control`, and `Vercel-CDN-Cache-Control` using a shared constant (`private, no-cache, no-store, max-age=0, must-revalidate`).
- **`src/lib/preview-cache-headers.ts`**: single source of truth for the directive string.
- **`src/lib/preview-cache-headers.test.ts`**: asserts required tokens are present (lightweight “integration” guard for the header value).
- **`docs/cms-preview.md`**: INF-107 section — layering table, `VERCEL_ENV` vs `/preview` route gotcha, manual `curl -I` checklist, updated threat-model row.

## Testing

- `bun test`
- `bun run lint`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-107](https://linear.app/only-football-fans/issue/INF-107/lls-preview-read-path-cache-rules-no-draft-in-cdn)

<div><a href="https://cursor.com/agents/bc-94e458eb-026e-4fbf-a4a3-2a5f606fb578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94e458eb-026e-4fbf-a4a3-2a5f606fb578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

