### PR TITLE
Fix React #301: scope Convex Clerk provider + defer Sentry

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -13,6 +13,7 @@ import {
   SIDEBAR_COOKIE_NAME,
 } from "@/lib/sidebar-cookie";
 import { Toaster } from "sonner";
+import { ConvexAuthenticatedProvider } from "@/components/convex-authenticated-provider";
 
 export const metadata: Metadata = {
   title: {
@@ -33,22 +34,24 @@ export default async function AdminLayout({
   );
 
   return (
-    <TooltipProvider>
-      <Toaster richColors closeButton position="top-right" />
-      <SidebarProvider
-        className="admin-dashboard-tokens"
-        defaultOpen={defaultOpen}
-        resizableWidth
-        sidebarWidthStorageKey="admin_sidebar_width_px"
-      >
-        <CmsWorkspaceProvider>
-          <AdminSidebar />
-          <SidebarInset className="text-foreground">
-            <CmsAdminPageSlot>{children}</CmsAdminPageSlot>
-            <CmsPersistentToolbarHost />
-          </SidebarInset>
-        </CmsWorkspaceProvider>
-      </SidebarProvider>
-    </TooltipProvider>
+    <ConvexAuthenticatedProvider>
+      <TooltipProvider>
+        <Toaster richColors closeButton position="top-right" />
+        <SidebarProvider
+          className="admin-dashboard-tokens"
+          defaultOpen={defaultOpen}
+          resizableWidth
+          sidebarWidthStorageKey="admin_sidebar_width_px"
+        >
+          <CmsWorkspaceProvider>
+            <AdminSidebar />
+            <SidebarInset className="text-foreground">
+              <CmsAdminPageSlot>{children}</CmsAdminPageSlot>
+              <CmsPersistentToolbarHost />
+            </SidebarInset>
+          </CmsWorkspaceProvider>
+        </SidebarProvider>
+      </TooltipProvider>
+    </ConvexAuthenticatedProvider>
   );
 }

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -4,16 +4,16 @@ import { type Preloaded } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { HomepageShell } from "@/components/homepage-shell";
 import {
+  type HomePublishedPreloads,
+  useHomePublishedQueries,
+} from "@/lib/use-home-published-queries";
+import {
   PUBLIC_CONVEX_QUERY_FAILED,
-  usePublicConvexQuery,
-  useSafePreloadedQuery,
   type PublicConvexQueryResult,
 } from "@/lib/use-public-convex-query";
 import type { PublishedAmenitiesNearby } from "@/components/amenities-nearby";
 import type { GalleryPhoto } from "@/components/the-space";
 import type { FaqCategoryProps } from "@/components/faq";
-import type { MarketingFeatureFlags } from "@/lib/site-settings";
-
 type PreloadedPricing = Preloaded<typeof api.public.getPublishedPricingFlags> | null;
 type PreloadedGear = Preloaded<typeof api.public.getPublishedGear> | null;
 type PreloadedPhotos = Preloaded<typeof api.public.getPublishedCarouselPhotos> | null;
@@ -46,296 +46,20 @@ function faqCategoriesFromFaq(
   return faq.categories;
 }
 
-function PhotosData({
-  preloaded,
-  children,
-}: {
-  preloaded: PreloadedPhotos | null;
-  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
-}) {
-  if (preloaded) {
-    return <PhotosFromPreload preloaded={preloaded}>{children}</PhotosFromPreload>;
-  }
-  return <PhotosLive>{children}</PhotosLive>;
-}
-
-function PhotosFromPreload({
-  preloaded,
-  children,
-}: {
-  preloaded: NonNullable<PreloadedPhotos>;
-  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
-}) {
-  const photos = useSafePreloadedQuery(preloaded, { section: "home_photos" });
-  return <>{children(photos)}</>;
-}
-
-function PhotosLive({
-  children,
-}: {
-  children: (photos: PublicConvexQueryResult<GalleryPhoto[]>) => React.ReactNode;
-}) {
-  const photos = usePublicConvexQuery(
-    api.public.getPublishedCarouselPhotos,
-    {},
-    { section: "home_photos" },
-  );
-  return <>{children(photos)}</>;
-}
-
-function FaqData({
-  preloaded,
-  children,
-}: {
-  preloaded: PreloadedFaq;
-  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
-}) {
-  if (preloaded) {
-    return <FaqFromPreload preloaded={preloaded}>{children}</FaqFromPreload>;
-  }
-  return <FaqLive>{children}</FaqLive>;
-}
-
-function FaqFromPreload({
-  preloaded,
-  children,
-}: {
-  preloaded: NonNullable<PreloadedFaq>;
-  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
-}) {
-  const faq = useSafePreloadedQuery(preloaded, { section: "home_faq" });
-  return <>{children(faq)}</>;
-}
-
-function FaqLive({
-  children,
-}: {
-  children: (faq: PublicConvexQueryResult<PublishedFaqPayload>) => React.ReactNode;
-}) {
-  const faq = usePublicConvexQuery(api.public.getPublishedFaq, {}, {
-    section: "home_faq",
-  });
-  return <>{children(faq)}</>;
-}
-
-function MarketingData({
-  preloaded,
-  children,
-}: {
-  preloaded: PreloadedMarketing;
-  children: (
-    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
-  ) => React.ReactNode;
-}) {
-  if (preloaded) {
-    return (
-      <MarketingFromPreload preloaded={preloaded}>
-        {children}
-      </MarketingFromPreload>
-    );
-  }
-  return <MarketingLive>{children}</MarketingLive>;
-}
-
-function MarketingFromPreload({
-  preloaded,
-  children,
-}: {
-  preloaded: NonNullable<PreloadedMarketing>;
-  children: (
-    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
-  ) => React.ReactNode;
-}) {
-  const marketing = useSafePreloadedQuery(preloaded, {
-    section: "home_marketing_flags",
-  });
-  return <>{children(marketing)}</>;
-}
-
-function MarketingLive({
-  children,
-}: {
-  children: (
-    marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>,
-  ) => React.ReactNode;
-}) {
-  const marketing = usePublicConvexQuery(
-    api.public.getPublishedMarketingFeatureFlags,
-    {},
-    { section: "home_marketing_flags" },
-  );
-  return <>{children(marketing)}</>;
-}
-
-function AmenitiesData({
-  preloaded,
-  children,
-}: {
-  preloaded: PreloadedAmenities;
-  children: (
-    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
-  ) => React.ReactNode;
-}) {
-  if (preloaded) {
-    return (
-      <AmenitiesFromPreload preloaded={preloaded}>
-        {children}
-      </AmenitiesFromPreload>
-    );
-  }
-  return <AmenitiesLive>{children}</AmenitiesLive>;
-}
-
-function AmenitiesFromPreload({
-  preloaded,
-  children,
-}: {
-  preloaded: NonNullable<PreloadedAmenities>;
-  children: (
-    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
-  ) => React.ReactNode;
-}) {
-  const amenities = useSafePreloadedQuery(preloaded, {
-    section: "home_amenities",
-  });
-  return <>{children(amenities)}</>;
-}
-
-function AmenitiesLive({
-  children,
-}: {
-  children: (
-    amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>,
-  ) => React.ReactNode;
-}) {
-  const amenities = usePublicConvexQuery(
-    api.public.getPublishedAmenitiesNearby,
-    {},
-    { section: "home_amenities" },
-  );
-  return <>{children(amenities)}</>;
-}
-
-function BothPreloaded({
-  preloadedPricing,
-  preloadedGear,
-  photos,
-  faq,
-  marketing,
-  amenities,
-}: {
-  preloadedPricing: NonNullable<PreloadedPricing>;
-  preloadedGear: NonNullable<PreloadedGear>;
-  photos: PublicConvexQueryResult<GalleryPhoto[]>;
-  faq: PublicConvexQueryResult<PublishedFaqPayload>;
-  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
-  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
-}) {
-  const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
-    section: "home_pricing",
-  });
-  const gear = useSafePreloadedQuery(preloadedGear, { section: "home_gear" });
+function HomeInner({ preloads }: { readonly preloads: HomePublishedPreloads }) {
+  const q = useHomePublishedQueries(preloads);
   return (
     <HomepageShell
-      pricingFlags={pricingFlags}
-      marketingFeatureFlags={marketing}
-      gear={gear}
-      photos={photos}
-      faqCategories={faqCategoriesFromFaq(faq)}
-      amenities={amenities}
-    />
-  );
-}
-
-function PricingPreloadedGearLive({
-  preloadedPricing,
-  photos,
-  faq,
-  marketing,
-  amenities,
-}: {
-  preloadedPricing: NonNullable<PreloadedPricing>;
-  photos: PublicConvexQueryResult<GalleryPhoto[]>;
-  faq: PublicConvexQueryResult<PublishedFaqPayload>;
-  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
-  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
-}) {
-  const pricingFlags = useSafePreloadedQuery(preloadedPricing, {
-    section: "home_pricing",
-  });
-  const gear = usePublicConvexQuery(api.public.getPublishedGear, {}, {
-    section: "home_gear",
-  });
-  return (
-    <HomepageShell
-      pricingFlags={pricingFlags}
-      marketingFeatureFlags={marketing}
-      gear={gear}
-      photos={photos}
-      faqCategories={faqCategoriesFromFaq(faq)}
-      amenities={amenities}
-    />
-  );
-}
-
-function PricingLiveGearPreloaded({
-  preloadedGear,
-  photos,
-  faq,
-  marketing,
-  amenities,
-}: {
-  preloadedGear: NonNullable<PreloadedGear>;
-  photos: PublicConvexQueryResult<GalleryPhoto[]>;
-  faq: PublicConvexQueryResult<PublishedFaqPayload>;
-  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
-  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
-}) {
-  const pricingFlags = usePublicConvexQuery(
-    api.public.getPublishedPricingFlags,
-    {},
-    { section: "home_pricing" },
-  );
-  const gear = useSafePreloadedQuery(preloadedGear, { section: "home_gear" });
-  return (
-    <HomepageShell
-      pricingFlags={pricingFlags}
-      marketingFeatureFlags={marketing}
-      gear={gear}
-      photos={photos}
-      faqCategories={faqCategoriesFromFaq(faq)}
-      amenities={amenities}
-    />
-  );
-}
-
-function BothLive({
-  photos,
-  faq,
-  marketing,
-  amenities,
-}: {
-  photos: PublicConvexQueryResult<GalleryPhoto[]>;
-  faq: PublicConvexQueryResult<PublishedFaqPayload>;
-  marketing: PublicConvexQueryResult<MarketingFeatureFlags | null>;
-  amenities: PublicConvexQueryResult<PublishedAmenitiesNearby | null>;
-}) {
-  const pricingFlags = usePublicConvexQuery(
-    api.public.getPublishedPricingFlags,
-    {},
-    { section: "home_pricing" },
-  );
-  const gear = usePublicConvexQuery(api.public.getPublishedGear, {}, {
-    section: "home_gear",
-  });
-  return (
-    <HomepageShell
-      pricingFlags={pricingFlags}
-      marketingFeatureFlags={marketing}
-      gear={gear}
-      photos={photos}
-      faqCategories={faqCategoriesFromFaq(faq)}
-      amenities={amenities}
+      pricingFlags={q.pricingFlags}
+      marketingFeatureFlags={q.marketing}
+      gear={q.gear}
+      photos={q.photos as PublicConvexQueryResult<GalleryPhoto[]>}
+      faqCategories={faqCategoriesFromFaq(q.faq)}
+      amenities={
+        q.amenities as PublicConvexQueryResult<
+          PublishedAmenitiesNearby | null
+        >
+      }
     />
   );
 }
@@ -355,64 +79,13 @@ export function HomeClient({
   preloadedMarketing: PreloadedMarketing;
   preloadedAmenities: PreloadedAmenities;
 }) {
-  return (
-    <MarketingData preloaded={preloadedMarketing}>
-      {(marketing) => (
-        <PhotosData preloaded={preloadedPhotos}>
-          {(photos) => (
-            <FaqData preloaded={preloadedFaq}>
-              {(faq) => (
-                <AmenitiesData preloaded={preloadedAmenities}>
-                  {(amenities) => {
-                    if (preloadedPricing && preloadedGear) {
-                      return (
-                        <BothPreloaded
-                          preloadedPricing={preloadedPricing}
-                          preloadedGear={preloadedGear}
-                          photos={photos}
-                          faq={faq}
-                          marketing={marketing}
-                          amenities={amenities}
-                        />
-                      );
-                    }
-                    if (preloadedPricing) {
-                      return (
-                        <PricingPreloadedGearLive
-                          preloadedPricing={preloadedPricing}
-                          photos={photos}
-                          faq={faq}
-                          marketing={marketing}
-                          amenities={amenities}
-                        />
-                      );
-                    }
-                    if (preloadedGear) {
-                      return (
-                        <PricingLiveGearPreloaded
-                          preloadedGear={preloadedGear}
-                          photos={photos}
-                          faq={faq}
-                          marketing={marketing}
-                          amenities={amenities}
-                        />
-                      );
-                    }
-                    return (
-                      <BothLive
-                        photos={photos}
-                        faq={faq}
-                        marketing={marketing}
-                        amenities={amenities}
-                      />
-                    );
-                  }}
-                </AmenitiesData>
-              )}
-            </FaqData>
-          )}
-        </PhotosData>
-      )}
-    </MarketingData>
-  );
+  const preloads: HomePublishedPreloads = {
+    pricing: preloadedPricing,
+    gear: preloadedGear,
+    photos: preloadedPhotos,
+    faq: preloadedFaq,
+    marketing: preloadedMarketing,
+    amenities: preloadedAmenities,
+  };
+  return <HomeInner preloads={preloads} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ClerkProvider } from "@clerk/nextjs";
-import { ConvexClientProvider } from "@/components/convex-client-provider";
+import { ConvexPublicProvider } from "@/components/convex-public-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 
@@ -117,7 +117,7 @@ export default function RootLayout({
       <body className="antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           <ClerkProvider>
-            <ConvexClientProvider>{children}</ConvexClientProvider>
+            <ConvexPublicProvider>{children}</ConvexPublicProvider>
           </ClerkProvider>
         </ThemeProvider>
         <Analytics />

--- a/src/app/preview/layout.tsx
+++ b/src/app/preview/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import { ConvexAuthenticatedProvider } from "@/components/convex-authenticated-provider";
+
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
@@ -12,5 +14,7 @@ export default function PreviewLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <>{children}</>;
+  return (
+    <ConvexAuthenticatedProvider>{children}</ConvexAuthenticatedProvider>
+  );
 }

--- a/src/components/convex-authenticated-provider.tsx
+++ b/src/components/convex-authenticated-provider.tsx
@@ -4,7 +4,12 @@ import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/nextjs";
 import { convex } from "@/lib/convex-client";
 
-export function ConvexClientProvider({
+/**
+ * Admin + owner preview: Clerk JWT wiring for Convex mutations and
+ * {@link Authenticated} gates. Scoped to these subtrees so public pages never
+ * hit ConvexProviderWithAuth's render-phase state sync (React #301).
+ */
+export function ConvexAuthenticatedProvider({
   children,
 }: {
   children: React.ReactNode;

--- a/src/components/convex-public-provider.tsx
+++ b/src/components/convex-public-provider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ConvexProvider } from "convex/react";
+import { convex } from "@/lib/convex-client";
+
+/**
+ * Public marketing routes: anonymous Convex subscriptions only.
+ *
+ * Avoids {@link ConvexProviderWithClerk} here: Convex's auth integration calls
+ * `setState` during render when syncing Clerk loading/unauthenticated state,
+ * which can hit React error #301 (render-phase update loop) on React 19.
+ */
+export function ConvexPublicProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+}

--- a/src/components/homepage-shell.tsx
+++ b/src/components/homepage-shell.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { api } from "../../convex/_generated/api";
-import {
-  PUBLIC_CONVEX_QUERY_FAILED,
-  usePublicConvexQuery,
-} from "@/lib/use-public-convex-query";
+import { PUBLIC_CONVEX_QUERY_FAILED } from "@/lib/use-public-convex-query";
 import { AmenitiesNearby } from "@/components/amenities-nearby";
 import { ArtistInquiries } from "@/components/artist-inquiries";
 import { MarketingPricingSection } from "@/components/dynamic-pricing";
@@ -86,7 +82,8 @@ export function HomepageShell({
 }: HomepageShellProps) {
   const { scrollY, containerRef } = useScrollAndReveal();
   const pathname = usePathname();
-  const marketingFromPropsResolved =
+  const marketingResolved =
+    marketingFromProps === undefined ||
     marketingFromProps === PUBLIC_CONVEX_QUERY_FAILED
       ? undefined
       : marketingFromProps;
@@ -96,20 +93,7 @@ export function HomepageShell({
   const homeSectionBase = isPreview ? "/preview" : "/";
   const recordingsNavHref = isPreview ? "/preview/recordings" : "/recordings";
 
-  const liveMarketing = usePublicConvexQuery(
-    api.public.getPublishedMarketingFeatureFlags,
-    {},
-    {
-      section: "home_marketing_flags",
-      skip: marketingFromPropsResolved !== undefined,
-    },
-  );
-  const marketing =
-    marketingFromPropsResolved === undefined
-      ? liveMarketing
-      : marketingFromPropsResolved;
-  const marketingForUi =
-    marketing === PUBLIC_CONVEX_QUERY_FAILED ? undefined : marketing;
+  const marketingForUi = marketingResolved;
 
   const logoScale = calculateLogoScale(scrollY);
   // Nav-link visibility intentionally defaults to OFF while the marketing

--- a/src/lib/use-home-published-queries.ts
+++ b/src/lib/use-home-published-queries.ts
@@ -1,0 +1,205 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import * as Sentry from "@sentry/nextjs";
+import {
+  useQueries,
+  type Preloaded,
+  type RequestForQueries,
+} from "convex/react";
+import type { Value } from "convex/values";
+import { jsonToConvex } from "convex/values";
+import type { FunctionReturnType } from "convex/server";
+import { usePathname } from "next/navigation";
+
+import { api } from "../../convex/_generated/api";
+import {
+  PUBLIC_CONVEX_QUERY_FAILED,
+  type PublicConvexQueryResult,
+} from "@/lib/use-public-convex-query";
+import { computePreviewTag } from "@/lib/sentry";
+
+export type HomePublishedPreloads = {
+  readonly pricing:
+    | Preloaded<typeof api.public.getPublishedPricingFlags>
+    | null;
+  readonly gear: Preloaded<typeof api.public.getPublishedGear> | null;
+  readonly photos:
+    | Preloaded<typeof api.public.getPublishedCarouselPhotos>
+    | null;
+  readonly faq: Preloaded<typeof api.public.getPublishedFaq> | null;
+  readonly marketing:
+    | Preloaded<typeof api.public.getPublishedMarketingFeatureFlags>
+    | null;
+  readonly amenities:
+    | Preloaded<typeof api.public.getPublishedAmenitiesNearby>
+    | null;
+};
+
+export type HomePublishedSnapshot = {
+  readonly pricingFlags: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedPricingFlags>
+  >;
+  readonly gear: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedGear>
+  >;
+  readonly photos: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedCarouselPhotos>
+  >;
+  readonly faq: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedFaq>
+  >;
+  readonly marketing: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedMarketingFeatureFlags>
+  >;
+  readonly amenities: PublicConvexQueryResult<
+    FunctionReturnType<typeof api.public.getPublishedAmenitiesNearby>
+  >;
+};
+
+/**
+ * Single Convex subscription for all homepage published reads (SSR preload +
+ * live updates). Avoids stacking many useQueries observers — Convex's internal
+ * subscription helper can synchronously setState during render when identities
+ * churn, tripping React's "Too many re-renders" guard.
+ */
+export function useHomePublishedQueries(
+  preloaded: HomePublishedPreloads,
+): HomePublishedSnapshot {
+  const pathname = usePathname();
+  const lastLoggedBySection = useRef<Partial<Record<string, string>>>({});
+
+  const queries = useMemo(
+    (): RequestForQueries => ({
+      pricingFlags: {
+        query: api.public.getPublishedPricingFlags,
+        args: {} as Record<string, Value>,
+      },
+      gear: {
+        query: api.public.getPublishedGear,
+        args: {} as Record<string, Value>,
+      },
+      photos: {
+        query: api.public.getPublishedCarouselPhotos,
+        args: {} as Record<string, Value>,
+      },
+      faq: {
+        query: api.public.getPublishedFaq,
+        args: {} as Record<string, Value>,
+      },
+      marketing: {
+        query: api.public.getPublishedMarketingFeatureFlags,
+        args: {} as Record<string, Value>,
+      },
+      amenities: {
+        query: api.public.getPublishedAmenitiesNearby,
+        args: {} as Record<string, Value>,
+      },
+    }),
+    [],
+  );
+
+  const results = useQueries(queries);
+
+  const pricingSnap = useMemo(
+    () =>
+      preloaded.pricing
+        ? (jsonToConvex(preloaded.pricing._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedPricingFlags
+          >)
+        : undefined,
+    [preloaded.pricing],
+  );
+  const gearSnap = useMemo(
+    () =>
+      preloaded.gear
+        ? (jsonToConvex(preloaded.gear._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedGear
+          >)
+        : undefined,
+    [preloaded.gear],
+  );
+  const photosSnap = useMemo(
+    () =>
+      preloaded.photos
+        ? (jsonToConvex(preloaded.photos._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedCarouselPhotos
+          >)
+        : undefined,
+    [preloaded.photos],
+  );
+  const faqSnap = useMemo(
+    () =>
+      preloaded.faq
+        ? (jsonToConvex(preloaded.faq._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedFaq
+          >)
+        : undefined,
+    [preloaded.faq],
+  );
+  const marketingSnap = useMemo(
+    () =>
+      preloaded.marketing
+        ? (jsonToConvex(preloaded.marketing._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedMarketingFeatureFlags
+          >)
+        : undefined,
+    [preloaded.marketing],
+  );
+  const amenitiesSnap = useMemo(
+    () =>
+      preloaded.amenities
+        ? (jsonToConvex(preloaded.amenities._valueJSON) as FunctionReturnType<
+            typeof api.public.getPublishedAmenitiesNearby
+          >)
+        : undefined,
+    [preloaded.amenities],
+  );
+
+  function mergeOne<T>(
+    section: string,
+    raw: unknown,
+    snapshot: T | undefined,
+  ): PublicConvexQueryResult<T> {
+    if (raw instanceof Error) {
+      const fingerprint = `${section}:${raw.message}`;
+      if (lastLoggedBySection.current[section] !== fingerprint) {
+        lastLoggedBySection.current[section] = fingerprint;
+        const err = raw;
+        const previewTag = computePreviewTag(pathname);
+        queueMicrotask(() => {
+          Sentry.captureException(err, {
+            tags: { section, preview: previewTag },
+          });
+        });
+      }
+      return PUBLIC_CONVEX_QUERY_FAILED;
+    }
+    if (raw !== undefined) {
+      delete lastLoggedBySection.current[section];
+      return raw as T;
+    }
+    return snapshot as T | undefined;
+  }
+
+  return {
+    pricingFlags: mergeOne(
+      "home_pricing",
+      results.pricingFlags,
+      pricingSnap,
+    ),
+    gear: mergeOne("home_gear", results.gear, gearSnap),
+    photos: mergeOne("home_photos", results.photos, photosSnap),
+    faq: mergeOne("home_faq", results.faq, faqSnap),
+    marketing: mergeOne(
+      "home_marketing_flags",
+      results.marketing,
+      marketingSnap,
+    ),
+    amenities: mergeOne(
+      "home_amenities",
+      results.amenities,
+      amenitiesSnap,
+    ),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Minified React error #301** / "Too many re-renders" on the homepage, with stack pointing at **`BothPreloaded`** in `home-client.tsx`.

### Root cause

`usePublicConvexQuery` uses Convex `useQueries` → internal **`use_subscription`**, which **calls `setState` synchronously during render** when the subscription config identity changes (`node_modules/convex/src/react/use_subscription.ts`).

The old `HomeClient` nested **six** independent `useQueries` observers (marketing, photos, FAQ, amenities, pricing, gear). During hydration those identities can churn enough times in one pass that React aborts after **25 render-phase updates**.

### Fix

1. **`useHomePublishedQueries`** (`src/lib/use-home-published-queries.ts`): one **stable** `useMemo` query map + **single** `useQueries` for all six published homepage reads; merge SSR preload snapshots the same way as `useSafePreloadedQuery`; per-section Sentry dedupe via ref map.

2. **`HomeClient`**: thin wrapper → **`HomeInner`** that only calls `useHomePublishedQueries` and renders **`HomepageShell`**.

3. **`HomepageShell`**: removed the **second** marketing `usePublicConvexQuery`. Also treats **`PUBLIC_CONVEX_QUERY_FAILED`** like **`undefined`** for nav so failed marketing flags do not flip between duplicate subscriptions.

### Earlier commits on this branch

- Defer Sentry `captureException` out of render  
- Scope `ConvexProviderWithClerk` to admin/preview  

### Verification

- `bun run lint`, `bun test`, `bun run build`

Pull locally and run `bun run dev` — homepage should load without the #301 loop.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ba9c460-7f7f-4207-a371-b6a4a93dfea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ba9c460-7f7f-4207-a371-b6a4a93dfea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

