### PR TITLE
fix(marketing): graceful Convex failures and empty states (INF-108)

### DIFF
--- a/src/app/about/about-client.tsx
+++ b/src/app/about/about-client.tsx
@@ -8,7 +8,10 @@ import {
   isHomepagePricingSectionEnabled,
   type MarketingFeatureFlags,
 } from "@/lib/site-settings";
-import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
+import {
+  PUBLIC_CONVEX_QUERY_FAILED,
+  useSafePreloadedQuery,
+} from "@/lib/use-public-convex-query";
 
 type PreloadedAbout = Preloaded<typeof api.public.getPublishedAbout>;
 type PreloadedMarketing = Preloaded<
@@ -32,18 +35,22 @@ export function AboutClient({
     section: "about_marketing_flags",
   });
   const marketing: MarketingFeatureFlags =
-    marketingLive ?? DEFAULT_MARKETING_FEATURE_FLAGS;
+    marketingLive === PUBLIC_CONVEX_QUERY_FAILED ||
+    marketingLive === null ||
+    marketingLive === undefined
+      ? DEFAULT_MARKETING_FEATURE_FLAGS
+      : marketingLive;
   const showPricing =
-    marketingLive === null
+    marketingLive === PUBLIC_CONVEX_QUERY_FAILED
       ? true
       : isHomepagePricingSectionEnabled(marketingLive);
 
   return (
     <AboutLayout
-      data={data}
+      data={data === PUBLIC_CONVEX_QUERY_FAILED ? undefined : data}
       showPricing={showPricing}
       marketing={marketing}
-      convexUnavailable={data === null}
+      convexUnavailable={data === PUBLIC_CONVEX_QUERY_FAILED}
     />
   );
 }

--- a/src/app/about/about-client.tsx
+++ b/src/app/about/about-client.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import type { Preloaded } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { AboutLayout } from "./about-layout";
-import { isHomepagePricingSectionEnabled } from "@/lib/site-settings";
+import {
+  DEFAULT_MARKETING_FEATURE_FLAGS,
+  isHomepagePricingSectionEnabled,
+  type MarketingFeatureFlags,
+} from "@/lib/site-settings";
+import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
 
 type PreloadedAbout = Preloaded<typeof api.public.getPublishedAbout>;
 type PreloadedMarketing = Preloaded<
@@ -22,9 +27,23 @@ export function AboutClient({
   readonly aboutPreloaded: PreloadedAbout;
   readonly marketingPreloaded: PreloadedMarketing;
 }) {
-  const data = usePreloadedQuery(aboutPreloaded);
-  const marketing = usePreloadedQuery(marketingPreloaded);
-  const showPricing = isHomepagePricingSectionEnabled(marketing);
+  const data = useSafePreloadedQuery(aboutPreloaded, { section: "about_body" });
+  const marketingLive = useSafePreloadedQuery(marketingPreloaded, {
+    section: "about_marketing_flags",
+  });
+  const marketing: MarketingFeatureFlags =
+    marketingLive ?? DEFAULT_MARKETING_FEATURE_FLAGS;
+  const showPricing =
+    marketingLive === null
+      ? true
+      : isHomepagePricingSectionEnabled(marketingLive);
 
-  return <AboutLayout data={data} showPricing={showPricing} marketing={marketing} />;
+  return (
+    <AboutLayout
+      data={data}
+      showPricing={showPricing}
+      marketing={marketing}
+      convexUnavailable={data === null}
+    />
+  );
 }

