### PR TITLE
feat(about): add team member bios

### DIFF
--- a/convex/aboutTree.test.ts
+++ b/convex/aboutTree.test.ts
@@ -46,6 +46,7 @@ function member(patch: Partial<TeamMemberDoc> = {}): TeamMemberDoc {
     stableId: "m1",
     name: "Alice",
     title: "Engineer",
+    bio: "Builds records.",
     sort: 0,
     ...patch,
   } as TeamMemberDoc;
@@ -110,6 +111,16 @@ describe("normalizeAboutTreeForCompare", () => {
     };
     expect(shape.teamMembers[0].storageId).toBeNull();
   });
+
+  test("team members normalize missing legacy bio to empty string", () => {
+    const tree = emptyTree({
+      teamMembers: [member({ bio: undefined } as Partial<TeamMemberDoc>)],
+    });
+    const shape = normalizeAboutTreeForCompare(tree) as {
+      teamMembers: { bio: string }[];
+    };
+    expect(shape.teamMembers[0].bio).toBe("");
+  });
 });
 
 describe("aboutDraftMatchesPublished", () => {
@@ -132,6 +143,20 @@ describe("aboutDraftMatchesPublished", () => {
   test("mismatched heroTitle is not equal", () => {
     const a: AboutTree = { content: contentDoc({ heroTitle: "A" }), highlights: [], teamMembers: [] };
     const b: AboutTree = { content: contentDoc({ heroTitle: "B" }), highlights: [], teamMembers: [] };
+    expect(aboutDraftMatchesPublished(a, b)).toBe(false);
+  });
+
+  test("mismatched team member bio is not equal", () => {
+    const a: AboutTree = {
+      content: null,
+      highlights: [],
+      teamMembers: [member({ bio: "Runs the room." })],
+    };
+    const b: AboutTree = {
+      content: null,
+      highlights: [],
+      teamMembers: [member({ bio: "Designs the sound." })],
+    };
     expect(aboutDraftMatchesPublished(a, b)).toBe(false);
   });
 

--- a/convex/aboutTree.ts
+++ b/convex/aboutTree.ts
@@ -28,6 +28,7 @@ export type AboutTeamMemberInput = {
   stableId: string;
   name: string;
   title: string;
+  bio: string;
   storageId?: Id<"_storage">;
   sort: number;
 };
@@ -137,6 +138,7 @@ export function normalizeAboutTreeForCompare(tree: AboutTree): unknown {
       stableId: m.stableId,
       name: m.name,
       title: m.title,
+      bio: m.bio ?? "",
       storageId: m.storageId ?? null,
       sort: m.sort,
     }));
@@ -246,6 +248,7 @@ export async function copyAboutScope(
       stableId: m.stableId,
       name: m.name,
       title: m.title,
+      bio: m.bio ?? "",
       ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
       sort: m.sort,
     });
@@ -308,6 +311,7 @@ export async function replaceAboutDraftTree(
       stableId: m.stableId,
       name: m.name,
       title: m.title,
+      bio: m.bio,
       ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
       sort: m.sort,
     });

--- a/convex/cms.ts
+++ b/convex/cms.ts
@@ -758,6 +758,7 @@ async function readSnapshotForAdmin(
               id: m.stableId,
               name: m.name,
               title: m.title,
+              bio: m.bio ?? "",
               ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
             })),
           }
@@ -848,6 +849,7 @@ async function replaceAboutDraftFromSnapshot(
       stableId: m.id,
       name: m.name,
       title: m.title,
+      bio: m.bio ?? "",
       ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
       sort: index,
     })),

--- a/convex/cmsPublishHelpers.ts
+++ b/convex/cmsPublishHelpers.ts
@@ -259,6 +259,12 @@ async function collectAboutIssuesFromTree(
           message: `${who} needs a title.`,
         });
       }
