### PR TITLE
fix(ci): Cursor autofix check succeeds when agent is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ on:
         type: boolean
         default: false
 
+# Separate groups per event so a PR synchronize does not cancel the push run
+# (and vice versa), which previously showed "cancelled" and a red commit status.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -56,27 +58,13 @@ jobs:
       - name: Build
         run: bun run build
 
+  # Always run after test-and-build so the check is green when we skip the agent.
+  # A skipped job fails required status checks; a successful no-op does not.
   cursor-autofix:
     name: Cursor autofix
     runs-on: ubuntu-latest
     needs: test-and-build
-    if: >-
-      ${{
-        failure() &&
-        needs.test-and-build.result == 'failure' &&
-        !startsWith(github.head_ref || github.ref_name, 'cursor/') &&
-        (
-          github.event_name == 'push' ||
-          (
-            github.event_name == 'workflow_dispatch' &&
-            inputs.cursor_autofix
-          ) ||
-          (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == github.repository
-          )
-        )
-      }}
+    if: always()
     permissions:
       contents: read
       pull-requests: read
@@ -85,12 +73,63 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Skip autofix (not applicable)
+        if: >-
+          always() &&
+          (
+            needs.test-and-build.result != 'failure' ||
+            startsWith(github.head_ref || github.ref_name, 'cursor/') ||
+            !(
+              github.event_name == 'push' ||
+              (
+                github.event_name == 'workflow_dispatch' &&
+                inputs.cursor_autofix
+              ) ||
+              (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name == github.repository
+              )
+            )
+          )
+        run: |
+          echo "Cursor autofix skipped (tests passed, job was not a failure, or this event/branch is not eligible)."
+
       - name: Setup Bun
+        if: >-
+          always() &&
+          needs.test-and-build.result == 'failure' &&
+          !startsWith(github.head_ref || github.ref_name, 'cursor/') &&
+          (
+            github.event_name == 'push' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.cursor_autofix
+            ) ||
+            (
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Cache Bun install
+        if: >-
+          always() &&
+          needs.test-and-build.result == 'failure' &&
+          !startsWith(github.head_ref || github.ref_name, 'cursor/') &&
+          (
+            github.event_name == 'push' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.cursor_autofix
+            ) ||
+            (
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
@@ -99,9 +138,39 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        if: >-
+          always() &&
+          needs.test-and-build.result == 'failure' &&
+          !startsWith(github.head_ref || github.ref_name, 'cursor/') &&
+          (
+            github.event_name == 'push' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.cursor_autofix
+            ) ||
+            (
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
         run: bun install --frozen-lockfile
 
       - name: Start Cursor Cloud Agent
+        if: >-
+          always() &&
+          needs.test-and-build.result == 'failure' &&
+          !startsWith(github.head_ref || github.ref_name, 'cursor/') &&
+          (
+            github.event_name == 'push' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.cursor_autofix
+            ) ||
+            (
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
         run: bun .github/scripts/cursor-autofix.ts
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitHub was showing a failing commit status when **Cursor autofix** was skipped (for example after tests passed). If that job is a **required** check, a **skipped** job counts as not satisfied, so the PR/commit stays red.

The screenshot also showed **Test and build (push)** cancelled while **Test and build (pull_request)** succeeded. That came from a single concurrency group for both `push` and `pull_request`, so one event cancelled the other.

## Changes

1. **`cursor-autofix` job** — The job always runs after `test-and-build` (`if: always()`). When autofix should not run, a **Skip autofix (not applicable)** step runs and exits successfully instead of skipping the whole job. When tests fail and the branch/event is eligible, the existing Bun setup and `cursor-autofix.ts` steps run unchanged.

2. **Concurrency** — The group key now includes `github.event_name`, so push and pull_request workflows for the same ref no longer cancel each other.

## Notes

If the repository still has a branch rule that treats **cancelled** as failure, the concurrency change should reduce spurious cancellations on PRs that receive both push and pull_request runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5679b3b-35ba-43ad-bf4c-6ed435f12102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5679b3b-35ba-43ad-bf4c-6ed435f12102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

