### PR TITLE
fix(ci): avoid failing Cursor autofix when test/build already pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
     with:
       workflows: CI
       workflow_name: ${{ github.workflow }}
+      # Avoid calling the Cursor API when CI already succeeded; ci-autofix's "Start Cursor
+      # Cloud Agent" step exits non-zero immediately on some setups and turns green builds red.
+      # Dry-run prints the prompt only and still satisfies a required autofix job.
+      dry_run: ${{ needs.test-and-build.result == 'success' }}
       pr_url: ${{ github.event.pull_request.html_url || '' }}
       # Cursor Cloud Agent expects a branch/ref name here; passing a commit SHA makes
       # createCloudAgent fail with "Branch '<sha>' does not exist".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation used the GitHub Actions API against [run 25293422566](https://github.com/wrowston/lula-lake-sound/actions/runs/25293422566) on `perf/lawn-inspired-optimizations`.

- **Test and build**: success (install, tests, build all succeeded).
- **cursor-autofix / Cursor autofix**: **failure** on step **Start Cursor Cloud Agent** (immediate failure).

So the red CI conclusion was driven by the reusable autofix workflow, not by application tests or Next.js build failures.

Local reproduction with CI env vars: `bun install --frozen-lockfile`, `bun test`, and `bun run build` **all succeeded** — consistent with the passing `test-and-build` job above.

## Change

Pass `dry_run: ${{ needs.test-and-build.result == 'success' }}` into `wrowston/ci-autofix` so when the repo’s real gates already passed, the Cursor Cloud Agent script only runs in dry-run mode (prompt only, exits 0) instead of invoking the Cursor API — which avoids spurious autofix-job failures marking the workflow red.

When `test-and-build` fails, `dry_run` is false so the agent can still run for real autofix scenarios.

## Verification

- GitHub Actions API inspection of failing job/steps on run **25293422566**.
- `bun run lint` ✓  
- Earlier in this workspace: CI-equivalent env + `bun install --frozen-lockfile`, `bun test`, `bun run build` ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c1b8d0c-fac1-47e9-ab89-d46cdb7ba884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c1b8d0c-fac1-47e9-ab89-d46cdb7ba884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