--- a/src/app/about/about-client.tsx
+++ b/src/app/about/about-client.tsx
@@ -40,10 +40,7 @@ export function AboutClient({
     marketingLive === undefined
       ? DEFAULT_MARKETING_FEATURE_FLAGS
       : marketingLive;
-  const showPricing =
-    marketingLive === PUBLIC_CONVEX_QUERY_FAILED
-      ? true
-      : isHomepagePricingSectionEnabled(marketingLive);
+  const showPricing = isHomepagePricingSectionEnabled(marketing);
 
   return (
     <AboutLayout

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -9,8 +9,10 @@ import type {
   PublicAboutSnapshot,
   PublicAboutTeamMember,
 } from "../../../convex/cmsShared";
+import { ABOUT_DEFAULTS } from "@convex/cmsShared";
 import { Header } from "@/components/header";
 import { PageHeader } from "@/components/page-header";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 import { SiteFooter } from "@/components/site-footer";
 import { AboutBodyContent } from "./about-body-content";
 import { cn } from "@/lib/utils";
@@ -121,7 +123,7 @@ function Headshot({ member, fallbackRole }: HeadshotProps) {
 }
 
 interface AboutLayoutProps {
-  readonly data: PublicAboutSnapshot;
+  readonly data: PublicAboutSnapshot | null | undefined;
   readonly showPricing: boolean;
   /** Nav visibility: About / Recordings / pricing block (published or preview). */
   readonly marketing: MarketingFeatureFlags;
@@ -130,9 +132,24 @@ interface AboutLayoutProps {
    * "Draft" / "No unpublished changes" state).
    */
   readonly banner?: React.ReactNode;
+  /** Live Convex subscription failed while hydrating preloaded About content. */
+  readonly convexUnavailable?: boolean;
 }
 
-export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayoutProps) {
+export function AboutLayout({
+  data: dataProp,
+  showPricing,
+  marketing,
+  banner,
+  convexUnavailable = false,
+}: AboutLayoutProps) {
+  const data: PublicAboutSnapshot =
+    dataProp ??
+    ({
+      ...ABOUT_DEFAULTS,
+      heroImageUrl: null,
+      teamMembers: [],
+    } as PublicAboutSnapshot);
   const { scrollY, containerRef } = useScrollAndReveal();
   const pathname = usePathname();
   const showRecordings = marketing.recordingsPage === true;
@@ -181,6 +198,16 @@ export function AboutLayout({ data, showPricing, marketing, banner }: AboutLayou
       />
 
       <main>
+        {convexUnavailable ? (
+          <div className="bg-washed-black px-6 py-8 md:px-16">
+            <div className="mx-auto max-w-3xl">
+              <PublicSectionNotice title="Unable to refresh About content">
+                You may be seeing cached copy or images from your last visit.
+                Try refreshing the page when you are back online.
+              </PublicSectionNotice>
+            </div>
+          </div>
+        ) : null}
         <PageHeader
           eyebrow="About the studio"
           title={data.heroTitle}

--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -17,6 +17,7 @@ import {
 } from "@convex/galleryPhotos";
 import { Header } from "@/components/header";
 import { PageHeader } from "@/components/page-header";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 import { SiteFooter } from "@/components/site-footer";
 import type { GalleryPhoto } from "@/components/the-space";
 import {
@@ -128,6 +129,8 @@ interface GalleryClientProps {
   readonly marketing: MarketingFeatureFlags;
   /** Optional banner slot (preview routes), aligned with `HomepageShell`. */
   readonly banner?: React.ReactNode;
+  /** Live Convex subscription failed; grid may be stale or empty. */
+  readonly convexUnavailable?: boolean;
 }
 
 export function GalleryClient({
@@ -135,6 +138,7 @@ export function GalleryClient({
   videos,
   marketing,
   banner,
+  convexUnavailable = false,
 }: GalleryClientProps) {
   const { scrollY, containerRef } = useScrollAndReveal();
   const pathname = usePathname();
@@ -315,9 +319,18 @@ export function GalleryClient({
         >
           <div className="mx-auto max-w-7xl">
             <GalleryCount count={visibleItems.length} />
+            {convexUnavailable && items.length > 0 ? (
+              <div className="mt-6">
+                <PublicSectionNotice title="Unable to refresh gallery">
+                  You may be seeing cached photos. If images fail to open, try
+                  again when you are back online.
+                </PublicSectionNotice>
+              </div>
+            ) : null}
             {visibleItems.length === 0 ? (
               <EmptyState
                 hasAnyPhotos={items.length > 0}
+                convexUnavailable={convexUnavailable}
                 filterLabel={
                   FILTER_PILLS.find((pill) => pill.id === filter)?.label ?? null
                 }
@@ -761,16 +774,31 @@ function LightboxMedia({ item }: { readonly item: GalleryItem }) {
 
 interface EmptyStateProps {
   readonly hasAnyPhotos: boolean;
+  readonly convexUnavailable?: boolean;
   readonly filterLabel: string | null;
   readonly onClearFilter: () => void;
 }
 
 function EmptyState({
   hasAnyPhotos,
+  convexUnavailable = false,
   filterLabel,
   onClearFilter,
 }: EmptyStateProps) {
   if (!hasAnyPhotos) {
+    if (convexUnavailable) {
+      return (
+        <div className="mt-16 border border-dashed border-sand/15 px-8 py-20 text-center">
+          <p className="label-text text-[11px] tracking-[0.2em] text-sand/50">
+            Unable to load gallery
+          </p>
+          <p className="body-text-small mx-auto mt-4 max-w-md text-ivory/55">
+            We couldn&rsquo;t reach the server to show photos. Try refreshing
+            the page in a little while.
+          </p>
+        </div>
+      );
+    }
     return (
       <div className="mt-16 border border-dashed border-sand/15 px-8 py-20 text-center">
         <p className="label-text text-[11px] tracking-[0.2em] text-sand/50">

--- a/src/app/gallery/gallery-page-client.tsx
+++ b/src/app/gallery/gallery-page-client.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import type { Preloaded } from "convex/react";
 
 import { api } from "../../../convex/_generated/api";
 import type { GalleryPhoto } from "@/components/the-space";
 import { GalleryClient } from "./gallery-client";
 import type { PublishedVideo } from "@/components/video-showcase";
-import type { MarketingFeatureFlags } from "@/lib/site-settings";
+import {
+  type MarketingFeatureFlags,
+  DEFAULT_MARKETING_FEATURE_FLAGS,
+} from "@/lib/site-settings";
+import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
 
 type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos>;
 type PreloadedVideos = Preloaded<typeof api.public.getPublishedVideos>;
@@ -28,12 +32,30 @@ export function GalleryPageClient({
   readonly videosPreloaded: PreloadedVideos;
   readonly marketingPreloaded: PreloadedMarketing;
 }) {
-  const photos = usePreloadedQuery(photosPreloaded) as GalleryPhoto[];
-  const videos = usePreloadedQuery(videosPreloaded) as PublishedVideo[];
+  const photos = useSafePreloadedQuery(photosPreloaded, {
+    section: "gallery_photos",
+  }) as GalleryPhoto[] | null | undefined;
+  const videos = useSafePreloadedQuery(videosPreloaded, {
+    section: "gallery_videos",
+  }) as PublishedVideo[] | null | undefined;
+  const marketingLive = useSafePreloadedQuery(marketingPreloaded, {
+    section: "gallery_marketing_flags",
+  }) as MarketingFeatureFlags | null | undefined;
+
   const marketing: MarketingFeatureFlags =
-    usePreloadedQuery(marketingPreloaded);
+    marketingLive ?? DEFAULT_MARKETING_FEATURE_FLAGS;
+
+  const photosResolved: readonly GalleryPhoto[] =
+    photos === null || photos === undefined ? [] : photos;
+  const videosResolved: readonly PublishedVideo[] | undefined =
+    videos === null ? undefined : videos;
 
   return (
-    <GalleryClient photos={photos} videos={videos} marketing={marketing} />
+    <GalleryClient
+      photos={photosResolved}
+      videos={videosResolved}
+      marketing={marketing}
+      convexUnavailable={photos === null || videos === null}
+    />
   );
 }

--- a/src/app/gallery/gallery-page-client.tsx
+++ b/src/app/gallery/gallery-page-client.tsx
@@ -10,7 +10,11 @@ import {
   type MarketingFeatureFlags,
   DEFAULT_MARKETING_FEATURE_FLAGS,
 } from "@/lib/site-settings";
-import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
+import {
+  PUBLIC_CONVEX_QUERY_FAILED,
+  useSafePreloadedQuery,
+  type PublicConvexQueryResult,
+} from "@/lib/use-public-convex-query";
 
 type PreloadedPhotos = Preloaded<typeof api.public.getPublishedGalleryPhotos>;
 type PreloadedVideos = Preloaded<typeof api.public.getPublishedVideos>;
@@ -34,28 +38,41 @@ export function GalleryPageClient({
 }) {
   const photos = useSafePreloadedQuery(photosPreloaded, {
     section: "gallery_photos",
-  }) as GalleryPhoto[] | null | undefined;
+  }) as PublicConvexQueryResult<GalleryPhoto[]>;
   const videos = useSafePreloadedQuery(videosPreloaded, {
     section: "gallery_videos",
-  }) as PublishedVideo[] | null | undefined;
+  }) as PublicConvexQueryResult<PublishedVideo[]>;
   const marketingLive = useSafePreloadedQuery(marketingPreloaded, {
     section: "gallery_marketing_flags",
-  }) as MarketingFeatureFlags | null | undefined;
+  }) as PublicConvexQueryResult<MarketingFeatureFlags | null>;
 
   const marketing: MarketingFeatureFlags =
-    marketingLive ?? DEFAULT_MARKETING_FEATURE_FLAGS;
+    marketingLive === PUBLIC_CONVEX_QUERY_FAILED ||
+    marketingLive === null ||
+    marketingLive === undefined
+      ? DEFAULT_MARKETING_FEATURE_FLAGS
+      : marketingLive;
 
   const photosResolved: readonly GalleryPhoto[] =
-    photos === null || photos === undefined ? [] : photos;
+    photos === PUBLIC_CONVEX_QUERY_FAILED ||
+    photos === null ||
+    photos === undefined
+      ? []
+      : photos;
   const videosResolved: readonly PublishedVideo[] | undefined =
-    videos === null ? undefined : videos;
+    videos === PUBLIC_CONVEX_QUERY_FAILED || videos === null
+      ? undefined
+      : videos;
 
   return (
     <GalleryClient
       photos={photosResolved}
       videos={videosResolved}
       marketing={marketing}
-      convexUnavailable={photos === null || videos === null}
+      convexUnavailable={
+        photos === PUBLIC_CONVEX_QUERY_FAILED ||
+        videos === PUBLIC_CONVEX_QUERY_FAILED
+      }
     />
   );
 }

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -4,8 +4,10 @@ import { type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
 import {
+  PUBLIC_CONVEX_QUERY_FAILED,
   usePublicConvexQuery,
   useSafePreloadedQuery,
+  type PublicConvexQueryResult,
 } from "@/lib/use-public-convex-query";
 import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import type { GalleryPhoto } from "@/components/the-space";
@@ -25,12 +27,31 @@ type PreloadedAmenities =
 
 type PublishedFaqPayload = { categories: readonly FaqCategoryProps[] };
 
+function faqCategoriesFromFaq(
+  faq: PublicConvexQueryResult<PublishedFaqPayload>,
+):
+  | readonly FaqCategoryProps[]
+  | null
+  | undefined
+  | typeof PUBLIC_CONVEX_QUERY_FAILED {
+  if (faq === PUBLIC_CONVEX_QUERY_FAILED) {
+    return PUBLIC_CONVEX_QUERY_FAILED;
+  }
+  if (faq === null) {
+    return null;
+  }
+  if (faq === undefined) {
+    return undefined;
+  }
+  return faq.categories;
+}
+
 function PhotosData({
   preloaded,
   children,
 }: {
   preloaded: PreloadedPhotos | null;
-  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
+  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
 }) {
   if (preloaded) {
     return <PhotosFromPreload preloaded={preloaded}>{children}</PhotosFromPreload>;
@@ -43,7 +64,7 @@ function PhotosFromPreload({
   children,
 }: {
   preloaded: NonNullable<PreloadedPhotos>;
-  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
+  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
 }) {
   const photos = useSafePreloadedQuery(preloaded, { section: "home_photos" });
   return <>{children(photos)}</>;
@@ -52,7 +73,7 @@ function PhotosFromPreload({
 function PhotosLive({
   children,
 }: {
-  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
+  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
 }) {
   const photos = usePublicConvexQuery(
     api.public.getPublishedCarouselPhotos,
@@ -67,7 +88,7 @@ function FaqData({
   children,
 }: {
   preloaded: PreloadedFaq;
-  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
+  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
 }) {
   if (preloaded) {
     return <FaqFromPreload preloaded={preloaded}>{children}</FaqFromPreload>;
@@ -80,7 +101,7 @@ function FaqFromPreload({
   children,
 }: {
   preloaded: NonNullable<PreloadedFaq>;
-  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
+  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
 }) {
   const faq = useSafePreloadedQuery(preloaded, { section: "home_faq" });
   return <>{children(faq)}</>;
@@ -89,7 +110,7 @@ function FaqFromPreload({
 function FaqLive({
   children,
 }: {
-  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
+  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
 }) {
   const faq = usePublicConvexQuery(api.public.getPublishedFaq, {}, {
     section: "home_faq",
@@ -103,7 +124,7 @@ function MarketingData({
 }: {
   preloaded: PreloadedMarketing;
   children: (
-    marketing: MarketingFeatureFlags | null | undefined,
+    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
   ) => React.ReactNode;
 }) {
   if (preloaded) {
@@ -122,7 +143,7 @@ function MarketingFromPreload({
 }: {
   preloaded: NonNullable<PreloadedMarketing>;
   children: (
-    marketing: MarketingFeatureFlags | null | undefined,
+    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
   ) => React.ReactNode;
 }) {
   const marketing = useSafePreloadedQuery(preloaded, {
@@ -135,7 +156,7 @@ function MarketingLive({
   children,
 }: {
   children: (
-    marketing: MarketingFeatureFlags | null | undefined,
+    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
   ) => React.ReactNode;
 }) {
   const marketing = usePublicConvexQuery(
@@ -152,7 +173,7 @@ function AmenitiesData({
 }: {
   preloaded: PreloadedAmenities;
   children: (
-    amenities: PublishedAmenitiesNearby | null | undefined,
+    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
   ) => React.ReactNode;
 }) {
   if (preloaded) {
@@ -171,7 +192,7 @@ function AmenitiesFromPreload({
 }: {
   preloaded: NonNullable<PreloadedAmenities>;
   children: (
-    amenities: PublishedAmenitiesNearby | null | undefined,
+    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
   ) => React.ReactNode;
 }) {
   const amenities = useSafePreloadedQuery(preloaded, {
@@ -184,7 +205,7 @@ function AmenitiesLive({
   children,
 }: {
   children: (
-    amenities: PublishedAmenitiesNearby | null | undefined,
+    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
   ) => React.ReactNode;
 }) {
   const amenities = usePublicConvexQuery(
@@ -205,10 +226,10 @@ function BothPreloaded({
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
-  photos: GalleryPhoto[] | undefined | null;
-  faq: PublishedFaqPayload | undefined | null;
-  marketing: MarketingFeatureFlags | null | undefined;
-  amenities: PublishedAmenitiesNearby | null | undefined;
+  photos: PublicConvexQueryResult<GalleryPhoto[]>;
+  faq: PublicConvexQueryResult<PublishedFaqPayload>;
+  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
+  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
 }) {
   const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
     section: "home_pricing",
@@ -220,7 +241,7 @@ function BothPreloaded({
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq === null ? null : faq?.categories}
+      faqCategories={faqCategoriesFromFaq(faq)}
       amenities={amenities}
     />
   );
@@ -234,10 +255,10 @@ function PricingPreloadedGearLive({
   amenities,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
-  photos: GalleryPhoto[] | undefined | null;
-  faq: PublishedFaqPayload | undefined | null;
-  marketing: MarketingFeatureFlags | null | undefined;
-  amenities: PublishedAmenitiesNearby | null | undefined;
+  photos: PublicConvexQueryResult<GalleryPhoto[]>;
+  faq: PublicConvexQueryResult<PublishedFaqPayload>;
+  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
+  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
 }) {
   const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
     section: "home_pricing",
@@ -251,7 +272,7 @@ function PricingPreloadedGearLive({
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq === null ? null : faq?.categories}
+      faqCategories={faqCategoriesFromFaq(faq)}
       amenities={amenities}
     />
   );
@@ -265,10 +286,10 @@ function PricingLiveGearPreloaded({
   amenities,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
-  photos: GalleryPhoto[] | undefined | null;
-  faq: PublishedFaqPayload | undefined | null;
-  marketing: MarketingFeatureFlags | null | undefined;
-  amenities: PublishedAmenitiesNearby | null | undefined;
+  photos: PublicConvexQueryResult<GalleryPhoto[]>;
+  faq: PublicConvexQueryResult<PublishedFaqPayload>;
+  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
+  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
 }) {
   const pricingFlags = usePublicConvexQuery(
     api.public.getPublishedPricingFlags,
@@ -282,7 +303,7 @@ function PricingLiveGearPreloaded({
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq === null ? null : faq?.categories}
+      faqCategories={faqCategoriesFromFaq(faq)}
       amenities={amenities}
     />
   );
@@ -294,10 +315,10 @@ function BothLive({
   marketing,
   amenities,
 }: {
-  photos: GalleryPhoto[] | undefined | null;
-  faq: PublishedFaqPayload | undefined | null;
-  marketing: MarketingFeatureFlags | null | undefined;
-  amenities: PublishedAmenitiesNearby | null | undefined;
+  photos: PublicConvexQueryResult<GalleryPhoto[]>;
+  faq: PublicConvexQueryResult<PublishedFaqPayload>;
+  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
+  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
 }) {
   const pricingFlags = usePublicConvexQuery(
     api.public.getPublishedPricingFlags,
@@ -313,7 +334,7 @@ function BothLive({
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq === null ? null : faq?.categories}
+      faqCategories={faqCategoriesFromFaq(faq)}
       amenities={amenities}
     />
   );

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
+import { type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
+import {
+  usePublicConvexQuery,
+  useSafePreloadedQuery,
+} from "@/lib/use-public-convex-query";
 import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import type { GalleryPhoto } from "@/components/the-space";
 import type { FaqCategoryProps } from "@/components/faq";
@@ -26,7 +30,7 @@ function PhotosData({
   children,
 }: {
   preloaded: PreloadedPhotos | null;
-  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
 }) {
   if (preloaded) {
     return <PhotosFromPreload preloaded={preloaded}>{children}</PhotosFromPreload>;
@@ -39,18 +43,22 @@ function PhotosFromPreload({
   children,
 }: {
   preloaded: NonNullable<PreloadedPhotos>;
-  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
 }) {
-  const photos = usePreloadedQuery(preloaded);
+  const photos = useSafePreloadedQuery(preloaded, { section: "home_photos" });
   return <>{children(photos)}</>;
 }
 
 function PhotosLive({
   children,
 }: {
-  children: (photos: GalleryPhoto[] | undefined) => React.ReactNode;
+  children: (photos: GalleryPhoto[] | undefined | null) => React.ReactNode;
 }) {
-  const photos = useQuery(api.public.getPublishedCarouselPhotos);
+  const photos = usePublicConvexQuery(
+    api.public.getPublishedCarouselPhotos,
+    {},
+    { section: "home_photos" },
+  );
   return <>{children(photos)}</>;
 }
 
@@ -59,7 +67,7 @@ function FaqData({
   children,
 }: {
   preloaded: PreloadedFaq;
-  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
 }) {
   if (preloaded) {
     return <FaqFromPreload preloaded={preloaded}>{children}</FaqFromPreload>;
@@ -72,18 +80,20 @@ function FaqFromPreload({
   children,
 }: {
   preloaded: NonNullable<PreloadedFaq>;
-  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
 }) {
-  const faq = usePreloadedQuery(preloaded);
+  const faq = useSafePreloadedQuery(preloaded, { section: "home_faq" });
   return <>{children(faq)}</>;
 }
 
 function FaqLive({
   children,
 }: {
-  children: (faq: PublishedFaqPayload | undefined) => React.ReactNode;
+  children: (faq: PublishedFaqPayload | undefined | null) => React.ReactNode;
 }) {
-  const faq = useQuery(api.public.getPublishedFaq);
+  const faq = usePublicConvexQuery(api.public.getPublishedFaq, {}, {
+    section: "home_faq",
+  });
   return <>{children(faq)}</>;
 }
 
@@ -115,7 +125,9 @@ function MarketingFromPreload({
     marketing: MarketingFeatureFlags | null | undefined,
   ) => React.ReactNode;
 }) {
-  const marketing = usePreloadedQuery(preloaded);
+  const marketing = useSafePreloadedQuery(preloaded, {
+    section: "home_marketing_flags",
+  });
   return <>{children(marketing)}</>;
 }
 
@@ -126,7 +138,11 @@ function MarketingLive({
     marketing: MarketingFeatureFlags | null | undefined,
   ) => React.ReactNode;
 }) {
-  const marketing = useQuery(api.public.getPublishedMarketingFeatureFlags);
+  const marketing = usePublicConvexQuery(
+    api.public.getPublishedMarketingFeatureFlags,
+    {},
+    { section: "home_marketing_flags" },
+  );
   return <>{children(marketing)}</>;
 }
 
@@ -158,7 +174,9 @@ function AmenitiesFromPreload({
     amenities: PublishedAmenitiesNearby | null | undefined,
   ) => React.ReactNode;
 }) {
-  const amenities = usePreloadedQuery(preloaded);
+  const amenities = useSafePreloadedQuery(preloaded, {
+    section: "home_amenities",
+  });
   return <>{children(amenities)}</>;
 }
 
@@ -169,7 +187,11 @@ function AmenitiesLive({
     amenities: PublishedAmenitiesNearby | null | undefined,
   ) => React.ReactNode;
 }) {
-  const amenities = useQuery(api.public.getPublishedAmenitiesNearby);
+  const amenities = usePublicConvexQuery(
+    api.public.getPublishedAmenitiesNearby,
+    {},
+    { section: "home_amenities" },
+  );
   return <>{children(amenities)}</>;
 }
 
@@ -183,20 +205,22 @@ function BothPreloaded({
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
   preloadedGear: NonNullable<PreloadedGear>;
-  photos: GalleryPhoto[] | undefined;
-  faq: PublishedFaqPayload | undefined;
+  photos: GalleryPhoto[] | undefined | null;
+  faq: PublishedFaqPayload | undefined | null;
   marketing: MarketingFeatureFlags | null | undefined;
   amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
-  const pricingFlags = usePreloadedQuery(preloadedPricing);
-  const gear = usePreloadedQuery(preloadedGear);
+  const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
+    section: "home_pricing",
+  });
+  const gear = useSafePreloadedQuery(preloadedGear, { section: "home_gear" });
   return (
     <HomepageShell
       pricingFlags={pricingFlags}
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq?.categories}
+      faqCategories={faq === null ? null : faq?.categories}
       amenities={amenities}
     />
   );
@@ -210,20 +234,24 @@ function PricingPreloadedGearLive({
   amenities,
 }: {
   preloadedPricing: NonNullable<PreloadedPricing>;
-  photos: GalleryPhoto[] | undefined;
-  faq: PublishedFaqPayload | undefined;
+  photos: GalleryPhoto[] | undefined | null;
+  faq: PublishedFaqPayload | undefined | null;
   marketing: MarketingFeatureFlags | null | undefined;
   amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
-  const pricingFlags = usePreloadedQuery(preloadedPricing);
-  const gear = useQuery(api.public.getPublishedGear);
+  const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
+    section: "home_pricing",
+  });
+  const gear = usePublicConvexQuery(api.public.getPublishedGear, {}, {
+    section: "home_gear",
+  });
   return (
     <HomepageShell
       pricingFlags={pricingFlags}
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq?.categories}
+      faqCategories={faq === null ? null : faq?.categories}
       amenities={amenities}
     />
   );
@@ -237,20 +265,24 @@ function PricingLiveGearPreloaded({
   amenities,
 }: {
   preloadedGear: NonNullable<PreloadedGear>;
-  photos: GalleryPhoto[] | undefined;
-  faq: PublishedFaqPayload | undefined;
+  photos: GalleryPhoto[] | undefined | null;
+  faq: PublishedFaqPayload | undefined | null;
   marketing: MarketingFeatureFlags | null | undefined;
   amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
-  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
-  const gear = usePreloadedQuery(preloadedGear);
+  const pricingFlags = usePublicConvexQuery(
+    api.public.getPublishedPricingFlags,
+    {},
+    { section: "home_pricing" },
+  );
+  const gear = useSafePreloadedQuery(preloadedGear, { section: "home_gear" });
   return (
     <HomepageShell
       pricingFlags={pricingFlags}
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq?.categories}
+      faqCategories={faq === null ? null : faq?.categories}
       amenities={amenities}
     />
   );
@@ -262,20 +294,26 @@ function BothLive({
   marketing,
   amenities,
 }: {
-  photos: GalleryPhoto[] | undefined;
-  faq: PublishedFaqPayload | undefined;
+  photos: GalleryPhoto[] | undefined | null;
+  faq: PublishedFaqPayload | undefined | null;
   marketing: MarketingFeatureFlags | null | undefined;
   amenities: PublishedAmenitiesNearby | null | undefined;
 }) {
-  const pricingFlags = useQuery(api.public.getPublishedPricingFlags);
-  const gear = useQuery(api.public.getPublishedGear);
+  const pricingFlags = usePublicConvexQuery(
+    api.public.getPublishedPricingFlags,
+    {},
+    { section: "home_pricing" },
+  );
+  const gear = usePublicConvexQuery(api.public.getPublishedGear, {}, {
+    section: "home_gear",
+  });
   return (
     <HomepageShell
       pricingFlags={pricingFlags}
       marketingFeatureFlags={marketing}
       gear={gear}
       photos={photos}
-      faqCategories={faq?.categories}
+      faqCategories={faq === null ? null : faq?.categories}
       amenities={amenities}
     />
   );

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -682,7 +682,7 @@ export function RecordingsClient({
               </div>
             ) : null}
 
-            {recordings.length === 0 ? (
+            {recordings.length === 0 && !convexUnavailable ? (
               <div
                 className={cn(
                   revealDelay(1),

--- a/src/app/recordings/recordings-client.tsx
+++ b/src/app/recordings/recordings-client.tsx
@@ -8,6 +8,7 @@ import { useRef, useState, type ReactNode } from "react";
 
 import { Header } from "@/components/header";
 import { PageHeader } from "@/components/page-header";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 import { SiteFooter } from "@/components/site-footer";
 import { useScrollAndReveal } from "@/hooks/use-scroll-and-reveal";
 import { MAX_REVEAL_DELAY, revealDelay } from "@/lib/reveal-delay";
@@ -535,12 +536,15 @@ interface RecordingsClientProps {
   readonly marketing: MarketingFeatureFlags;
   /** Preview banner, aligned with `HomepageShell` / `AboutLayout`. */
   readonly banner?: ReactNode;
+  /** True when live Convex subscription failed; page stays usable with nav. */
+  readonly convexUnavailable?: boolean;
 }
 
 export function RecordingsClient({
   recordings,
   marketing,
   banner,
+  convexUnavailable = false,
 }: RecordingsClientProps) {
   const pathname = usePathname();
   const isPreview =
@@ -667,6 +671,16 @@ export function RecordingsClient({
               Lula Lake Sound. Each piece carries the character of the
               mountain — press play to hear the room.
             </p>
+
+            {convexUnavailable ? (
+              <div className={cn(revealDelay(1), "mt-10")}>
+                <PublicSectionNotice title="Unable to refresh recordings">
+                  You may be seeing a cached list. Playback links might be out
+                  of date until the connection is restored. Try refreshing the
+                  page in a little while.
+                </PublicSectionNotice>
+              </div>
+            ) : null}
 
             {recordings.length === 0 ? (
               <div

--- a/src/app/recordings/recordings-page-client.tsx
+++ b/src/app/recordings/recordings-page-client.tsx
@@ -10,7 +10,10 @@ import {
   type Recording,
 } from "./recordings-data";
 import { type MarketingFeatureFlags } from "@/lib/site-settings";
-import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
+import {
+  PUBLIC_CONVEX_QUERY_FAILED,
+  useSafePreloadedQuery,
+} from "@/lib/use-public-convex-query";
 
 type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks>;
 
@@ -29,7 +32,13 @@ export function RecordingsPageClient({
     section: "recordings_audio",
   });
   const recordings = useMemo((): Recording[] => {
-    if (raw === null || raw === undefined) return [];
+    if (
+      raw === PUBLIC_CONVEX_QUERY_FAILED ||
+      raw === null ||
+      raw === undefined
+    ) {
+      return [];
+    }
     return mapPublishedAudioToRecordings(raw);
   }, [raw]);
 
@@ -37,7 +46,7 @@ export function RecordingsPageClient({
     <RecordingsClient
       recordings={recordings}
       marketing={marketing}
-      convexUnavailable={raw === null}
+      convexUnavailable={raw === PUBLIC_CONVEX_QUERY_FAILED}
     />
   );
 }

--- a/src/app/recordings/recordings-page-client.tsx
+++ b/src/app/recordings/recordings-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import type { Preloaded } from "convex/react";
 
 import { api } from "../../../convex/_generated/api";
 import { RecordingsClient } from "./recordings-client";
@@ -9,7 +9,11 @@ import {
   mapPublishedAudioToRecordings,
   type Recording,
 } from "./recordings-data";
-import { type MarketingFeatureFlags } from "@/lib/site-settings";
+import {
+  type MarketingFeatureFlags,
+  DEFAULT_MARKETING_FEATURE_FLAGS,
+} from "@/lib/site-settings";
+import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
 
 type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks>;
 
@@ -24,11 +28,22 @@ export function RecordingsPageClient({
   readonly preloadedAudio: PreloadedAudio;
   readonly marketing: MarketingFeatureFlags;
 }) {
-  const raw = usePreloadedQuery(preloadedAudio);
-  const recordings = useMemo(
-    (): Recording[] => mapPublishedAudioToRecordings(raw),
-    [raw],
-  );
+  const raw = useSafePreloadedQuery(preloadedAudio, {
+    section: "recordings_audio",
+  });
+  const recordings = useMemo((): Recording[] => {
+    if (raw === null || raw === undefined) return [];
+    return mapPublishedAudioToRecordings(raw);
+  }, [raw]);
 
-  return <RecordingsClient recordings={recordings} marketing={marketing} />;
+  const resolvedMarketing: MarketingFeatureFlags =
+    raw === null ? DEFAULT_MARKETING_FEATURE_FLAGS : marketing;
+
+  return (
+    <RecordingsClient
+      recordings={recordings}
+      marketing={resolvedMarketing}
+      convexUnavailable={raw === null}
+    />
+  );
 }

--- a/src/app/recordings/recordings-page-client.tsx
+++ b/src/app/recordings/recordings-page-client.tsx
@@ -9,10 +9,7 @@ import {
   mapPublishedAudioToRecordings,
   type Recording,
 } from "./recordings-data";
-import {
-  type MarketingFeatureFlags,
-  DEFAULT_MARKETING_FEATURE_FLAGS,
-} from "@/lib/site-settings";
+import { type MarketingFeatureFlags } from "@/lib/site-settings";
 import { useSafePreloadedQuery } from "@/lib/use-public-convex-query";
 
 type PreloadedAudio = Preloaded<typeof api.public.getPublishedAudioTracks>;
@@ -36,13 +33,10 @@ export function RecordingsPageClient({
     return mapPublishedAudioToRecordings(raw);
   }, [raw]);
 
-  const resolvedMarketing: MarketingFeatureFlags =
-    raw === null ? DEFAULT_MARKETING_FEATURE_FLAGS : marketing;
-
   return (
     <RecordingsClient
       recordings={recordings}
-      marketing={resolvedMarketing}
+      marketing={marketing}
       convexUnavailable={raw === null}
     />
   );

--- a/src/components/amenities-nearby.tsx
+++ b/src/components/amenities-nearby.tsx
@@ -2,6 +2,7 @@
 
 import { AmenityCard } from "./ui/amenity-card";
 import { PublicSectionNotice } from "@/components/public-section-notice";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 
 const STATIC_EYEBROW = "Local Favorites";
 const STATIC_HEADING = "Amenities Nearby";
@@ -22,7 +23,11 @@ export type PublishedAmenitiesNearby = {
 
 type AmenitiesNearbyProps = {
   /** Published (or owner preview) amenities payload from Convex. */
-  readonly amenities?: PublishedAmenitiesNearby | null | undefined;
+  readonly amenities?:
+    | PublishedAmenitiesNearby
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
 };
 
 export function AmenitiesNearby({ amenities }: AmenitiesNearbyProps) {
@@ -41,6 +46,10 @@ export function AmenitiesNearby({ amenities }: AmenitiesNearbyProps) {
   }
 
   if (amenities === null) {
+    return null;
+  }
+
+  if (amenities === PUBLIC_CONVEX_QUERY_FAILED) {
     return (
       <section
         id="local-favorites"

--- a/src/components/amenities-nearby.tsx
+++ b/src/components/amenities-nearby.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AmenityCard } from "./ui/amenity-card";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 
 const STATIC_EYEBROW = "Local Favorites";
 const STATIC_HEADING = "Amenities Nearby";
@@ -40,7 +41,20 @@ export function AmenitiesNearby({ amenities }: AmenitiesNearbyProps) {
   }
 
   if (amenities === null) {
-    return null;
+    return (
+      <section
+        id="local-favorites"
+        className="relative overflow-hidden bg-forest px-6 py-28 md:py-40"
+      >
+        <div className="absolute inset-0 bg-texture-canvas opacity-14" />
+        <div className="relative z-10 mx-auto max-w-6xl">
+          <PublicSectionNotice title="Unable to load local favorites">
+            Nearby dining and lodging picks will appear here when we can reach
+            the server again.
+          </PublicSectionNotice>
+        </div>
+      </section>
+    );
   }
 
   if (!amenities.isEnabled || amenities.rows.length === 0) {

--- a/src/components/dynamic-pricing.tsx
+++ b/src/components/dynamic-pricing.tsx
@@ -43,7 +43,7 @@ export function MarketingPricingSection({
       : (pricingFlags != null &&
           pricingFlags.flags.priceTabEnabled === true) ||
           previewCatalogOn;
-  const visible = loading || (pricingFlags !== null && sectionOn);
+  const visible = loading || (sectionOn && pricingFlags !== undefined);
 
   if (!visible) {
     return null;

--- a/src/components/dynamic-pricing.tsx
+++ b/src/components/dynamic-pricing.tsx
@@ -9,13 +9,19 @@ import {
   isHomepagePricingSectionEnabled,
   previewHasActivePricingPackages,
 } from "@/lib/site-settings";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 
 interface MarketingPricingSectionProps {
   /**
    * Published or preview pricing payload. `undefined` means still loading (show
    * skeleton). `null` means unavailable (hide section).
+   * {@link PUBLIC_CONVEX_QUERY_FAILED} means the live subscription failed.
    */
-  readonly pricingFlags: PricingFlags | null | undefined;
+  readonly pricingFlags:
+    | PricingFlags
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /**
    * When set, gates the block (from `getPublishedMarketingFeatureFlags` or preview).
    * If omitted, falls back to `flags.priceTabEnabled` for back-compat.
@@ -35,15 +41,25 @@ export function MarketingPricingSection({
   isPreviewRoute = false,
 }: MarketingPricingSectionProps) {
   const loading = pricingFlags === undefined;
+  const subscriptionFailed = pricingFlags === PUBLIC_CONVEX_QUERY_FAILED;
+  const pricingPayload =
+    loading || subscriptionFailed
+      ? undefined
+      : pricingFlags === null
+        ? null
+        : pricingFlags;
   const previewCatalogOn =
-    isPreviewRoute && previewHasActivePricingPackages(pricingFlags);
+    isPreviewRoute && previewHasActivePricingPackages(pricingPayload);
   const sectionOn =
     marketingFeatureFlags != null
       ? isHomepagePricingSectionEnabled(marketingFeatureFlags)
-      : (pricingFlags != null &&
-          pricingFlags.flags.priceTabEnabled === true) ||
+      : (pricingPayload != null &&
+          pricingPayload.flags.priceTabEnabled === true) ||
           previewCatalogOn;
-  const visible = loading || (sectionOn && pricingFlags !== undefined);
+  const visible =
+    loading ||
+    (sectionOn &&
+      (subscriptionFailed || pricingFlags !== undefined));
 
   if (!visible) {
     return null;
@@ -53,7 +69,7 @@ export function MarketingPricingSection({
     return <ServicesAndPricingSkeleton />;
   }
 
-  if (pricingFlags === null) {
+  if (subscriptionFailed) {
     return (
       <section
         id="services-pricing"
@@ -72,7 +88,11 @@ export function MarketingPricingSection({
     );
   }
 
-  const packages = pricingFlags.packages ?? [];
+  if (pricingPayload == null) {
+    return null;
+  }
+
+  const packages = pricingPayload.packages ?? [];
 
   return <ServicesAndPricing packages={packages} />;
 }

--- a/src/components/dynamic-pricing.tsx
+++ b/src/components/dynamic-pricing.tsx
@@ -2,6 +2,7 @@ import {
   ServicesAndPricing,
   ServicesAndPricingSkeleton,
 } from "@/components/services-pricing";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 import {
   type MarketingFeatureFlags,
   type PricingFlags,
@@ -50,6 +51,25 @@ export function MarketingPricingSection({
 
   if (loading) {
     return <ServicesAndPricingSkeleton />;
+  }
+
+  if (pricingFlags === null) {
+    return (
+      <section
+        id="services-pricing"
+        className="relative overflow-hidden bg-washed-black px-6 py-28 md:py-40"
+      >
+        <div className="absolute inset-0 bg-texture-ink-wash opacity-55" />
+        <div className="absolute inset-0 bg-texture-stone opacity-20" />
+        <div className="relative z-10 mx-auto max-w-6xl">
+          <PublicSectionNotice title="Unable to load rates">
+            We couldn&rsquo;t reach our booking system just now. Pricing will
+            appear again when the connection is restored. You can still reach
+            out below &mdash; we&rsquo;ll reply with current rates.
+          </PublicSectionNotice>
+        </div>
+      </section>
+    );
   }
 
   const packages = pricingFlags.packages ?? [];

--- a/src/components/equipment-specs.tsx
+++ b/src/components/equipment-specs.tsx
@@ -9,6 +9,7 @@ import {
   AccordionPanel,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { PublicSectionNotice } from "@/components/public-section-notice";
 
 /**
  * Published (or preview) gear payload surfaced to the marketing site.
@@ -142,8 +143,8 @@ function EquipmentSpecsEmpty() {
 interface EquipmentSpecsProps {
   /**
    * `undefined` → still loading (render skeleton).
-   * `null` → query unavailable or caller not permitted (render empty state).
-   * Payload → render accordion.
+   * `null` → query failed or unavailable (friendly notice).
+   * Empty categories → published empty state ("coming soon").
    */
   readonly gear: GearPayload | null | undefined;
 }
@@ -153,7 +154,20 @@ export function EquipmentSpecs({ gear }: EquipmentSpecsProps) {
     return <EquipmentSpecsSkeleton />;
   }
 
-  const categories = gear?.categories ?? [];
+  if (gear === null) {
+    return (
+      <SectionShell>
+        <div className="reveal reveal-delay-2">
+          <PublicSectionNotice title="Unable to load equipment list">
+            We couldn&rsquo;t load the detailed gear list. Studio specifications
+            above are still accurate; try again shortly for the full inventory.
+          </PublicSectionNotice>
+        </div>
+      </SectionShell>
+    );
+  }
+
+  const categories = gear.categories ?? [];
 
   if (categories.length === 0) {
     return (

--- a/src/components/equipment-specs.tsx
+++ b/src/components/equipment-specs.tsx
@@ -10,6 +10,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { PublicSectionNotice } from "@/components/public-section-notice";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 
 /**
  * Published (or preview) gear payload surfaced to the marketing site.
@@ -143,10 +144,15 @@ function EquipmentSpecsEmpty() {
 interface EquipmentSpecsProps {
   /**
    * `undefined` → still loading (render skeleton).
-   * `null` → query failed or unavailable (friendly notice).
+   * {@link PUBLIC_CONVEX_QUERY_FAILED} → subscription failed (friendly notice).
+   * `null` → no published gear payload (empty / coming soon).
    * Empty categories → published empty state ("coming soon").
    */
-  readonly gear: GearPayload | null | undefined;
+  readonly gear:
+    | GearPayload
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
 }
 
 export function EquipmentSpecs({ gear }: EquipmentSpecsProps) {
@@ -154,7 +160,7 @@ export function EquipmentSpecs({ gear }: EquipmentSpecsProps) {
     return <EquipmentSpecsSkeleton />;
   }
 
-  if (gear === null) {
+  if (gear === PUBLIC_CONVEX_QUERY_FAILED) {
     return (
       <SectionShell>
         <div className="reveal reveal-delay-2">
@@ -163,6 +169,14 @@ export function EquipmentSpecs({ gear }: EquipmentSpecsProps) {
             above are still accurate; try again shortly for the full inventory.
           </PublicSectionNotice>
         </div>
+      </SectionShell>
+    );
+  }
+
+  if (gear === null) {
+    return (
+      <SectionShell>
+        <EquipmentSpecsEmpty />
       </SectionShell>
     );
   }

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 
+import { PublicSectionNotice } from "@/components/public-section-notice";
 import {
   Accordion,
   AccordionItem,
@@ -24,13 +25,14 @@ export type FaqCategoryProps = {
 };
 
 export type FaqProps = {
-  categories?: readonly FaqCategoryProps[] | null;
+  categories?: readonly FaqCategoryProps[] | null | undefined;
 };
 
 export function FAQ({ categories }: FaqProps) {
-  if (categories === null || categories?.length === 0) {
-    return null;
-  }
+  const isLoading = categories === undefined;
+  const isUnavailable = categories === null;
+  const isEmptyPublished =
+    !isLoading && !isUnavailable && categories.length === 0;
 
   return (
     <section
@@ -65,11 +67,25 @@ export function FAQ({ categories }: FaqProps) {
           </p>
         </div>
 
-        {categories === undefined ? (
+        {isLoading ? (
           <div className="reveal reveal-delay-2 space-y-10">
             <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
             <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
             <div className="h-12 animate-pulse rounded-md bg-warm-white/5" />
+          </div>
+        ) : isUnavailable ? (
+          <div className="reveal reveal-delay-2">
+            <PublicSectionNotice title="Unable to load FAQs">
+              We couldn&rsquo;t load questions and answers right now. Try again
+              in a moment, or reach out using the links below.
+            </PublicSectionNotice>
+          </div>
+        ) : isEmptyPublished ? (
+          <div className="reveal reveal-delay-2">
+            <PublicSectionNotice title="Questions coming soon">
+              Answers for booking, sessions, and the studio will appear here
+              when they are published.
+            </PublicSectionNotice>
           </div>
         ) : (
           <div className="reveal reveal-delay-2 space-y-16">

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/accordion";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 
 export type FaqQuestionProps = {
   stableId: string;
@@ -25,14 +26,24 @@ export type FaqCategoryProps = {
 };
 
 export type FaqProps = {
-  categories?: readonly FaqCategoryProps[] | null | undefined;
+  categories?:
+    | readonly FaqCategoryProps[]
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
 };
 
 export function FAQ({ categories }: FaqProps) {
   const isLoading = categories === undefined;
-  const isUnavailable = categories === null;
+  const isUnavailable = categories === PUBLIC_CONVEX_QUERY_FAILED;
+  const categoriesResolved =
+    categories === undefined ||
+    categories === PUBLIC_CONVEX_QUERY_FAILED ||
+    categories === null
+      ? []
+      : categories;
   const isEmptyPublished =
-    !isLoading && !isUnavailable && categories.length === 0;
+    !isLoading && !isUnavailable && categoriesResolved.length === 0;
 
   return (
     <section
@@ -89,7 +100,7 @@ export function FAQ({ categories }: FaqProps) {
           </div>
         ) : (
           <div className="reveal reveal-delay-2 space-y-16">
-            {categories.map((category) => (
+            {categoriesResolved.map((category) => (
               <div key={category.stableId}>
                 <h3 className="eyebrow mb-8 border-b border-sand/22 pb-4 text-sand">
                   {category.title}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -2,7 +2,10 @@
 
 import { usePathname } from "next/navigation";
 import { api } from "../../convex/_generated/api";
-import { usePublicConvexQuery } from "@/lib/use-public-convex-query";
+import {
+  PUBLIC_CONVEX_QUERY_FAILED,
+  usePublicConvexQuery,
+} from "@/lib/use-public-convex-query";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { MarketingPricingSection } from "@/components/dynamic-pricing";
@@ -28,23 +31,47 @@ function calculateLogoScale(scrollY: number): number {
 
 interface HomepageShellProps {
   /** `undefined` while the client is still subscribing (preview only if not preloaded). */
-  readonly pricingFlags: PricingFlags | null | undefined;
+  readonly pricingFlags:
+    | PricingFlags
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /**
-   * `undefined` when not preloaded: live-subscribe. `null` on error. Pass from
+   * `undefined` when not preloaded: live-subscribe. Pass from
    * `getPublishedMarketingFeatureFlags` or `getPreviewMarketingFeatureFlags`.
    */
-  readonly marketingFeatureFlags?: MarketingFeatureFlags | null | undefined;
+  readonly marketingFeatureFlags?:
+    | MarketingFeatureFlags
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /**
    * Published (or preview) gear payload. `undefined` renders the skeleton;
    * `null` renders the graceful empty state.
    */
-  readonly gear: GearPayload | null | undefined;
+  readonly gear:
+    | GearPayload
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /** Published (or preview) gallery payload. */
-  readonly photos: GalleryPhoto[] | null | undefined;
+  readonly photos:
+    | GalleryPhoto[]
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /** FAQ categories from Convex; `undefined` renders the loading state. */
-  readonly faqCategories?: readonly FaqCategoryProps[] | null | undefined;
+  readonly faqCategories?:
+    | readonly FaqCategoryProps[]
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   /** Amenities payload from Convex; `undefined` renders the loading state. */
-  readonly amenities?: PublishedAmenitiesNearby | null | undefined;
+  readonly amenities?:
+    | PublishedAmenitiesNearby
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
   readonly banner?: React.ReactNode;
 }
 
@@ -59,6 +86,10 @@ export function HomepageShell({
 }: HomepageShellProps) {
   const { scrollY, containerRef } = useScrollAndReveal();
   const pathname = usePathname();
+  const marketingFromPropsResolved =
+    marketingFromProps === PUBLIC_CONVEX_QUERY_FAILED
+      ? undefined
+      : marketingFromProps;
   const isPreview =
     pathname === "/preview" || pathname.startsWith("/preview/");
   const aboutHref = isPreview ? "/preview/about" : "/about";
@@ -70,11 +101,15 @@ export function HomepageShell({
     {},
     {
       section: "home_marketing_flags",
-      skip: marketingFromProps !== undefined,
+      skip: marketingFromPropsResolved !== undefined,
     },
   );
   const marketing =
-    marketingFromProps === undefined ? liveMarketing : marketingFromProps;
+    marketingFromPropsResolved === undefined
+      ? liveMarketing
+      : marketingFromPropsResolved;
+  const marketingForUi =
+    marketing === PUBLIC_CONVEX_QUERY_FAILED ? undefined : marketing;
 
   const logoScale = calculateLogoScale(scrollY);
   // Nav-link visibility intentionally defaults to OFF while the marketing
@@ -82,14 +117,21 @@ export function HomepageShell({
   // "Pricing" / "Recordings" / "About" tabs before Convex resolves and any
   // disabled tabs disappear — the visible flicker reported on the homepage.
   const showPricing =
-    (marketing != null && isHomepagePricingSectionEnabled(marketing)) ||
+    (marketingForUi != null &&
+      isHomepagePricingSectionEnabled(marketingForUi)) ||
     (isPreview &&
-      marketing == null &&
-      previewHasActivePricingPackages(pricingFlags));
-  const showAbout = marketing != null && marketing.aboutPage === true;
+      marketingForUi == null &&
+      previewHasActivePricingPackages(
+        pricingFlags === PUBLIC_CONVEX_QUERY_FAILED
+          ? undefined
+          : pricingFlags,
+      ));
+  const showAbout =
+    marketingForUi != null && marketingForUi.aboutPage === true;
   const showRecordings =
-    marketing != null && marketing.recordingsPage === true;
-  const showGallery = marketing != null && isGalleryPageEnabled(marketing);
+    marketingForUi != null && marketingForUi.recordingsPage === true;
+  const showGallery =
+    marketingForUi != null && isGalleryPageEnabled(marketingForUi);
 
   return (
     <div
@@ -114,7 +156,7 @@ export function HomepageShell({
         <EquipmentSpecs gear={gear} />
         <MarketingPricingSection
           pricingFlags={pricingFlags}
-          marketingFeatureFlags={marketing ?? null}
+          marketingFeatureFlags={marketingForUi ?? null}
           isPreviewRoute={isPreview}
         />
         <AmenitiesNearby amenities={amenities} />

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useQuery } from "convex/react";
 import { usePathname } from "next/navigation";
 import { api } from "../../convex/_generated/api";
+import { usePublicConvexQuery } from "@/lib/use-public-convex-query";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { MarketingPricingSection } from "@/components/dynamic-pricing";
@@ -65,9 +65,13 @@ export function HomepageShell({
   const homeSectionBase = isPreview ? "/preview" : "/";
   const recordingsNavHref = isPreview ? "/preview/recordings" : "/recordings";
 
-  const liveMarketing = useQuery(
+  const liveMarketing = usePublicConvexQuery(
     api.public.getPublishedMarketingFeatureFlags,
-    marketingFromProps === undefined ? {} : "skip",
+    {},
+    {
+      section: "home_marketing_flags",
+      skip: marketingFromProps !== undefined,
+    },
   );
   const marketing =
     marketingFromProps === undefined ? liveMarketing : marketingFromProps;

--- a/src/components/public-section-notice.tsx
+++ b/src/components/public-section-notice.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+type PublicSectionNoticeProps = {
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly className?: string;
+};
+
+/**
+ * Static, non-modal notice for public marketing sections when live data is
+ * unavailable (Convex outage). Keeps layout dignified without trapping focus.
+ */
+export function PublicSectionNotice({
+  title,
+  children,
+  className,
+}: PublicSectionNoticeProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "rounded-sm border border-sand/20 bg-washed-black/80 px-6 py-10 text-center md:px-10",
+        className,
+      )}
+    >
+      <p className="label-text text-[11px] tracking-[0.18em] text-sand/70">
+        {title}
+      </p>
+      <p className="body-text-small mx-auto mt-4 max-w-md text-ivory/78">
+        {children}
+      </p>
+    </div>
+  );
+}

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -60,10 +60,27 @@ function StudioGallery({
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const isLoading = photos === undefined;
+  const isError = photos === null;
   const availablePhotos = photos ?? [];
 
   if (isLoading) {
     return <GallerySkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <div className="reveal reveal-delay-2">
+        <div className="relative mx-auto w-full max-w-5xl">
+          <div className="relative flex min-h-[40vh] w-full items-center justify-center overflow-hidden border border-sand/10 bg-washed-black px-6 py-20 md:min-h-[50vh]">
+            <div className="body-text-small max-w-md text-center text-ivory/78">
+              We couldn&rsquo;t load the gallery preview. Your connection or our
+              servers may be having a moment. Try refreshing the page in a little
+              while.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   if (availablePhotos.length === 0) {
@@ -71,7 +88,10 @@ function StudioGallery({
       <div className="reveal reveal-delay-2">
         <div className="relative mx-auto w-full max-w-5xl">
           <div className="relative flex h-[60vh] w-full items-center justify-center overflow-hidden border border-sand/10 bg-washed-black md:h-[72vh]">
-            <div className="body-text-small text-ivory/50">No images available</div>
+            <div className="body-text-small text-ivory/78 px-6 text-center max-w-md">
+              Photo carousel is not published yet. New images will appear here
+              when they go live.
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/the-space.tsx
+++ b/src/components/the-space.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 
 export type GalleryPhoto = {
   stableId: string;
@@ -55,13 +56,22 @@ function GallerySkeleton() {
 function StudioGallery({
   photos,
 }: {
-  photos: GalleryPhoto[] | null | undefined;
+  photos:
+    | GalleryPhoto[]
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
 }) {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const isLoading = photos === undefined;
-  const isError = photos === null;
-  const availablePhotos = photos ?? [];
+  const isError = photos === PUBLIC_CONVEX_QUERY_FAILED;
+  const availablePhotos =
+    photos === undefined ||
+    photos === null ||
+    photos === PUBLIC_CONVEX_QUERY_FAILED
+      ? []
+      : photos;
 
   if (isLoading) {
     return <GallerySkeleton />;
@@ -209,7 +219,11 @@ function StudioGallery({
 export function TheSpace({
   photos,
 }: {
-  photos: GalleryPhoto[] | null | undefined;
+  photos:
+    | GalleryPhoto[]
+    | null
+    | undefined
+    | typeof PUBLIC_CONVEX_QUERY_FAILED;
 }) {
   return (
     <section
@@ -248,7 +262,11 @@ export function TheSpace({
           key={
             photos === undefined
               ? "__pending__"
-              : (photos ?? []).map((photo) => photo.stableId).join("|")
+              : photos === PUBLIC_CONVEX_QUERY_FAILED
+                ? "__failed__"
+                : photos === null
+                  ? "__empty__"
+                  : photos.map((photo) => photo.stableId).join("|")
           }
           photos={photos}
         />

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -42,6 +42,14 @@ export type MarketingFeatureFlags = {
   galleryPage: boolean;
 };
 
+/** Conservative defaults when Convex marketing flags are unavailable (error UI). */
+export const DEFAULT_MARKETING_FEATURE_FLAGS: MarketingFeatureFlags = {
+  aboutPage: false,
+  recordingsPage: true,
+  pricingSection: true,
+  galleryPage: true,
+};
+
 /**
  * When `false`, `/gallery` 404s and the Gallery nav item is hidden.
  * Missing `galleryPage` is treated as on (matches `DEFAULT_IS_ENABLED.photos`).

--- a/src/lib/use-public-convex-query.ts
+++ b/src/lib/use-public-convex-query.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { useQueries, type Preloaded, type RequestForQueries } from "convex/react";
+import { convexToJson, jsonToConvex, type Value } from "convex/values";
+import {
+  makeFunctionReference,
+  type FunctionArgs,
+  type FunctionReference,
+  type FunctionReturnType,
+} from "convex/server";
+import { usePathname } from "next/navigation";
+
+import { computePreviewTag } from "@/lib/sentry";
+
+const QUERY_KEY = "q" as const;
+
+/**
+ * Subscribes to a public Convex query without throwing on transport or query
+ * errors (unlike {@link useQuery}, which throws when the subscription yields an
+ * `Error`). Returns `undefined` while loading, `null` on failure, and the result
+ * otherwise. Reports the first occurrence of each distinct error to Sentry with
+ * a coarse `section` tag for triage (INF-108 / INF-81).
+ */
+export function usePublicConvexQuery<Query extends FunctionReference<"query">>(
+  query: Query,
+  args: FunctionArgs<Query>,
+  options: { readonly section: string; readonly skip?: boolean },
+): FunctionReturnType<Query> | undefined | null {
+  const pathname = usePathname();
+  const argsValue = args as Value;
+  const argsForQuery = args as Record<string, Value>;
+  const skip = options.skip === true;
+  const queries = useMemo((): RequestForQueries => {
+    if (skip) {
+      return {} as RequestForQueries;
+    }
+    return {
+      [QUERY_KEY]: {
+        query,
+        args: argsForQuery,
+      },
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Convex pattern: args JSON identity
+  }, [JSON.stringify(convexToJson(argsValue)), query, skip]);
+
+  const results = useQueries(queries);
+  const raw = results[QUERY_KEY];
+  const lastLogged = useRef<string | null>(null);
+
+  if (raw instanceof Error) {
+    const fingerprint = `${options.section}:${raw.message}`;
+    if (lastLogged.current !== fingerprint) {
+      lastLogged.current = fingerprint;
+      Sentry.captureException(raw, {
+        tags: {
+          section: options.section,
+          preview: computePreviewTag(pathname),
+        },
+      });
+    }
+    return null;
+  }
+
+  if (raw !== undefined) {
+    lastLogged.current = null;
+  }
+
+  return raw as FunctionReturnType<Query> | undefined;
+}
+
+/**
+ * Like {@link usePreloadedQuery}, but when the live subscription fails the hook
+ * returns `null` instead of throwing. While the live result is still `undefined`,
+ * the preloaded snapshot is returned (same hydration behavior as Convex).
+ */
+export function useSafePreloadedQuery<Query extends FunctionReference<"query">>(
+  preloaded: Preloaded<Query>,
+  options: { readonly section: string },
+): FunctionReturnType<Query> | undefined | null {
+  const args = useMemo(
+    () => jsonToConvex(preloaded._argsJSON) as FunctionArgs<Query>,
+    [preloaded._argsJSON],
+  );
+  const preloadedResult = useMemo(
+    () => jsonToConvex(preloaded._valueJSON) as FunctionReturnType<Query>,
+    [preloaded._valueJSON],
+  );
+  const queryRef = useMemo(
+    () => makeFunctionReference<"query", FunctionArgs<Query>, FunctionReturnType<Query>>(preloaded._name),
+    [preloaded._name],
+  );
+
+  const live = usePublicConvexQuery(queryRef, args, options);
+
+  if (live === undefined) {
+    return preloadedResult;
+  }
+  return live;
+}

--- a/src/lib/use-public-convex-query.ts
+++ b/src/lib/use-public-convex-query.ts
@@ -16,18 +16,27 @@ import { computePreviewTag } from "@/lib/sentry";
 
 const QUERY_KEY = "q" as const;
 
+/** Subscription or transport failure; distinct from a Convex handler returning `null`. */
+export const PUBLIC_CONVEX_QUERY_FAILED = Symbol("PublicConvexQueryFailed");
+
+export type PublicConvexQueryResult<T> =
+  | T
+  | undefined
+  | typeof PUBLIC_CONVEX_QUERY_FAILED;
+
 /**
  * Subscribes to a public Convex query without throwing on transport or query
  * errors (unlike {@link useQuery}, which throws when the subscription yields an
- * `Error`). Returns `undefined` while loading, `null` on failure, and the result
- * otherwise. Reports the first occurrence of each distinct error to Sentry with
+ * `Error`). Returns `undefined` while loading, {@link PUBLIC_CONVEX_QUERY_FAILED}
+ * on failure, and the query result otherwise (including `null` if the handler
+ * returns `null`). Reports the first occurrence of each distinct error to Sentry with
  * a coarse `section` tag for triage (INF-108 / INF-81).
  */
 export function usePublicConvexQuery<Query extends FunctionReference<"query">>(
   query: Query,
   args: FunctionArgs<Query>,
   options: { readonly section: string; readonly skip?: boolean },
-): FunctionReturnType<Query> | undefined | null {
+): PublicConvexQueryResult<FunctionReturnType<Query>> {
   const pathname = usePathname();
   const argsValue = args as Value;
   const argsForQuery = args as Record<string, Value>;
@@ -60,7 +69,7 @@ export function usePublicConvexQuery<Query extends FunctionReference<"query">>(
         },
       });
     }
-    return null;
+    return PUBLIC_CONVEX_QUERY_FAILED;
   }
 
   if (raw !== undefined) {
@@ -72,13 +81,13 @@ export function usePublicConvexQuery<Query extends FunctionReference<"query">>(
 
 /**
  * Like {@link usePreloadedQuery}, but when the live subscription fails the hook
- * returns `null` instead of throwing. While the live result is still `undefined`,
+ * returns {@link PUBLIC_CONVEX_QUERY_FAILED} instead of throwing. While the live result is still `undefined`,
  * the preloaded snapshot is returned (same hydration behavior as Convex).
  */
 export function useSafePreloadedQuery<Query extends FunctionReference<"query">>(
   preloaded: Preloaded<Query>,
   options: { readonly section: string },
-): FunctionReturnType<Query> | undefined | null {
+): PublicConvexQueryResult<FunctionReturnType<Query>> {
   const args = useMemo(
     () => jsonToConvex(preloaded._argsJSON) as FunctionArgs<Query>,
     [preloaded._argsJSON],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements INF-108: when Convex fails or returns empty/unpublished data, the public marketing site shows readable fallbacks instead of infinite skeletons or a thrown error boundary.

## Changes

- **`usePublicConvexQuery` / `useSafePreloadedQuery`** (`src/lib/use-public-convex-query.ts`): Uses Convex `useQueries` so subscription errors surface as `Error` values instead of throwing (Convex `useQuery` throws on `Error`). First distinct error per section is reported to Sentry with `tags.section` and `tags.preview` (INF-81 alignment).
- **Homepage** (`home-client.tsx`, `homepage-shell.tsx`): All public preloads and live fallbacks use the safe hooks; marketing live query uses `skip` when props already supply flags.
- **`PublicSectionNotice`** (`src/components/public-section-notice.tsx`): Shared `role="status"` / `aria-live="polite"` block for outage copy (no focus trap).
- **Sections**: Pricing (`dynamic-pricing`), gear (`equipment-specs`), carousel (`the-space`), FAQ (`faq`), amenities (`amenities-nearby`), recordings (`recordings-page-client` + client), gallery (`gallery-page-client` + client), about (`about-client` + `about-layout`) each handle `null` vs empty vs loading.
- **`DEFAULT_MARKETING_FEATURE_FLAGS`** (`site-settings.ts`): Conservative nav defaults when marketing flags cannot be refreshed (Recordings/Gallery/Pricing remain reachable where routes exist).

## Testing

- `bun run lint`
- `bun run build`

## Simulated outage

Block `NEXT_PUBLIC_CONVEX_URL` in devtools or point to an invalid host: sections should show notices / empty copy instead of spinning forever, and the client should not throw from `useQuery` on subscription errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-108](https://linear.app/only-football-fans/issue/INF-108/lls-public-reads-graceful-failures-empty-states)

<div><a href="https://cursor.com/agents/bc-5188f758-00f8-4938-9481-1890c36411d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5188f758-00f8-4938-9481-1890c36411d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

