### PR TITLE
INF-128: Show contact submissions in CMS dashboard

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as admin_about from "../admin/about.js";
 import type * as admin_aboutTeam from "../admin/aboutTeam.js";
 import type * as admin_audio from "../admin/audio.js";
 import type * as admin_gear from "../admin/gear.js";
+import type * as admin_inquiries from "../admin/inquiries.js";
 import type * as admin_photos from "../admin/photos.js";
 import type * as admin_pricing from "../admin/pricing.js";
 import type * as admin_publish from "../admin/publish.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   "admin/aboutTeam": typeof admin_aboutTeam;
   "admin/audio": typeof admin_audio;
   "admin/gear": typeof admin_gear;
+  "admin/inquiries": typeof admin_inquiries;
   "admin/photos": typeof admin_photos;
   "admin/pricing": typeof admin_pricing;
   "admin/publish": typeof admin_publish;

--- a/convex/admin/inquiries.ts
+++ b/convex/admin/inquiries.ts
@@ -1,0 +1,31 @@
+import { query } from "../_generated/server";
+import { requireCmsOwner } from "../lib/auth";
+
+const ADMIN_INQUIRIES_LIST_LIMIT = 100;
+
+/**
+ * Recent contact form submissions for the CMS (read-only).
+ * Gated to the same identities as other admin mutations (`requireCmsOwner`).
+ */
+export const listForAdmin = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireCmsOwner(ctx);
+
+    const rows = await ctx.db
+      .query("inquiries")
+      .withIndex("by_createdAt")
+      .order("desc")
+      .take(ADMIN_INQUIRIES_LIST_LIMIT);
+
+    return rows.map((row) => ({
+      _id: row._id,
+      artistName: row.artistName,
+      contactName: row.contactName,
+      email: row.email,
+      phone: row.phone,
+      message: row.message,
+      createdAt: row.createdAt,
+    }));
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -41,7 +41,7 @@ export default defineSchema({
     phone: v.optional(v.string()),
     message: v.string(),
     createdAt: v.number(),
-  }),
+  }).index("by_createdAt", ["createdAt"]),
 
   cmsSections: defineTable({
     section: cmsSectionRowValidator,

--- a/src/app/admin/inquiries/inquiries-editor-skeleton.tsx
+++ b/src/app/admin/inquiries/inquiries-editor-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Loading shell for the contact submissions admin page. */
+export function InquiriesEditorSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-4 w-full max-w-xl" />
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-lg border border-border/60 bg-muted/20 p-5"
+          >
+            <Skeleton className="mb-3 h-5 w-40" />
+            <Skeleton className="h-3 w-full max-w-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/inquiries/inquiries-editor-skeleton.tsx
+++ b/src/app/admin/inquiries/inquiries-editor-skeleton.tsx
@@ -5,14 +5,21 @@ export function InquiriesEditorSkeleton() {
   return (
     <div className="space-y-6">
       <Skeleton className="h-4 w-full max-w-xl" />
-      <div className="space-y-4">
-        {Array.from({ length: 3 }).map((_, i) => (
+      <div className="overflow-hidden rounded-lg border border-border/60 bg-card">
+        <div className="border-b border-border/60 bg-muted/30 px-2 py-3">
+          <Skeleton className="h-3 w-32" />
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-lg border border-border/60 bg-muted/20 p-5"
+            className="flex items-center gap-4 border-b border-border/40 px-2 py-3 last:border-0"
           >
-            <Skeleton className="mb-3 h-5 w-40" />
-            <Skeleton className="h-3 w-full max-w-lg" />
+            <Skeleton className="size-4" />
+            <Skeleton className="h-3 w-32" />
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="ml-auto h-3 w-28" />
           </div>
         ))}
       </div>

--- a/src/app/admin/inquiries/inquiries-editor.tsx
+++ b/src/app/admin/inquiries/inquiries-editor.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Fragment, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import {
   Authenticated,
   Unauthenticated,
@@ -9,71 +11,188 @@ import {
 import { api } from "../../../../convex/_generated/api";
 import { formatInquiryTimestamp } from "@/lib/format-inquiry-timestamp";
 import { InquiriesQueryErrorBoundary } from "@/components/admin/inquiries-query-error-boundary";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
-function InquiryRow({
-  artistName,
-  contactName,
-  email,
-  phone,
-  message,
-  createdAt,
-}: {
+type InquiryRowData = {
+  readonly _id: string;
   readonly artistName: string;
   readonly contactName: string;
   readonly email: string;
   readonly phone: string | undefined;
   readonly message: string;
   readonly createdAt: number;
-}) {
+};
+
+const COLUMN_COUNT = 6;
+
+function InquiriesTable({ rows }: { readonly rows: ReadonlyArray<InquiryRowData> }) {
+  const [openId, setOpenId] = useState<string | null>(null);
+
   return (
-    <article className="rounded-lg border border-border bg-card p-4 sm:p-5">
-      <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-        <h3 className="headline-secondary text-foreground text-base">
-          {artistName}
-        </h3>
-        <time
-          className="body-text-small shrink-0 text-muted-foreground"
-          dateTime={new Date(createdAt).toISOString()}
-        >
-          {formatInquiryTimestamp(createdAt)}
-        </time>
-      </div>
-      <dl className="body-text-small grid gap-2 text-muted-foreground sm:grid-cols-2">
-        <div>
-          <dt className="sr-only">Contact name</dt>
-          <dd>
-            <span className="text-foreground/80">Contact: </span>
-            {contactName}
-          </dd>
-        </div>
-        <div>
-          <dt className="sr-only">Email</dt>
-          <dd className="min-w-0 break-all">
-            <span className="text-foreground/80">Email: </span>
-            <a className="text-primary underline-offset-2 hover:underline" href={`mailto:${email}`}>
-              {email}
-            </a>
-          </dd>
-        </div>
-        {phone ? (
-          <div className="sm:col-span-2">
-            <dt className="sr-only">Phone</dt>
-            <dd className="min-w-0 break-all">
-              <span className="text-foreground/80">Phone: </span>
-              <a className="text-primary underline-offset-2 hover:underline" href={`tel:${phone}`}>
-                {phone}
-              </a>
-            </dd>
-          </div>
-        ) : null}
-      </dl>
-      <div className="mt-4 border-t border-border pt-3">
-        <h4 className="sr-only">Message</h4>
-        <p className="body-text-small max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-foreground">
-          {message}
-        </p>
-      </div>
-    </article>
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead className="w-10" aria-label="Expand row" />
+            <TableHead>Artist</TableHead>
+            <TableHead>Contact</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Phone</TableHead>
+            <TableHead className="text-right">Submitted</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => {
+            const isOpen = openId === row._id;
+            const panelId = `inquiry-panel-${row._id}`;
+            const toggle = () => setOpenId(isOpen ? null : row._id);
+
+            return (
+              <Fragment key={row._id}>
+                <TableRow
+                  className={cn(
+                    "cursor-pointer",
+                    isOpen && "border-b-0",
+                  )}
+                  onClick={toggle}
+                  data-state={isOpen ? "selected" : undefined}
+                >
+                  <TableCell className="w-10">
+                    <button
+                      type="button"
+                      aria-expanded={isOpen}
+                      aria-controls={panelId}
+                      aria-label={`${isOpen ? "Collapse" : "Expand"} inquiry from ${row.artistName}`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        toggle();
+                      }}
+                      className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <ChevronDown
+                        aria-hidden
+                        className={cn(
+                          "size-4 transition-transform duration-200",
+                          isOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
+                  </TableCell>
+                  <TableCell className="font-medium text-foreground">
+                    {row.artistName}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {row.contactName}
+                  </TableCell>
+                  <TableCell className="max-w-[14rem] truncate">
+                    <a
+                      className="text-primary underline-offset-2 hover:underline"
+                      href={`mailto:${row.email}`}
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {row.email}
+                    </a>
+                  </TableCell>
+                  <TableCell>
+                    {row.phone ? (
+                      <a
+                        className="text-primary underline-offset-2 hover:underline"
+                        href={`tel:${row.phone}`}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        {row.phone}
+                      </a>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right text-muted-foreground">
+                    <time dateTime={new Date(row.createdAt).toISOString()}>
+                      {formatInquiryTimestamp(row.createdAt)}
+                    </time>
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  id={panelId}
+                  role="region"
+                  aria-label={`Message from ${row.artistName}`}
+                  hidden={!isOpen}
+                  className="bg-muted/20 hover:bg-muted/20"
+                >
+                  <TableCell />
+                  <TableCell
+                    colSpan={COLUMN_COUNT - 1}
+                    className="whitespace-normal py-4 pr-4"
+                  >
+                    <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Message
+                    </h4>
+                    <p className="body-text-small max-h-72 overflow-y-auto whitespace-pre-wrap break-words text-foreground">
+                      {row.message}
+                    </p>
+                  </TableCell>
+                </TableRow>
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function InquiriesTableSkeleton() {
+  return (
+    <div
+      className="overflow-hidden rounded-lg border border-border bg-card"
+      aria-busy="true"
+      aria-label="Loading inquiries"
+    >
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead className="w-10" />
+            <TableHead>Artist</TableHead>
+            <TableHead>Contact</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Phone</TableHead>
+            <TableHead className="text-right">Submitted</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <TableRow key={i} className="animate-pulse">
+              <TableCell>
+                <div className="size-4 rounded bg-muted" />
+              </TableCell>
+              <TableCell>
+                <div className="h-3 w-32 rounded bg-muted" />
+              </TableCell>
+              <TableCell>
+                <div className="h-3 w-24 rounded bg-muted" />
+              </TableCell>
+              <TableCell>
+                <div className="h-3 w-40 rounded bg-muted" />
+              </TableCell>
+              <TableCell>
+                <div className="h-3 w-24 rounded bg-muted" />
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="ml-auto h-3 w-28 rounded bg-muted" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
@@ -81,20 +200,7 @@ function InquiriesListBody() {
   const rows = useQuery(api.admin.inquiries.listForAdmin, {});
 
   if (rows === undefined) {
-    return (
-      <div className="space-y-4" aria-busy="true" aria-label="Loading inquiries">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="animate-pulse rounded-lg border border-border/60 bg-muted/20 p-5"
-          >
-            <div className="mb-3 h-5 w-48 rounded bg-muted" />
-            <div className="mb-2 h-3 w-full max-w-md rounded bg-muted" />
-            <div className="h-3 w-full max-w-sm rounded bg-muted" />
-          </div>
-        ))}
-      </div>
-    );
+    return <InquiriesTableSkeleton />;
   }
 
   if (rows.length === 0) {
@@ -105,21 +211,7 @@ function InquiriesListBody() {
     );
   }
 
-  return (
-    <div className="space-y-4">
-      {rows.map((row) => (
-        <InquiryRow
-          key={row._id}
-          artistName={row.artistName}
-          contactName={row.contactName}
-          email={row.email}
-          phone={row.phone}
-          message={row.message}
-          createdAt={row.createdAt}
-        />
-      ))}
-    </div>
-  );
+  return <InquiriesTable rows={rows} />;
 }
 
 export function InquiriesEditor() {

--- a/src/app/admin/inquiries/inquiries-editor.tsx
+++ b/src/app/admin/inquiries/inquiries-editor.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useQuery,
+} from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { formatInquiryTimestamp } from "@/lib/format-inquiry-timestamp";
+import { InquiriesQueryErrorBoundary } from "@/components/admin/inquiries-query-error-boundary";
+
+function InquiryRow({
+  artistName,
+  contactName,
+  email,
+  phone,
+  message,
+  createdAt,
+}: {
+  readonly artistName: string;
+  readonly contactName: string;
+  readonly email: string;
+  readonly phone: string | undefined;
+  readonly message: string;
+  readonly createdAt: number;
+}) {
+  return (
+    <article className="rounded-lg border border-border bg-card p-4 sm:p-5">
+      <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+        <h3 className="headline-secondary text-foreground text-base">
+          {artistName}
+        </h3>
+        <time
+          className="body-text-small shrink-0 text-muted-foreground"
+          dateTime={new Date(createdAt).toISOString()}
+        >
+          {formatInquiryTimestamp(createdAt)}
+        </time>
+      </div>
+      <dl className="body-text-small grid gap-2 text-muted-foreground sm:grid-cols-2">
+        <div>
+          <dt className="sr-only">Contact name</dt>
+          <dd>
+            <span className="text-foreground/80">Contact: </span>
+            {contactName}
+          </dd>
+        </div>
+        <div>
+          <dt className="sr-only">Email</dt>
+          <dd className="min-w-0 break-all">
+            <span className="text-foreground/80">Email: </span>
+            <a className="text-primary underline-offset-2 hover:underline" href={`mailto:${email}`}>
+              {email}
+            </a>
+          </dd>
+        </div>
+        {phone ? (
+          <div className="sm:col-span-2">
+            <dt className="sr-only">Phone</dt>
+            <dd className="min-w-0 break-all">
+              <span className="text-foreground/80">Phone: </span>
+              <a className="text-primary underline-offset-2 hover:underline" href={`tel:${phone}`}>
+                {phone}
+              </a>
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+      <div className="mt-4 border-t border-border pt-3">
+        <h4 className="sr-only">Message</h4>
+        <p className="body-text-small max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-foreground">
+          {message}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function InquiriesListBody() {
+  const rows = useQuery(api.admin.inquiries.listForAdmin, {});
+
+  if (rows === undefined) {
+    return (
+      <div className="space-y-4" aria-busy="true" aria-label="Loading inquiries">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-lg border border-border/60 bg-muted/20 p-5"
+          >
+            <div className="mb-3 h-5 w-48 rounded bg-muted" />
+            <div className="mb-2 h-3 w-full max-w-md rounded bg-muted" />
+            <div className="h-3 w-full max-w-sm rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="body-text text-muted-foreground rounded-lg border border-dashed border-border bg-muted/20 px-4 py-8 text-center">
+        No contact submissions yet. New inquiries from the site form will appear here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {rows.map((row) => (
+        <InquiryRow
+          key={row._id}
+          artistName={row.artistName}
+          contactName={row.contactName}
+          email={row.email}
+          phone={row.phone}
+          message={row.message}
+          createdAt={row.createdAt}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function InquiriesEditor() {
+  return (
+    <>
+      <AuthLoading>
+        <p className="body-text text-muted-foreground">Authenticating…</p>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <p className="body-text text-muted-foreground">
+          Sign in to view contact submissions.
+        </p>
+      </Unauthenticated>
+
+      <Authenticated>
+        <InquiriesQueryErrorBoundary>
+          <InquiriesListBody />
+        </InquiriesQueryErrorBoundary>
+      </Authenticated>
+    </>
+  );
+}

--- a/src/app/admin/inquiries/loading.tsx
+++ b/src/app/admin/inquiries/loading.tsx
@@ -1,0 +1,29 @@
+import { AdminSectionLoadingFrame } from "@/components/admin/admin-section-loading-frame";
+import { getAdminPendingLayout } from "@/lib/admin-pending-layout";
+
+const layout = getAdminPendingLayout("/admin/inquiries");
+
+export default function InquiriesLoading() {
+  return (
+    <AdminSectionLoadingFrame
+      title={layout.title}
+      outerClassName={layout.outerClassName}
+      innerClassName={layout.innerClassName}
+    >
+      <div className="space-y-6">
+        <div className="h-4 w-full max-w-xl animate-pulse rounded bg-muted" />
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="animate-pulse rounded-lg border border-border/60 bg-muted/20 p-5"
+            >
+              <div className="mb-3 h-5 w-40 rounded bg-muted" />
+              <div className="h-3 w-full max-w-lg rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </AdminSectionLoadingFrame>
+  );
+}

--- a/src/app/admin/inquiries/page.tsx
+++ b/src/app/admin/inquiries/page.tsx
@@ -11,14 +11,24 @@ const InquiriesEditor = dynamic(
     import("./inquiries-editor").then((m) => ({ default: m.InquiriesEditor })),
   {
     loading: () => (
-      <div className="space-y-4" aria-busy="true">
-        {Array.from({ length: 3 }).map((_, i) => (
+      <div
+        className="overflow-hidden rounded-lg border border-border/60 bg-card"
+        aria-busy="true"
+      >
+        <div className="border-b border-border/60 bg-muted/30 px-2 py-3">
+          <div className="h-3 w-32 rounded bg-muted" />
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={i}
-            className="animate-pulse rounded-lg border border-border/60 bg-muted/20 p-5"
+            className="flex animate-pulse items-center gap-4 border-b border-border/40 px-2 py-3 last:border-0"
           >
-            <div className="mb-3 h-5 w-40 rounded bg-muted" />
-            <div className="h-3 w-full max-w-lg rounded bg-muted" />
+            <div className="size-4 rounded bg-muted" />
+            <div className="h-3 w-32 rounded bg-muted" />
+            <div className="h-3 w-24 rounded bg-muted" />
+            <div className="h-3 w-40 rounded bg-muted" />
+            <div className="h-3 w-24 rounded bg-muted" />
+            <div className="ml-auto h-3 w-28 rounded bg-muted" />
           </div>
         ))}
       </div>

--- a/src/app/admin/inquiries/page.tsx
+++ b/src/app/admin/inquiries/page.tsx
@@ -1,0 +1,50 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+import { AdminHeader } from "@/components/admin/admin-header";
+import {
+  ADMIN_PAGE_INNER_CLASS,
+  ADMIN_PAGE_OUTER_CLASS,
+} from "@/lib/admin-pending-layout";
+
+const InquiriesEditor = dynamic(
+  () =>
+    import("./inquiries-editor").then((m) => ({ default: m.InquiriesEditor })),
+  {
+    loading: () => (
+      <div className="space-y-4" aria-busy="true">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-lg border border-border/60 bg-muted/20 p-5"
+          >
+            <div className="mb-3 h-5 w-40 rounded bg-muted" />
+            <div className="h-3 w-full max-w-lg rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    ),
+  },
+);
+
+export const metadata: Metadata = {
+  title: "Contact submissions",
+};
+
+export default function AdminInquiriesPage() {
+  return (
+    <>
+      <AdminHeader title="Contact submissions" />
+      <div className={ADMIN_PAGE_OUTER_CLASS}>
+        <div className={`${ADMIN_PAGE_INNER_CLASS} space-y-6`}>
+          <div>
+            <p className="body-text-small text-muted-foreground max-w-2xl">
+              Read-only list of inquiries saved from the public contact form (newest first).
+              Email delivery may still be used for notifications; this view is the in-dashboard record.
+            </p>
+          </div>
+          <InquiriesEditor />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import { AdminHeader } from "@/components/admin/admin-header";
 import { AdminDashboardNavCards } from "@/components/admin/admin-dashboard-nav-cards";
+import { InquiriesDashboardPreview } from "@/components/admin/inquiries-dashboard-preview";
 import {
   ADMIN_DASHBOARD_INNER_CLASS,
   ADMIN_PAGE_OUTER_CLASS,
@@ -21,6 +22,8 @@ export default function DashboardPage() {
               Manage your studio site content from here.
             </p>
           </div>
+
+          <InquiriesDashboardPreview />
 
           <AdminDashboardNavCards />
         </div>

--- a/src/components/admin/admin-dashboard-loading-skeleton.tsx
+++ b/src/components/admin/admin-dashboard-loading-skeleton.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-/** Matches the dashboard welcome block + manage grid on `/admin`. */
+/** Matches the dashboard welcome block + inquiries preview + manage grid on `/admin`. */
 export function AdminDashboardLoadingSkeleton() {
   return (
     <>
@@ -8,8 +8,23 @@ export function AdminDashboardLoadingSkeleton() {
         <Skeleton className="mb-1 h-6 w-40" />
         <Skeleton className="h-3.5 w-80 max-w-full" />
       </div>
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-5 sm:p-6">
+        <Skeleton className="mb-2 h-5 w-56" />
+        <Skeleton className="mb-4 h-3 w-full max-w-md" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-3 border-b border-border/40 pb-3 last:border-0">
+              <Skeleton className="size-10 shrink-0 rounded-md" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-36" />
+                <Skeleton className="h-3 w-full max-w-xs" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 9 }).map((_, i) => (
+        {Array.from({ length: 10 }).map((_, i) => (
           <div
             key={i}
             className="rounded-lg border border-border/60 bg-muted/20 p-5"

--- a/src/components/admin/inquiries-dashboard-preview.tsx
+++ b/src/components/admin/inquiries-dashboard-preview.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight, Inbox } from "lucide-react";
+import {
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useQuery,
+} from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { formatInquiryTimestamp } from "@/lib/format-inquiry-timestamp";
+import { InquiriesQueryErrorBoundary } from "@/components/admin/inquiries-query-error-boundary";
+
+const DASHBOARD_PREVIEW_LIMIT = 5;
+
+function RecentInquiriesPreviewBody() {
+  const rows = useQuery(api.admin.inquiries.listForAdmin, {});
+
+  if (rows === undefined) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex animate-pulse gap-3 border-b border-border/60 pb-3 last:border-0">
+            <div className="h-10 w-10 shrink-0 rounded-md bg-muted" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="h-4 w-40 rounded bg-muted" />
+              <div className="h-3 w-full max-w-xs rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="body-text-small text-muted-foreground py-2">
+        No submissions yet. They will show up here when visitors use the contact form.
+      </p>
+    );
+  }
+
+  const slice = rows.slice(0, DASHBOARD_PREVIEW_LIMIT);
+
+  return (
+    <ul className="divide-y divide-border/60">
+      {slice.map((row) => (
+        <li key={row._id} className="flex gap-3 py-3 first:pt-0">
+          <div
+            className="flex size-10 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+            aria-hidden
+          >
+            <Inbox className="size-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="body-text-small truncate font-medium text-foreground">
+              {row.artistName}
+            </p>
+            <p className="body-text-small truncate text-muted-foreground">
+              {row.contactName} · {row.email}
+            </p>
+            <p className="body-text-small mt-0.5 text-muted-foreground">
+              <time dateTime={new Date(row.createdAt).toISOString()}>
+                {formatInquiryTimestamp(row.createdAt)}
+              </time>
+            </p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function InquiriesDashboardPreview() {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5 sm:p-6">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="headline-secondary text-foreground text-base">
+            Recent contact submissions
+          </h2>
+          <p className="body-text-small text-muted-foreground mt-0.5">
+            Newest inquiries from the public form (read-only).
+          </p>
+        </div>
+        <Link
+          href="/admin/inquiries"
+          className="body-text-small inline-flex items-center gap-1 font-medium text-primary hover:underline"
+        >
+          View all
+          <ChevronRight className="size-4" aria-hidden />
+        </Link>
+      </div>
+
+      <AuthLoading>
+        <p className="body-text-small text-muted-foreground">Authenticating…</p>
+      </AuthLoading>
+
+      <Unauthenticated>
+        <p className="body-text-small text-muted-foreground">
+          Sign in to see recent submissions.
+        </p>
+      </Unauthenticated>
+
+      <Authenticated>
+        <InquiriesQueryErrorBoundary>
+          <RecentInquiriesPreviewBody />
+        </InquiriesQueryErrorBoundary>
+      </Authenticated>
+    </section>
+  );
+}

--- a/src/components/admin/inquiries-query-error-boundary.test.tsx
+++ b/src/components/admin/inquiries-query-error-boundary.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { ConvexError } from "convex/values";
+import { InquiriesQueryErrorBoundary } from "./inquiries-query-error-boundary";
+
+describe("InquiriesQueryErrorBoundary", () => {
+  test("getDerivedStateFromError captures the error", () => {
+    const err = new ConvexError({
+      code: "UNAUTHORIZED",
+      message: "You do not have permission to perform this action.",
+      kind: "forbidden",
+    });
+    const state = InquiriesQueryErrorBoundary.getDerivedStateFromError(err);
+    expect(state?.error).toBe(err);
+  });
+});

--- a/src/components/admin/inquiries-query-error-boundary.tsx
+++ b/src/components/admin/inquiries-query-error-boundary.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ConvexError } from "convex/values";
+import type { CmsConvexErrorPayload } from "@/lib/effect-errors";
+
+function isCmsConvexErrorPayload(value: unknown): value is CmsConvexErrorPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    typeof (value as { code: unknown }).code === "string" &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string"
+  );
+}
+
+function convexErrorMessage(error: unknown): string {
+  if (error instanceof ConvexError) {
+    const data = error.data;
+    if (isCmsConvexErrorPayload(data)) {
+      return data.message;
+    }
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Something went wrong while loading inquiries.";
+}
+
+type Props = { readonly children: ReactNode };
+
+type State = { readonly error: Error | null };
+
+/**
+ * Catches Convex query failures from child `useQuery` (e.g. forbidden) so the
+ * admin shell does not white-screen.
+ */
+export class InquiriesQueryErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("admin inquiries query failed", error, info.componentStack);
+  }
+
+  override render() {
+    if (this.state.error) {
+      return (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          {convexErrorMessage(this.state.error)}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/admin/inquiries-query-error-boundary.tsx
+++ b/src/components/admin/inquiries-query-error-boundary.tsx
@@ -2,18 +2,7 @@
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { ConvexError } from "convex/values";
-import type { CmsConvexErrorPayload } from "@/lib/effect-errors";
-
-function isCmsConvexErrorPayload(value: unknown): value is CmsConvexErrorPayload {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "code" in value &&
-    typeof (value as { code: unknown }).code === "string" &&
-    "message" in value &&
-    typeof (value as { message: unknown }).message === "string"
-  );
-}
+import { isCmsConvexErrorPayload } from "@/lib/effect-errors";
 
 function convexErrorMessage(error: unknown): string {
   if (error instanceof ConvexError) {

--- a/src/lib/admin-nav.test.ts
+++ b/src/lib/admin-nav.test.ts
@@ -10,6 +10,7 @@ describe("ADMIN_MANAGE_NAV_ITEMS", () => {
   test("includes every CMS admin destination expected by the sidebar", () => {
     const hrefs = ADMIN_MANAGE_NAV_ITEMS.map((i) => i.href);
     expect(hrefs).toEqual([
+      "/admin/inquiries",
       "/admin/about",
       "/admin/photos",
       "/admin/gear",

--- a/src/lib/admin-nav.ts
+++ b/src/lib/admin-nav.ts
@@ -9,6 +9,7 @@ import {
   Settings,
   MapPin,
   CircleHelp,
+  Inbox,
 } from "lucide-react";
 
 /** Shared routes for admin sidebar and dashboard cards (excludes /admin root). */
@@ -18,6 +19,12 @@ export const ADMIN_MANAGE_NAV_ITEMS: {
   icon: LucideIcon;
   description: string;
 }[] = [
+  {
+    title: "Contact submissions",
+    href: "/admin/inquiries",
+    icon: Inbox,
+    description: "Inquiries from the site form",
+  },
   {
     title: "About",
     href: "/admin/about",

--- a/src/lib/admin-pending-layout.ts
+++ b/src/lib/admin-pending-layout.ts
@@ -9,6 +9,7 @@ import { AmenitiesEditorSkeleton } from "@/app/admin/amenities-nearby/amenities-
 import { FaqEditorSkeleton } from "@/app/admin/faq/faq-editor-skeleton";
 import { VideosEditorSkeleton } from "@/app/admin/videos/videos-editor-skeleton";
 import { SettingsEditorSkeleton } from "@/app/admin/settings/settings-editor-skeleton";
+import { InquiriesEditorSkeleton } from "@/app/admin/inquiries/inquiries-editor-skeleton";
 
 /** Shared layout shell classes for admin CMS pages and their loading states. */
 export const ADMIN_PAGE_OUTER_CLASS = "flex-1 px-5 py-8 pb-12 sm:px-8";
@@ -32,6 +33,12 @@ const ROUTES = {
     outerClassName: ADMIN_PAGE_OUTER_CLASS,
     innerClassName: ADMIN_DASHBOARD_INNER_CLASS,
     Body: AdminDashboardLoadingSkeleton,
+  },
+  "/admin/inquiries": {
+    title: "Contact submissions",
+    outerClassName: ADMIN_PAGE_OUTER_CLASS,
+    innerClassName: ADMIN_PAGE_INNER_CLASS,
+    Body: InquiriesEditorSkeleton,
   },
   "/admin/about": {
     title: "About",

--- a/src/lib/effect-errors.ts
+++ b/src/lib/effect-errors.ts
@@ -79,7 +79,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isCmsConvexErrorPayload(
+export function isCmsConvexErrorPayload(
   value: unknown,
 ): value is CmsConvexErrorPayload {
   if (!isRecord(value)) return false;

--- a/src/lib/format-inquiry-timestamp.test.ts
+++ b/src/lib/format-inquiry-timestamp.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { formatInquiryTimestamp } from "./format-inquiry-timestamp";
+
+describe("formatInquiryTimestamp", () => {
+  test("formats a known instant in America/New_York", () => {
+    const ms = Date.UTC(2026, 0, 15, 18, 30, 0);
+    const out = formatInquiryTimestamp(ms, "America/New_York");
+    expect(out).toContain("2026");
+    expect(out).toContain("Jan");
+  });
+});

--- a/src/lib/format-inquiry-timestamp.ts
+++ b/src/lib/format-inquiry-timestamp.ts
@@ -1,0 +1,14 @@
+/**
+ * Format `createdAt` (epoch ms) for admin inquiry lists. Uses a fixed calendar
+ * so snapshots/tests stay stable across environments.
+ */
+export function formatInquiryTimestamp(
+  createdAtMs: number,
+  timeZone = "America/New_York",
+): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(createdAtMs));
+}

--- a/src/lib/format-inquiry-timestamp.ts
+++ b/src/lib/format-inquiry-timestamp.ts
@@ -1,13 +1,13 @@
 /**
- * Format `createdAt` (epoch ms) for admin inquiry lists. Uses a fixed calendar
- * so snapshots/tests stay stable across environments.
+ * Format `createdAt` (epoch ms) for admin inquiry lists in the browser's local
+ * timezone. Tests pass an explicit `timeZone` for stable assertions.
  */
 export function formatInquiryTimestamp(
   createdAtMs: number,
-  timeZone = "America/New_York",
+  timeZone?: string,
 ): string {
   return new Intl.DateTimeFormat("en-US", {
-    timeZone,
+    ...(timeZone !== undefined ? { timeZone } : {}),
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(createdAtMs));

--- a/src/lib/route-prewarm.test.ts
+++ b/src/lib/route-prewarm.test.ts
@@ -135,6 +135,15 @@ describe("prewarmAdminNavigation", () => {
     expect(prewarmQuery.mock.calls.length).toBe(1);
   });
 
+  test("prewarms contact submissions list", () => {
+    const { client, prewarmQuery } = makeFakeClient();
+    prewarmAdminNavigation(client, "/admin/inquiries");
+    expect(prewarmQuery.mock.calls.length).toBe(1);
+    expect(prewarmQuery.mock.calls[0][0].query).toEqual(
+      api.admin.inquiries.listForAdmin,
+    );
+  });
+
   test("prewarms about (section + marketing flags only)", () => {
     const { client, prewarmQuery } = makeFakeClient();
     prewarmAdminNavigation(client, "/admin/about");

--- a/src/lib/route-prewarm.ts
+++ b/src/lib/route-prewarm.ts
@@ -88,6 +88,11 @@ export function prewarmAdminNavigation(
       makeRouteQuerySpec(api.cms.getSection, { section: "settings" }),
     ]);
   }
+  if (href === "/admin/inquiries") {
+    prewarmSpecs(convex, [
+      makeRouteQuerySpec(api.admin.inquiries.listForAdmin, {}),
+    ]);
+  }
   if (href === "/admin/pricing") {
     prewarmSpecs(convex, [
       makeRouteQuerySpec(api.admin.pricing.listDraft, {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **INF-128**: admins can view contact form submissions from the CMS without relying on email alone.

## Changes

- **Convex:** Added `by_createdAt` index on `inquiries` and new `api.admin.inquiries.listForAdmin` query (owner-gated via `requireCmsOwner`, same as other admin mutations). Returns up to 100 rows, **newest first**, using the index with `order("desc")`.
- **Dashboard:** `/admin` now includes a **Recent contact submissions** card (preview of five) with link to the full list.
- **Full page:** New `/admin/inquiries` read-only list with loading skeleton, empty state, and an error boundary so Convex auth/forbidden errors surface inline instead of crashing the tree. Long messages use a **max-height scroll area** and `break-words` / `whitespace-pre-wrap`.
- **Nav / UX:** Contact submissions entry in `ADMIN_MANAGE_NAV_ITEMS` (sidebar + dashboard cards), optimistic nav skeleton via `admin-pending-layout`, and route prewarm for the list query.
- **Tests:** Timestamp formatter test, nav href order update, prewarm test for inquiries, and a small error-boundary static test.

## Notes

- `convex/_generated/api.d.ts` was updated manually to register `admin/inquiries` (cloud codegen was unavailable without Convex auth). `api.js` remains `anyApi`, so runtime references work as before.

## Verification

- `bun run lint`
- `bun test`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-128](https://linear.app/only-football-fans/issue/INF-128/show-contact-submissions-in-the-cms-dashboard)

<div><a href="https://cursor.com/agents/bc-109e3142-beef-4efe-af87-b4ac41ded160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-109e3142-beef-4efe-af87-b4ac41ded160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