+      if ((team[i].bio ?? "").trim().length === 0) {
+        issues.push({
+          path: `${base}.bio`,
+          message: `${who} needs a short bio.`,
+        });
+      }
       if (team[i].storageId === undefined) {
         issues.push({
           path: `${base}.storageId`,

--- a/convex/cmsShared.ts
+++ b/convex/cmsShared.ts
@@ -54,6 +54,7 @@ export type PublicAboutTeamMember = {
   id: string;
   name: string;
   title: string;
+  bio: string;
   imageUrl: string | null;
 };
 

--- a/convex/publicSettingsSnapshot.ts
+++ b/convex/publicSettingsSnapshot.ts
@@ -164,6 +164,7 @@ function aboutSnapshotFromTree(tree: AboutTree): AboutSnapshot {
             id: m.stableId,
             name: m.name,
             title: m.title,
+            bio: m.bio ?? "",
             ...(m.storageId !== undefined
               ? { storageId: m.storageId as Id<"_storage"> }
               : {}),
@@ -222,6 +223,7 @@ export async function materializePublicAbout(
             id: m.id,
             name: m.name,
             title: m.title,
+            bio: m.bio ?? "",
             imageUrl:
               m.storageId !== undefined
                 ? await ctx.storage.getUrl(m.storageId)

--- a/convex/schema.shared.ts
+++ b/convex/schema.shared.ts
@@ -130,6 +130,7 @@ export const aboutTeamMemberValidator = v.object({
   id: v.string(),
   name: v.string(),
   title: v.string(),
+  bio: v.optional(v.string()),
   /** Required to publish; optional while drafting so rows can be added before upload. */
   storageId: v.optional(v.id("_storage")),
 });
@@ -266,6 +267,7 @@ export const aboutTeamMemberRowValidator = {
   stableId: v.string(),
   name: v.string(),
   title: v.string(),
+  bio: v.optional(v.string()),
   storageId: v.optional(v.id("_storage")),
   sort: v.number(),
 } as const;

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -85,7 +85,7 @@ interface HeadshotProps {
 
 function Headshot({ member, fallbackRole }: HeadshotProps) {
   const role = member?.title ?? fallbackRole;
-  const bio = member?.bio.trim();
+  const bio = member?.bio?.trim();
   return (
     <div className="flex flex-col items-center">
       <div className="relative aspect-square w-full max-w-[220px] overflow-hidden rounded-full border border-sand/10 bg-charcoal/40">

--- a/src/app/about/about-layout.tsx
+++ b/src/app/about/about-layout.tsx
@@ -85,6 +85,7 @@ interface HeadshotProps {
 
 function Headshot({ member, fallbackRole }: HeadshotProps) {
   const role = member?.title ?? fallbackRole;
+  const bio = member?.bio.trim();
   return (
     <div className="flex flex-col items-center">
       <div className="relative aspect-square w-full max-w-[220px] overflow-hidden rounded-full border border-sand/10 bg-charcoal/40">
@@ -110,13 +111,18 @@ function Headshot({ member, fallbackRole }: HeadshotProps) {
           </div>
         )}
       </div>
-      <div className="mt-5 text-center">
+      <div className="mt-5 max-w-xs text-center">
         {member?.name ? (
           <p className="headline-secondary text-ivory text-lg">{member.name}</p>
         ) : null}
         <p className="label-text text-sand/60 text-[10px] tracking-[0.2em] mt-1">
           {role}
         </p>
+        {bio ? (
+          <p className="body-text-small mt-4 text-sm leading-[1.7] text-ivory/60">
+            {bio}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/admin/about/about-editor.test.ts
+++ b/src/app/admin/about/about-editor.test.ts
@@ -115,14 +115,24 @@ describe("toAboutContent", () => {
     const c = toAboutContent({
       heroTitle: "Hi",
       teamMembers: [
-        { id: "a", name: "Alice", title: "Engineer" },
+        { id: "a", name: "Alice", title: "Engineer", bio: "Builds records." },
         { id: "b" },
         null,
         { id: "c", name: 1, title: "x" },
       ],
     });
     expect(c.teamMembers).toEqual([
-      { id: "a", name: "Alice", title: "Engineer" },
+      { id: "a", name: "Alice", title: "Engineer", bio: "Builds records." },
+    ]);
+  });
+
+  test("defaults missing legacy team member bio to an empty string", () => {
+    const c = toAboutContent({
+      heroTitle: "Hi",
+      teamMembers: [{ id: "a", name: "Alice", title: "Engineer" }],
+    });
+    expect(c.teamMembers).toEqual([
+      { id: "a", name: "Alice", title: "Engineer", bio: "" },
     ]);
   });
 
@@ -177,14 +187,15 @@ describe("collectAboutIssues", () => {
     expect(issues.some((i) => i.path === "highlights[0]")).toBe(false);
   });
 
-  test("team member missing storageId / name / title reported", () => {
+  test("team member missing storageId / name / title / bio reported", () => {
     const team: AboutTeamMemberRow[] = [
-      { id: "a", name: "", title: "" },
+      { id: "a", name: "", title: "", bio: "" },
     ];
     const issues = collectAboutIssues(content({ teamMembers: team }));
     const paths = issues.map((i) => i.path);
     expect(paths).toContain("teamMembers[0].name");
     expect(paths).toContain("teamMembers[0].title");
+    expect(paths).toContain("teamMembers[0].bio");
     expect(paths).toContain("teamMembers[0].storageId");
   });
 
@@ -193,6 +204,7 @@ describe("collectAboutIssues", () => {
       id: `p-${i}`,
       name: `N${i}`,
       title: "T",
+      bio: "Short bio",
       storageId: "st-x" as never,
     }));
     const issues = collectAboutIssues(content({ teamMembers: team }));

--- a/src/app/admin/about/about-editor.tsx
+++ b/src/app/admin/about/about-editor.tsx
@@ -65,6 +65,7 @@ export type AboutTeamMemberRow = {
   id: string;
   name: string;
   title: string;
+  bio: string;
   storageId?: Id<"_storage">;
 };
 
@@ -205,6 +206,7 @@ export function toAboutContent(raw: unknown): AboutContent {
           id: m.id,
           name: m.name,
           title: m.title,
+          bio: typeof m.bio === "string" ? m.bio : "",
           ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
         }))
     : [];
@@ -292,6 +294,12 @@ export function collectAboutIssues(
         issues.push({
           path: `${base}.title`,
           message: `${who} needs a title.`,
+        });
+      }
+      if (team[i].bio.trim().length === 0) {
+        issues.push({
+          path: `${base}.bio`,
+          message: `${who} needs a short bio.`,
         });
       }
       if (team[i].storageId === undefined) {
@@ -582,6 +590,7 @@ function AboutForm() {
                 id: m.id,
                 name: m.name,
                 title: m.title,
+                bio: m.bio,
                 ...(m.storageId !== undefined ? { storageId: m.storageId } : {}),
               })),
             },
@@ -1336,7 +1345,7 @@ const TeamMembersEditor = memo(function TeamMembersEditor({
     if (members.length >= MAX_TEAM_MEMBERS) return;
     onChange([
       ...members,
-      { id: crypto.randomUUID(), name: "", title: "" },
+      { id: crypto.randomUUID(), name: "", title: "", bio: "" },
     ]);
   };
 
@@ -1354,7 +1363,7 @@ const TeamMembersEditor = memo(function TeamMembersEditor({
 
   const updateField = (
     idx: number,
-    field: "name" | "title",
+    field: "name" | "title" | "bio",
     value: string,
   ) => {
     const next = [...members];
@@ -1389,6 +1398,7 @@ const TeamMembersEditor = memo(function TeamMembersEditor({
       id: cur.id,
       name: cur.name,
       title: cur.title,
+      bio: cur.bio,
     };
     onChange(next);
     toast.success("Photo removed.");
@@ -1445,6 +1455,17 @@ const TeamMembersEditor = memo(function TeamMembersEditor({
                       onChange={(e) => updateField(idx, "title", e.target.value)}
                       placeholder="Engineer / Producer"
                       className="text-foreground placeholder:text-muted-foreground"
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="body-text-small text-muted-foreground">
+                      Short bio
+                    </span>
+                    <Textarea
+                      value={m.bio}
+                      onChange={(e) => updateField(idx, "bio", e.target.value)}
+                      placeholder="A few sentences about this person's role, creative background, or studio focus."
+                      className="min-h-24 text-foreground placeholder:text-muted-foreground"
                     />
                   </label>
                   <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new required-in-practice `bio` field to About team members and enforces it in publish validation, which could block publishing or affect existing draft/published data if any rows lack bios. Changes span backend snapshot/scoped-table mapping plus both admin and public rendering paths.
> 
> **Overview**
> Adds support for **team member bios** across the About CMS pipeline.
> 
> Backend now carries `bio` through About snapshot/scoped-row transforms (`cms.ts`, `publicSettingsSnapshot.ts`, `aboutTree.ts`), normalizes missing legacy bios to `""`, and includes `bio` in draft-vs-published equality checks; publish validation now requires non-empty bios (`cmsPublishHelpers.ts`).
> 
> Admin About editor adds a *Short bio* field to team member rows (defaulting legacy/missing bios to empty) and validates it as a publish blocker; the public About page renders the bio under headshots when present (`about-layout.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd869693043ae80dd11b2bad5ed2828ee57df2e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->