### PR TITLE
fix(ci): gate cursor-autofix on failed test-and-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,10 @@ jobs:
 
   cursor-autofix:
     needs: [test-and-build]
-    # Always run after test-and-build so the check is green when we skip the agent.
-    # A skipped job fails required status checks; a successful no-op does not.
-    if: always()
+    # Only run when tests or build fail. Running the Cursor agent on every push can
+    # fail the whole workflow (API/timeout) even when the app is healthy; green runs
+    # should not depend on autofix infrastructure.
+    if: needs.test-and-build.result == 'failure'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The failing run (e.g. [run 25293551837](https://github.com/wrowston/lula-lake-sound/actions/runs/25293551837)) showed **Test and build** succeeding while the **cursor-autofix / Cursor autofix** reusable job was still running or could fail independently. The app-level CI steps (`bun install --frozen-lockfile`, `bun test`, `bun run build`) are healthy on that branch when reproduced locally with the same env vars as the workflow.

`cursor-autofix` starts a Cursor Cloud Agent (`Start Cursor Cloud Agent` in wrowston/ci-autofix). That depends on API/key availability and runtime; when it fails or times out, it can turn the whole **CI** workflow red even though tests and build passed.

## Change

Run the `cursor-autofix` reusable workflow **only when** `needs.test-and-build.result == 'failure'`, so green runs reflect application health and autofix stays a recovery path for failing builds/tests.

## Verification (local)

With CI env vars from `.github/workflows/ci.yml`:

- `bun install --frozen-lockfile` — OK  
- `bun test` — 399 pass  
- `bun run build` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc9802fa-a231-4762-aa9a-52b0233793a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc9802fa-a231-4762-aa9a-52b0233793a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

