### PR TITLE
Fix React #301 by deferring Sentry capture out of render

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -15,7 +15,10 @@ export default function GlobalError({
 
   if (lastReportedError.current !== error) {
     lastReportedError.current = error;
-    Sentry.captureException(error);
+    const captured = error;
+    queueMicrotask(() => {
+      Sentry.captureException(captured);
+    });
   }
 
   return (

--- a/src/lib/use-public-convex-query.ts
+++ b/src/lib/use-public-convex-query.ts
@@ -62,11 +62,15 @@ export function usePublicConvexQuery<Query extends FunctionReference<"query">>(
     const fingerprint = `${options.section}:${raw.message}`;
     if (lastLogged.current !== fingerprint) {
       lastLogged.current = fingerprint;
-      Sentry.captureException(raw, {
-        tags: {
-          section: options.section,
-          preview: computePreviewTag(pathname),
-        },
+      const err = raw;
+      const previewTag = computePreviewTag(pathname);
+      queueMicrotask(() => {
+        Sentry.captureException(err, {
+          tags: {
+            section: options.section,
+            preview: previewTag,
+          },
+        });
       });
     }
     return PUBLIC_CONVEX_QUERY_FAILED;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production showed **Minified React error #301**, which corresponds to React aborting after too many render-phase updates (often triggered when something schedules nested updates during render).

## Changes

- **`usePublicConvexQuery`**: When a Convex subscription returns an `Error`, we still dedupe logging by fingerprint, but **`Sentry.captureException` now runs in `queueMicrotask`** so it runs after the current render finishes instead of synchronously inside the hook body.
- **`global-error`**: Same pattern for the root error boundary so reporting does not run synchronously during render.

## Notes

- **`net::ERR_BLOCKED_BY_CLIENT` on Sentry ingest** is separate (browser extensions). It does not cause #301; it only blocks sending events.

## Verification

- `bun run lint`
- `bun test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ba9c460-7f7f-4207-a371-b6a4a93dfea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ba9c460-7f7f-4207-a371-b6a4a93dfea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

